### PR TITLE
Improve plugins serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
  "polling",
  "rustix 0.37.23",
  "slab",
- "socket2 0.4.9",
+ "socket2",
  "waker-fn",
 ]
 
@@ -722,26 +722,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "bstr"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
-dependencies = [
- "memchr",
- "regex-automata 0.3.3",
- "serde",
-]
-
-[[package]]
-name = "btoi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1139,12 +1119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clru"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807"
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,20 +1361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,16 +1392,6 @@ dependencies = [
  "crossbeam-utils",
  "memoffset 0.9.0",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1547,12 +1497,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "debug-ignore"
@@ -1780,12 +1724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,18 +1880,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "enumflags2"
@@ -2331,6 +2257,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytesize",
+ "floneumite",
  "futures-util",
  "headless_chrome",
  "instant-distance",
@@ -2424,7 +2351,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "directories 5.0.1",
- "gix",
  "hyper",
  "log",
  "octocrab",
@@ -2693,7 +2619,7 @@ version = "0.2.0-dev"
 source = "git+https://github.com/rustformers/llm?rev=7f13bb90f678e2bdf70d221f1b790fab55cb4d7f#7f13bb90f678e2bdf70d221f1b790fab55cb4d7f"
 dependencies = [
  "ggml-sys",
- "memmap2 0.5.10",
+ "memmap2",
  "thiserror",
 ]
 
@@ -2724,628 +2650,6 @@ dependencies = [
  "fallible-iterator",
  "indexmap 1.9.3",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "gix"
-version = "0.48.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-commitgraph",
- "gix-config",
- "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-features",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-mailmap",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
- "gix-path",
- "gix-prompt",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-sec",
- "gix-tempfile",
- "gix-trace",
- "gix-transport",
- "gix-traverse",
- "gix-url",
- "gix-utils",
- "gix-validate",
- "gix-worktree",
- "log",
- "once_cell",
- "reqwest",
- "signal-hook",
- "smallvec",
- "thiserror",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.23.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "btoi",
- "gix-date",
- "itoa 1.0.9",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.14.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-glob",
- "gix-path",
- "gix-quote",
- "kstring",
- "log",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.2.5"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.4.3"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "gix-command"
-version = "0.2.6"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.17.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-chunk",
- "gix-features",
- "gix-hash",
- "memmap2 0.7.1",
- "thiserror",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.25.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "log",
- "memchr",
- "nom",
- "once_cell",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.12.3"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bitflags 2.3.3",
- "bstr 1.6.0",
- "gix-path",
- "libc",
- "thiserror",
-]
-
-[[package]]
-name = "gix-credentials"
-version = "0.16.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-command",
- "gix-config-value",
- "gix-path",
- "gix-prompt",
- "gix-sec",
- "gix-url",
- "thiserror",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.7.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "itoa 1.0.9",
- "thiserror",
- "time 0.3.23",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.32.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-hash",
- "gix-object",
- "imara-diff",
- "thiserror",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.21.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "dunce",
- "gix-hash",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.31.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bytes",
- "bytesize",
- "crc32fast",
- "crossbeam-channel",
- "flate2",
- "gix-hash",
- "gix-trace",
- "jwalk",
- "libc",
- "once_cell",
- "parking_lot",
- "prodash",
- "sha1_smol",
- "thiserror",
- "walkdir",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.3.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-features",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.9.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bitflags 2.3.3",
- "bstr 1.6.0",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "hex",
- "thiserror",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.2.3"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-hash",
- "hashbrown 0.14.0",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.4.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-glob",
- "gix-path",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.20.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bitflags 2.3.3",
- "bstr 1.6.0",
- "btoi",
- "filetime",
- "gix-bitmap",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
- "itoa 1.0.9",
- "memmap2 0.7.1",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-lock"
-version = "7.0.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror",
-]
-
-[[package]]
-name = "gix-mailmap"
-version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-actor",
- "gix-date",
- "thiserror",
-]
-
-[[package]]
-name = "gix-negotiate"
-version = "0.4.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bitflags 2.3.3",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.32.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "btoi",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-validate",
- "hex",
- "itoa 1.0.9",
- "nom",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.49.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "arc-swap",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-object",
- "gix-pack",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.39.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-diff",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-traverse",
- "memmap2 0.7.1",
- "parking_lot",
- "smallvec",
- "thiserror",
- "uluru",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.16.3"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "hex",
- "thiserror",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.8.3"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-trace",
- "home",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "gix-prompt"
-version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-command",
- "gix-config-value",
- "parking_lot",
- "rustix 0.37.23",
- "thiserror",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "btoi",
- "gix-credentials",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-transport",
- "maybe-async",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.4.5"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "btoi",
- "thiserror",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.32.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-validate",
- "memmap2 0.7.1",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-hash",
- "gix-revision",
- "gix-validate",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.17.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "thiserror",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.3.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.8.3"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bitflags 2.3.3",
- "gix-path",
- "libc",
- "windows 0.48.0",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "7.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-fs",
- "libc",
- "once_cell",
- "parking_lot",
- "signal-hook",
- "signal-hook-registry",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.2"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-
-[[package]]
-name = "gix-transport"
-version = "0.33.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "base64 0.21.2",
- "bstr 1.6.0",
- "gix-command",
- "gix-credentials",
- "gix-features",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
- "reqwest",
- "thiserror",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.29.0"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.20.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "gix-features",
- "gix-path",
- "home",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.1.4"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "fastrand 2.0.0",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.7.6"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "thiserror",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.21.1"
-source = "git+https://github.com/Byron/gitoxide?rev=97f8e960ed52538bb55b72f9dfc5f9d144d72885#97f8e960ed52538bb55b72f9dfc5f9d144d72885"
-dependencies = [
- "bstr 1.6.0",
- "filetime",
- "gix-attributes",
- "gix-features",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "io-close",
- "thiserror",
 ]
 
 [[package]]
@@ -3554,7 +2858,7 @@ dependencies = [
  "url",
  "walkdir",
  "which",
- "winreg 0.10.1",
+ "winreg",
  "zip",
 ]
 
@@ -3610,17 +2914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
 ]
 
 [[package]]
@@ -3692,12 +2985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "human_format"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cce260d758a9aa3d7c4b99d55c815a540f8a37514ba6046ab6be402a157cb0"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3720,7 +3007,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.9",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3805,17 +3092,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -3841,16 +3117,6 @@ dependencies = [
  "png",
  "qoi",
  "tiff",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
-dependencies = [
- "ahash 0.8.3",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3924,16 +3190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-close"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "io-extras"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3959,18 +3215,6 @@ name = "io-lifetimes"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb4def18c48926ccac55c1223e02865ce1a821751a95920448662696e7472c"
-
-[[package]]
-name = "ipconfig"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
-dependencies = [
- "socket2 0.5.3",
- "widestring 1.0.2",
- "windows-sys 0.48.0",
- "winreg 0.50.0",
-]
 
 [[package]]
 name = "ipnet"
@@ -4131,16 +3375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
-]
-
-[[package]]
 name = "keccak"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,15 +3388,6 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
-name = "kstring"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
-dependencies = [
- "static_assertions",
-]
 
 [[package]]
 name = "lalrpop-util"
@@ -4245,12 +3470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4285,7 +3504,7 @@ dependencies = [
  "bytemuck",
  "ggml",
  "half 2.3.1",
- "memmap2 0.5.10",
+ "memmap2",
  "partial_sort",
  "rand 0.8.5",
  "regex",
@@ -4359,15 +3578,6 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "lz4_flex"
@@ -4523,12 +3733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4542,17 +3746,6 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
-name = "maybe-async"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "maybe-owned"
@@ -4580,15 +3773,6 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
 ]
@@ -5677,16 +4861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prodash"
-version = "25.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c236e70b7f9b9ea00d33c69f63ec1ae6e9ae96118923cd37bd4e9c7396f0b107"
-dependencies = [
- "bytesize",
- "human_format",
-]
-
-[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5725,12 +4899,6 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -5978,7 +5146,6 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -5988,34 +5155,19 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower-service",
- "trust-dns-resolver",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.22.6",
- "winreg 0.10.1",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error",
+ "winreg",
 ]
 
 [[package]]
@@ -6220,7 +5372,7 @@ source = "git+https://github.com/RustPython/RustPython?rev=7e66db0d43b6fd93bc114
 dependencies = [
  "ascii",
  "bitflags 2.3.3",
- "bstr 0.2.17",
+ "bstr",
  "cfg-if",
  "itertools 0.10.5",
  "libc",
@@ -6236,7 +5388,7 @@ dependencies = [
  "rustpython-format",
  "siphasher",
  "volatile",
- "widestring 0.5.1",
+ "widestring",
 ]
 
 [[package]]
@@ -6365,7 +5517,7 @@ dependencies = [
  "ascii",
  "atty",
  "bitflags 2.3.3",
- "bstr 0.2.17",
+ "bstr",
  "caseless",
  "cfg-if",
  "chrono",
@@ -6423,10 +5575,10 @@ dependencies = [
  "unicode_names2",
  "wasm-bindgen",
  "which",
- "widestring 0.5.1",
+ "widestring",
  "winapi",
  "windows 0.39.0",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]
@@ -6553,7 +5705,7 @@ checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2 0.5.10",
+ "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -6783,12 +5935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6942,7 +6088,7 @@ dependencies = [
  "dlib",
  "lazy_static",
  "log",
- "memmap2 0.5.10",
+ "memmap2",
  "nix 0.24.3",
  "pkg-config",
  "wayland-client",
@@ -6991,16 +6137,6 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7507,7 +6643,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -7741,51 +6877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand 0.8.5",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7846,15 +6937,6 @@ checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
 dependencies = [
  "tempfile",
  "winapi",
-]
-
-[[package]]
-name = "uluru"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -7957,12 +7039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
-name = "unicode-bom"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552"
-
-[[package]]
 name = "unicode-casing"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8054,7 +7130,7 @@ dependencies = [
  "rustls-webpki 0.100.1",
  "socks",
  "url",
- "webpki-roots 0.23.1",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -8064,7 +7140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -8825,25 +7901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8874,12 +7931,6 @@ name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
-
-[[package]]
-name = "widestring"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "wiggle"
@@ -9256,16 +8307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/floneum-cli/src/main.rs
+++ b/floneum-cli/src/main.rs
@@ -104,8 +104,8 @@ async fn package_and_build(
         build_path = build_path
             .join(&this_package.name.replace('-', "_"))
             .with_extension("wasm");
-        let plugin = plugin_manager.load_plugin(&build_path).await;
-        let instance = plugin.instance().await;
+        let plugin = plugin_manager.load_plugin(&build_path);
+        let instance = plugin.instance().await.unwrap();
         let info = instance.metadata();
         let name = &info.name;
         let version = this_package.version.to_string();

--- a/floneumite/Cargo.toml
+++ b/floneumite/Cargo.toml
@@ -9,7 +9,6 @@ authors = ["Evan Almloff <evanalmloff@gmail.com>"]
 [dependencies]
 anyhow = "1.0.71"
 directories = "5.0.1"
-gix = { git = "https://github.com/Byron/gitoxide", features = ["blocking-network-client", "blocking-http-transport-reqwest-rust-tls"], rev = "97f8e960ed52538bb55b72f9dfc5f9d144d72885" }
 hyper = "0.14.27"
 log = "0.4.19"
 octocrab = "0.28.0"

--- a/floneumite/src/lib.rs
+++ b/floneumite/src/lib.rs
@@ -7,7 +7,7 @@ mod package;
 pub use package::PackageStructure;
 
 mod index;
-pub use index::FloneumPackageIndex;
+pub use index::{FloneumPackageIndex, PackageIndexEntry};
 
 pub use crate::package::Config;
 

--- a/floneumite/src/package.rs
+++ b/floneumite/src/package.rs
@@ -21,15 +21,15 @@ impl Config {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PackageStructure {
-    pub(crate) name: String,
+    pub name: String,
     #[serde(default)]
-    pub(crate) authors: Vec<String>,
+    pub authors: Vec<String>,
     #[serde(default)]
-    pub(crate) description: String,
+    pub description: String,
     #[serde(default = "default_version")]
-    pub(crate) package_version: String,
+    pub package_version: String,
     #[serde(default = "default_binding_version")]
-    pub(crate) binding_version: String,
+    pub binding_version: String,
 }
 
 fn default_version() -> String {

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -26,3 +26,4 @@ headless_chrome = {git = "https://github.com/atroche/rust-headless-chrome", feat
 url = "2.4.0"
 anyhow = "1.0.71"
 tracing = "0.1.37"
+floneumite = { path = "../floneumite" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,27 +33,27 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 const BUILT_IN_PLUGINS: &[&str] = &[
-            "add_embedding",
-            "embedding",
-            "embedding_db",
-            "format",
-            "generate_text",
-            "generate_structured_text",
-            "search",
-            "search_engine",
-            "if_statement",
-            "contains",
-            "write_to_file",
-            "read_from_file",
-            "run_python",
-            "create_browser",
-            "find_node",
-            "find_child_node",
-            "click_node",
-            "node_text",
-            "type_in_node",
-            "navigate_to",
-        ];
+    "add_embedding",
+    "embedding",
+    "embedding_db",
+    "format",
+    "generate_text",
+    "generate_structured_text",
+    "search",
+    "search_engine",
+    "if_statement",
+    "contains",
+    "write_to_file",
+    "read_from_file",
+    "run_python",
+    "create_browser",
+    "find_node",
+    "find_child_node",
+    "click_node",
+    "node_text",
+    "type_in_node",
+    "navigate_to",
+];
 
 trait Variants: Sized + 'static {
     const VARIANTS: &'static [Self];
@@ -707,8 +707,7 @@ impl NodeTemplateTrait for PluginId {
     type CategoryType = &'static str;
 
     fn node_finder_label(&self, user_state: &mut Self::UserState) -> Cow<'_, str> {
-        
-        let name = user_state.get_plugin(*self).name();
+        let name = user_state.get_plugin(*self).name().block_on().unwrap();
         if BUILT_IN_PLUGINS.contains(&&*name) {
             Cow::Owned(format!("{name} (Official)"))
         } else {
@@ -733,7 +732,7 @@ impl NodeTemplateTrait for PluginId {
             queued: false,
             error: None,
             run_count: 0,
-            instance: user_state.get_plugin(*self).instance().block_on(),
+            instance: user_state.get_plugin(*self).instance().block_on().unwrap(),
         }
     }
 
@@ -1136,8 +1135,7 @@ impl NodeGraphExample {
         };
 
         for package in package_manager.entries() {
-            let path = package.wasm_path();
-            let plugin = user_state.plugin_engine.load_plugin(&path).await;
+            let plugin = user_state.plugin_engine.load_plugin_from_source(package.clone());
             let id = user_state.plugins.insert(plugin);
             user_state.all_plugins.insert(PluginId(id));
         }
@@ -1248,7 +1246,7 @@ impl eframe::App for NodeGraphExample {
                 {
                     let path = PathBuf::from(&self.plugin_path_text);
                     if path.exists() {
-                        let plugin = self.user_state.plugin_engine.load_plugin(&path).block_on();
+                        let plugin = self.user_state.plugin_engine.load_plugin(&path);
                         let id = self.user_state.plugins.insert(plugin);
                         self.user_state.all_plugins.insert(PluginId(id));
                     }


### PR DESCRIPTION
Now that the package manager is in a better shape, we can rely on it to store the plugins instead of serializing the data directly into the save file

Fixes #23 