### PR TITLE
Fix selecting the whole screen

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -325,6 +325,7 @@ pub fn FlowView(cx: Scope<FlowViewProps>) -> Element {
 
     render! {
         div { position: "relative",
+            style: "-webkit-user-select: none; -ms-user-select: none; user-select: none;",
             width: "100%",
             height: "100%",
             div {


### PR DESCRIPTION
Fixes a bug that let you highlight the whole screen by dragging a node over the zoom buttons