### PR TITLE
Update to llm-samplers v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "ggml"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
 dependencies = [
  "ggml-sys",
  "memmap2 0.5.10",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "ggml-sys"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
 dependencies = [
  "cc",
 ]
@@ -4942,7 +4942,7 @@ dependencies = [
  "kalosm-language",
  "kalosm-sound",
  "kalosm-streams",
- "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llm-samplers",
  "rand 0.8.5",
  "tokio",
  "tracing-subscriber 0.2.25",
@@ -4972,7 +4972,7 @@ dependencies = [
  "kalosm-sample",
  "kalosm-streams",
  "llm",
- "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llm-samplers",
  "log",
  "meval",
  "num_cpus",
@@ -5020,7 +5020,7 @@ dependencies = [
  "kalosm-sample",
  "kalosm-streams",
  "llm",
- "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llm-samplers",
  "log",
  "num_cpus",
  "once_cell",
@@ -5049,7 +5049,7 @@ dependencies = [
  "anyhow",
  "candle-core",
  "llm",
- "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llm-samplers",
  "rand 0.8.5",
  "rustc-hash",
  "tokenizers 0.13.4",
@@ -5314,7 +5314,7 @@ checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 [[package]]
 name = "llm"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
 dependencies = [
  "llm-base",
  "llm-bloom",
@@ -5330,12 +5330,12 @@ dependencies = [
 [[package]]
 name = "llm-base"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
 dependencies = [
  "bytemuck",
  "ggml",
  "half 2.3.1",
- "llm-samplers 0.0.7 (git+https://github.com/KerfuffleV2/llm-samplers?branch=feat-v0.0.7)",
+ "llm-samplers",
  "memmap2 0.5.10",
  "partial_sort",
  "rand 0.8.5",
@@ -5402,17 +5402,6 @@ name = "llm-samplers"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e85df656cd89e7702cb56171d75aa77c7bec828af7d2054d9987c34411cf896"
-dependencies = [
- "anyhow",
- "num-traits",
- "rand 0.8.5",
- "thiserror",
-]
-
-[[package]]
-name = "llm-samplers"
-version = "0.0.7"
-source = "git+https://github.com/KerfuffleV2/llm-samplers?branch=feat-v0.0.7#8c72d0c2838471bfbe26394694b41054bd789549"
 dependencies = [
  "anyhow",
  "num-traits",
@@ -7909,7 +7898,7 @@ dependencies = [
  "kalosm-language-model",
  "kalosm-sample",
  "kalosm-streams",
- "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llm-samplers",
  "rand 0.8.5",
  "serde_json",
  "tokenizers 0.13.4",
@@ -7947,7 +7936,7 @@ dependencies = [
  "kalosm-language-model",
  "kalosm-sample",
  "kalosm-streams",
- "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llm-samplers",
  "rand 0.8.5",
  "serde_json",
  "tokenizers 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "ggml"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "ggml-sys",
  "memmap2 0.5.10",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "ggml-sys"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "cc",
 ]
@@ -5314,7 +5314,7 @@ checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 [[package]]
 name = "llm"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "llm-base",
  "llm-bloom",
@@ -5330,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "llm-base"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "bytemuck",
  "ggml",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "llm-bloom"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "llm-base",
 ]
@@ -5358,7 +5358,7 @@ dependencies = [
 [[package]]
 name = "llm-gpt2"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "bytemuck",
  "llm-base",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "llm-gptj"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "llm-base",
 ]
@@ -5375,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "llm-gptneox"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "llm-base",
 ]
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "llm-llama"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "llm-base",
  "tracing",
@@ -5392,16 +5392,15 @@ dependencies = [
 [[package]]
 name = "llm-mpt"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm#aeafa44634eae891933ff44ad568b5e4462a533e"
+source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "llm-base",
 ]
 
 [[package]]
 name = "llm-samplers"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7553f60d113c9cdc6a5402456a31cd9a273bef79f6f16d8a4f7b4bedf5f754b2"
+version = "0.0.7"
+source = "git+https://github.com/KerfuffleV2/llm-samplers?branch=feat-v0.0.7#8c72d0c2838471bfbe26394694b41054bd789549"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "ggml"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "ggml-sys",
  "memmap2 0.5.10",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "ggml-sys"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "cc",
 ]
@@ -5314,7 +5314,7 @@ checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 [[package]]
 name = "llm"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "llm-base",
  "llm-bloom",
@@ -5330,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "llm-base"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#9df5a7e48cfa2c6df81958982efcdbedd21bbd74"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "bytemuck",
  "ggml",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "llm-bloom"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "llm-base",
 ]
@@ -5358,7 +5358,7 @@ dependencies = [
 [[package]]
 name = "llm-gpt2"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "bytemuck",
  "llm-base",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "llm-gptj"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "llm-base",
 ]
@@ -5375,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "llm-gptneox"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "llm-base",
 ]
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "llm-llama"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "llm-base",
  "tracing",
@@ -5392,7 +5392,7 @@ dependencies = [
 [[package]]
 name = "llm-mpt"
 version = "0.2.0-dev"
-source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
+source = "git+https://github.com/rustformers/llm#23e4b46d1945dfd1fb16445c2ab840283de4a2c8"
 dependencies = [
  "llm-base",
 ]
@@ -10242,7 +10242,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4942,7 +4942,7 @@ dependencies = [
  "kalosm-language",
  "kalosm-sound",
  "kalosm-streams",
- "llm-samplers",
+ "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "tokio",
  "tracing-subscriber 0.2.25",
@@ -4972,7 +4972,7 @@ dependencies = [
  "kalosm-sample",
  "kalosm-streams",
  "llm",
- "llm-samplers",
+ "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "meval",
  "num_cpus",
@@ -5020,7 +5020,7 @@ dependencies = [
  "kalosm-sample",
  "kalosm-streams",
  "llm",
- "llm-samplers",
+ "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "num_cpus",
  "once_cell",
@@ -5049,7 +5049,7 @@ dependencies = [
  "anyhow",
  "candle-core",
  "llm",
- "llm-samplers",
+ "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "rustc-hash",
  "tokenizers 0.13.4",
@@ -5335,7 +5335,7 @@ dependencies = [
  "bytemuck",
  "ggml",
  "half 2.3.1",
- "llm-samplers",
+ "llm-samplers 0.0.7 (git+https://github.com/KerfuffleV2/llm-samplers?branch=feat-v0.0.7)",
  "memmap2 0.5.10",
  "partial_sort",
  "rand 0.8.5",
@@ -5395,6 +5395,18 @@ version = "0.2.0-dev"
 source = "git+https://github.com/rustformers/llm?rev=refs/pull/440/head#5fa9bb28ce28690102e7eddd3f561a3582c55008"
 dependencies = [
  "llm-base",
+]
+
+[[package]]
+name = "llm-samplers"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e85df656cd89e7702cb56171d75aa77c7bec828af7d2054d9987c34411cf896"
+dependencies = [
+ "anyhow",
+ "num-traits",
+ "rand 0.8.5",
+ "thiserror",
 ]
 
 [[package]]
@@ -7897,7 +7909,7 @@ dependencies = [
  "kalosm-language-model",
  "kalosm-sample",
  "kalosm-streams",
- "llm-samplers",
+ "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "serde_json",
  "tokenizers 0.13.4",
@@ -7935,7 +7947,7 @@ dependencies = [
  "kalosm-language-model",
  "kalosm-sample",
  "kalosm-streams",
- "llm-samplers",
+ "llm-samplers 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "serde_json",
  "tokenizers 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,8 +128,7 @@ rmistral = { path = "./rmistral", version = "0.1.0" }
 rwhisper = { path = "./rwhisper", version = "0.1.0" }
 rwuerstchen = { path = "./rwuerstchen", version = "0.1.0" }
 segment-anything-rs = { path = "./segment-anything-rs", version = "0.1.0" }
-
-llm-samplers = { git = "https://github.com/KerfuffleV2/llm-samplers", branch = "feat-v0.0.7" }
+llm-samplers = "=0.0.7"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,8 @@ rwhisper = { path = "./rwhisper", version = "0.1.0" }
 rwuerstchen = { path = "./rwuerstchen", version = "0.1.0" }
 segment-anything-rs = { path = "./segment-anything-rs", version = "0.1.0" }
 
+llm-samplers = { git = "https://github.com/KerfuffleV2/llm-samplers", branch = "feat-v0.0.7" }
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/kalosm-language/Cargo.toml
+++ b/kalosm-language/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 bytesize = "1.2.0"
 futures-util = "0.3.28"
 llm-samplers = { workspace = true }
-llm = { git = "https://github.com/rustformers/llm", rev = "refs/pull/440/head" }
+llm = { git = "https://github.com/rustformers/llm" }
 log = "0.4.17"
 rand = "0.8.5"
 reqwest = { version = "0.11.18", features = ["stream", "json"] }

--- a/kalosm-language/Cargo.toml
+++ b/kalosm-language/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 bytesize = "1.2.0"
 futures-util = "0.3.28"
-llm-samplers = { version = "0.0.6" }
-llm = { git = "https://github.com/rustformers/llm" }
+llm-samplers = { workspace = true }
+llm = { git = "https://github.com/rustformers/llm", rev = "refs/pull/440/head" }
 log = "0.4.17"
 rand = "0.8.5"
 reqwest = { version = "0.11.18", features = ["stream", "json"] }

--- a/kalosm-sample/Cargo.toml
+++ b/kalosm-sample/Cargo.toml
@@ -10,7 +10,7 @@ llm-samplers = { workspace = true }
 rand = "0.8.5"
 anyhow = "1.0.71"
 tracing = "0.1.37"
-llm = { git = "https://github.com/rustformers/llm", rev = "refs/pull/440/head" }
+llm = { git = "https://github.com/rustformers/llm" }
 candle-core.workspace = true
 tokenizers = { version = "0.13.4" }
 rustc-hash = "1.1.0"

--- a/kalosm-sample/Cargo.toml
+++ b/kalosm-sample/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-llm-samplers = { version = "0.0.6" }
+llm-samplers = { workspace = true }
 rand = "0.8.5"
 anyhow = "1.0.71"
 tracing = "0.1.37"
-llm = { git = "https://github.com/rustformers/llm" }
+llm = { git = "https://github.com/rustformers/llm", rev = "refs/pull/440/head" }
 candle-core.workspace = true
 tokenizers = { version = "0.13.4" }
 rustc-hash = "1.1.0"

--- a/kalosm-sample/src/structured.rs
+++ b/kalosm-sample/src/structured.rs
@@ -46,13 +46,13 @@ impl<
         E,
         O,
         PA,
-    > Sampler<u32, f32> for StructuredSampler<V, E, O, PA>
+    > Sampler for StructuredSampler<V, E, O, PA>
 {
     fn sample<'a>(
         &mut self,
-        res: &mut dyn HasSamplerResources<TokenId = u32>,
-        logits: &'a mut Logits<u32, f32>,
-    ) -> anyhow::Result<&'a mut Logits<u32, f32>> {
+        res: &mut dyn HasSamplerResources,
+        logits: &'a mut Logits,
+    ) -> anyhow::Result<&'a mut Logits> {
         let mut valid_tokens = 0;
         let mut best_token: Option<Logit> = None;
         res.with_last_tokens(&mut |previous_tokens| {

--- a/kalosm/Cargo.toml
+++ b/kalosm/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.8.5"
 
 [dev-dependencies]
 tracing-subscriber = "0.2"
-llm-samplers = { version = "0.0.6" }
+llm-samplers = { workspace = true }
 
 [features]
 metal = ["kalosm-language/metal"]

--- a/language-model/Cargo.toml
+++ b/language-model/Cargo.toml
@@ -31,7 +31,7 @@ tokenizers = { version = "0.13.4" }
 rustc-hash = "1.1.0"
 kalosm-sample.workspace = true
 # Required for LLM
-llm = { git = "https://github.com/rustformers/llm", rev = "refs/pull/440/head" }
+llm = { git = "https://github.com/rustformers/llm" }
 kalosm-streams.workspace = true
 spinoff = "0.8.0"
 bytesize = "1.3.0"

--- a/language-model/Cargo.toml
+++ b/language-model/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 futures-util = "0.3.28"
-llm-samplers = { version = "0.0.6" }
+llm-samplers = { workspace = true }
 log = "0.4.17"
 rand = "0.8.5"
 reqwest = { version = "0.11.18", features = ["stream", "json"] }
@@ -31,7 +31,7 @@ tokenizers = { version = "0.13.4" }
 rustc-hash = "1.1.0"
 kalosm-sample.workspace = true
 # Required for LLM
-llm = { git = "https://github.com/rustformers/llm" }
+llm = { git = "https://github.com/rustformers/llm", rev = "refs/pull/440/head" }
 kalosm-streams.workspace = true
 spinoff = "0.8.0"
 bytesize = "1.3.0"

--- a/language-model/src/local/mod.rs
+++ b/language-model/src/local/mod.rs
@@ -62,7 +62,7 @@ macro_rules! local_model {
                 prompt: &str,
                 max_tokens: Option<u32>,
                 stop_on: Option<&str>,
-                sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+                sampler: Arc<Mutex<dyn Sampler>>,
             ) -> anyhow::Result<Self::TextStream> {
                 Ok(self
                     .infer_sampler(prompt.to_string(), max_tokens, stop_on, sampler)

--- a/language-model/src/local/session.rs
+++ b/language-model/src/local/session.rs
@@ -121,7 +121,7 @@ impl<S: VectorSpace + Send + Sync + 'static> LocalSession<S> {
         prompt: String,
         max_tokens: Option<u32>,
         stop_on: Option<&str>,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     ) -> ChannelTextStream<String> {
         let (sender, receiver) = tokio::sync::oneshot::channel();
         self.task_sender
@@ -161,7 +161,7 @@ enum Task<S: VectorSpace> {
         prompt: String,
         max_tokens: Option<u32>,
         stop_on: Option<String>,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
         sender: tokio::sync::oneshot::Sender<ChannelTextStream<String>>,
     },
     GetEmbedding {
@@ -188,7 +188,7 @@ impl<S: VectorSpace> LocalSessionInner<S> {
         prompt: String,
         max_tokens: Option<u32>,
         stop_on: Option<&str>,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
         out: tokio::sync::oneshot::Sender<ChannelTextStream<String>>,
     ) {
         let session = &mut self.session;

--- a/language-model/src/model.rs
+++ b/language-model/src/model.rs
@@ -564,7 +564,7 @@ pub trait SyncModelExt: SyncModel {
         prompt: impl Display,
         parser: P,
         parser_state: P::PartialState,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
         on_token: impl FnMut(String) -> anyhow::Result<()>,
     ) -> anyhow::Result<P::Output> {
         generate_structured(

--- a/language-model/src/model.rs
+++ b/language-model/src/model.rs
@@ -415,7 +415,7 @@ pub trait ModelExt: Model + Send + 'static {
         prompt: &str,
         parser: P,
         parser_state: P::PartialState,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     ) -> anyhow::Result<StructureParserResult<Self::TextStream, P::Output>>
     where
         Self::TextStream: From<tokio::sync::mpsc::UnboundedReceiver<String>>,
@@ -539,14 +539,14 @@ pub trait SyncModel {
         &mut self,
         session: &mut Self::Session,
         prompt: &str,
-    ) -> anyhow::Result<Logits<u32, f32>>;
+    ) -> anyhow::Result<Logits>;
 
     /// Run the model synchronously with a pre-tokenized input.
     fn feed_tokens(
         &mut self,
         session: &mut Self::Session,
         tokens: &[u32],
-    ) -> anyhow::Result<Logits<u32, f32>>;
+    ) -> anyhow::Result<Logits>;
 
     /// Get the token ID that represents the end of a sequence.
     fn stop_token(&self) -> anyhow::Result<u32>;
@@ -592,7 +592,7 @@ impl SyncModel for SyncModelNotSupported {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
-    fn feed_text(&mut self, _session: &mut (), _prompt: &str) -> anyhow::Result<Logits<u32, f32>> {
+    fn feed_text(&mut self, _session: &mut (), _prompt: &str) -> anyhow::Result<Logits> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
@@ -600,7 +600,7 @@ impl SyncModel for SyncModelNotSupported {
         &mut self,
         _session: &mut (),
         _tokens: &[u32],
-    ) -> anyhow::Result<Logits<u32, f32>> {
+    ) -> anyhow::Result<Logits> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
@@ -649,7 +649,7 @@ pub trait Model: Send + 'static {
         prompt: &str,
         max_tokens: Option<u32>,
         stop_on: Option<&str>,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     ) -> anyhow::Result<String> {
         let mut text = String::new();
 
@@ -685,7 +685,7 @@ pub trait Model: Send + 'static {
         _prompt: &str,
         _max_tokens: Option<u32>,
         _stop_on: Option<&str>,
-        _sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        _sampler: Arc<Mutex<dyn Sampler>>,
     ) -> anyhow::Result<Self::TextStream> {
         Err(anyhow::Error::msg("Not implemented"))
     }
@@ -757,7 +757,7 @@ impl SyncModel for BoxedSyncModel {
         &mut self,
         session: &mut Self::Session,
         prompt: &str,
-    ) -> anyhow::Result<Logits<u32, f32>> {
+    ) -> anyhow::Result<Logits> {
         let self_ref: &mut (dyn SyncModel<Session = Box<dyn Any>>) = self.as_mut();
         self_ref.feed_text(session, prompt)
     }
@@ -766,7 +766,7 @@ impl SyncModel for BoxedSyncModel {
         &mut self,
         session: &mut Self::Session,
         tokens: &[u32],
-    ) -> anyhow::Result<Logits<u32, f32>> {
+    ) -> anyhow::Result<Logits> {
         let self_ref: &mut (dyn SyncModel<Session = Box<dyn Any>>) = self.as_mut();
         self_ref.feed_tokens(session, tokens)
     }
@@ -795,7 +795,7 @@ impl<M: SyncModel<Session = S>, S: Any> SyncModel for AnySyncModel<M, S> {
         &mut self,
         session: &mut Self::Session,
         prompt: &str,
-    ) -> anyhow::Result<Logits<u32, f32>> {
+    ) -> anyhow::Result<Logits> {
         self.0.feed_text(
             match session.downcast_mut() {
                 Some(s) => s,
@@ -814,7 +814,7 @@ impl<M: SyncModel<Session = S>, S: Any> SyncModel for AnySyncModel<M, S> {
         &mut self,
         session: &mut Self::Session,
         tokens: &[u32],
-    ) -> anyhow::Result<Logits<u32, f32>> {
+    ) -> anyhow::Result<Logits> {
         self.0.feed_tokens(
             match session.downcast_mut() {
                 Some(s) => s,
@@ -872,7 +872,7 @@ where
         prompt: &str,
         max_tokens: Option<u32>,
         stop_on: Option<&str>,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     ) -> anyhow::Result<Self::TextStream> {
         self.0
             .stream_text_with_sampler(prompt, max_tokens, stop_on, sampler)

--- a/language-model/src/structured.rs
+++ b/language-model/src/structured.rs
@@ -17,7 +17,7 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
     tokenizer: &Arc<dyn Tokenizer + Send + Sync>,
     parser: P,
     mut parser_state: P::PartialState,
-    mut sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+    mut sampler: Arc<Mutex<dyn Sampler>>,
     mut on_token: impl FnMut(String) -> anyhow::Result<()>,
 ) -> anyhow::Result<P::Output> {
     let prompt_text = prompt.to_string();
@@ -156,8 +156,6 @@ impl<R> HasSamplerResources for SamplerResources<'_, '_, R>
 where
     R: rand::Rng,
 {
-    type TokenId = u32;
-
     fn with_rng_mut(
         &mut self,
         fun: &mut dyn FnMut(&mut dyn rand::RngCore),
@@ -166,7 +164,7 @@ where
         Ok(())
     }
 
-    fn with_last_tokens(&self, fun: &mut dyn FnMut(&[Self::TokenId])) -> Result<(), SamplerError> {
+    fn with_last_tokens(&self, fun: &mut dyn FnMut(&[u32])) -> Result<(), SamplerError> {
         fun(self.previous_tokens);
         Ok(())
     }

--- a/rmistral/Cargo.toml
+++ b/rmistral/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0.106"
 rand = "0.8.5"
 tokio = { version = "1.32.0", features = ["full"] }
 async-trait = "0.1.73"
-llm-samplers = { version = "0.0.6" }
+llm-samplers = { workspace = true }
 kalosm-sample.workspace = true
 kalosm-language-model.workspace = true
 kalosm-streams.workspace = true

--- a/rmistral/src/language_model.rs
+++ b/rmistral/src/language_model.rs
@@ -62,7 +62,7 @@ impl Model for Mistral {
         prompt: &str,
         max_tokens: Option<u32>,
         stop_on: Option<&str>,
-        sampler: Arc<Mutex<dyn llm_samplers::prelude::Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn llm_samplers::prelude::Sampler>>,
     ) -> anyhow::Result<Self::TextStream> {
         let max_length = max_tokens.unwrap_or(64);
         self.run(

--- a/rmistral/src/lib.rs
+++ b/rmistral/src/lib.rs
@@ -58,7 +58,7 @@ enum Task {
     Infer {
         settings: InferenceSettings,
         sender: tokio::sync::mpsc::UnboundedSender<String>,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     },
     RunSync {
         callback: Box<
@@ -148,7 +148,7 @@ impl Mistral {
     fn run(
         &mut self,
         settings: InferenceSettings,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     ) -> anyhow::Result<tokio::sync::mpsc::UnboundedReceiver<String>> {
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
         self.task_sender

--- a/rphi/Cargo.toml
+++ b/rphi/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.37"
 serde_json = "1.0.106"
 rand = "0.8.5"
 tokio = { version = "1.32.0", features = ["full"] }
-llm-samplers = { version = "0.0.6" }
+llm-samplers = { workspace = true }
 async-trait = "0.1.73"
 kalosm-sample.workspace = true
 kalosm-language-model.workspace = true

--- a/rphi/src/language_model.rs
+++ b/rphi/src/language_model.rs
@@ -63,7 +63,7 @@ impl Model for Phi {
         prompt: &str,
         max_tokens: Option<u32>,
         stop_on: Option<&str>,
-        sampler: Arc<Mutex<dyn llm_samplers::prelude::Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn llm_samplers::prelude::Sampler>>,
     ) -> anyhow::Result<Self::TextStream> {
         let max_length = max_tokens.unwrap_or(64);
         self.run(

--- a/rphi/src/lib.rs
+++ b/rphi/src/lib.rs
@@ -63,7 +63,7 @@ enum Task {
     Infer {
         settings: InferenceSettings,
         sender: tokio::sync::mpsc::UnboundedSender<String>,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     },
     RunSync {
         callback: Box<
@@ -153,7 +153,7 @@ impl Phi {
     fn run(
         &mut self,
         settings: InferenceSettings,
-        sampler: Arc<Mutex<dyn Sampler<u32, f32>>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
     ) -> anyhow::Result<tokio::sync::mpsc::UnboundedReceiver<String>> {
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
         self.task_sender


### PR DESCRIPTION
I'm not sure how you feel about putting `llm-samplers` in the main workspace. It's convenient right now when I was trying to get it to compile but that can be changed.

This is a little awkward also because it depends on `llm`, luckily I already had a pull there so I was able to point your deps at that.