### PR TITLE
Add an example for openai compatible remote models

### DIFF
--- a/kalosm/examples/remote-open-ai-compatable.rs
+++ b/kalosm/examples/remote-open-ai-compatable.rs
@@ -1,0 +1,27 @@
+//! This example works for any endpoint that has the same interface as OpenAI's API.
+//! This can be useful if you want to self-host a remote model.
+//! 
+//! If you would like to self host a llama model, you can use a tool like litellm to host the model: https://github.com/BerriAI/litellm#openai-proxy---docs
+
+use std::io::Write;
+
+use futures_util::stream::StreamExt;
+use kalosm_language::*;
+use kalosm_streams::TextStream;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let mut llm = Gpt4::builder().with_base_url("your/openai/api/url").build();
+    let prompt = "The following is a 300 word essay about why the capital of France is Paris:";
+    print!("{}", prompt);
+
+    let stream = llm.stream_text(prompt).with_max_length(300).await.unwrap();
+
+    let mut sentences = stream.words();
+    while let Some(text) = sentences.next().await {
+        print!("{}", text);
+        std::io::stdout().flush().unwrap();
+    }
+}

--- a/language-model/src/remote/open_ai.rs
+++ b/language-model/src/remote/open_ai.rs
@@ -16,35 +16,48 @@ macro_rules! openai_model {
             client: Client<async_openai::config::OpenAIConfig>,
         }
 
+        /// A builder for
+        #[doc = $model]
+        pub struct $tybuilder {
+            config: async_openai::config::OpenAIConfig,
+        }
+
         impl $tybuilder {
             /// Creates a new builder
             pub fn new() -> Self {
                 Self {
-                    client: Client::new(),
+                    config: Default::default(),
                 }
             }
 
             /// Sets the API key for the builder.
             pub fn with_api_key(mut self, api_key: &str) -> Self {
-                self.client = self.client.with_api_key(api_key);
+                self.config = self.config.with_api_key(api_key);
                 self
             }
 
             /// Set the base URL of the API.
             pub fn with_base_url(mut self, base_url: &str) -> Self {
-                self.client = self.client.with_api_base(base_url);
+                self.config = self.config.with_api_base(base_url);
                 self
             }
 
             /// Set the organization ID for the builder.
             pub fn with_organization_id(mut self, organization_id: &str) -> Self {
-                self.client = self.client.with_org_id(organization_id);
+                self.config = self.config.with_org_id(organization_id);
                 self
             }
 
             /// Build the model.
             pub fn build(self) -> $ty {
-                $ty { client: self.client }
+                $ty { client: Client::with_config(self.config) }
+            }
+        }
+
+        impl $ty {
+            /// Creates a new builder
+            pub fn builder() -> $tybuilder {
+                $tybuilder::new()
             }
         }
 
@@ -107,8 +120,8 @@ macro_rules! openai_model {
     };
 }
 
-openai_model!(Gpt3_5, "gpt-3.5-turbo");
-openai_model!(Gpt4, "text-davinci-003");
+openai_model!(Gpt3_5, Gpt3_5Builder, "gpt-3.5-turbo");
+openai_model!(Gpt4, Gpt4Builder, "text-davinci-003");
 
 /// A stream of text from OpenAI's API.
 #[pin_project::pin_project]
@@ -147,6 +160,50 @@ impl Stream for MappedResponseStream {
 #[derive(Debug)]
 pub struct AdaEmbedder {
     client: Client<async_openai::config::OpenAIConfig>,
+}
+
+/// A builder for the Ada embedder.
+pub struct AdaEmbedderBuilder {
+    config: async_openai::config::OpenAIConfig,
+}
+
+impl AdaEmbedderBuilder {
+    /// Creates a new builder
+    pub fn new() -> Self {
+        Self {
+            config: Default::default(),
+        }
+    }
+
+    /// Sets the API key for the builder.
+    pub fn with_api_key(mut self, api_key: &str) -> Self {
+        self.config = self.config.with_api_key(api_key);
+        self
+    }
+
+    /// Set the base URL of the API.
+    pub fn with_base_url(mut self, base_url: &str) -> Self {
+        self.config = self.config.with_api_base(base_url);
+        self
+    }
+
+    /// Set the organization ID for the builder.
+    pub fn with_organization_id(mut self, organization_id: &str) -> Self {
+        self.config = self.config.with_org_id(organization_id);
+        self
+    }
+
+    /// Build the model.
+    pub fn build(self) -> AdaEmbedder {
+        AdaEmbedder { client: Client::with_config(self.config) }
+    }
+}
+
+impl AdaEmbedder {
+    /// Creates a new builder
+    pub fn builder() -> AdaEmbedderBuilder {
+        AdaEmbedderBuilder::new()
+    }
 }
 
 impl Default for AdaEmbedder {

--- a/language-model/src/remote/open_ai.rs
+++ b/language-model/src/remote/open_ai.rs
@@ -10,15 +10,46 @@ use std::sync::Arc;
 use crate::{CreateModel, Embedder, Embedding, GenerationParameters, VectorSpace};
 
 macro_rules! openai_model {
-    ($ty: ident, $model: literal) => {
+    ($ty: ident, $tybuilder: ident, $model: literal) => {
         /// A model that uses OpenAI's API.
         pub struct $ty {
             client: Client<async_openai::config::OpenAIConfig>,
         }
 
-        impl $ty {
-            /// Creates a new OpenAI model.
+        impl $tybuilder {
+            /// Creates a new builder
             pub fn new() -> Self {
+                Self {
+                    client: Client::new(),
+                }
+            }
+
+            /// Sets the API key for the builder.
+            pub fn with_api_key(mut self, api_key: &str) -> Self {
+                self.client = self.client.with_api_key(api_key);
+                self
+            }
+
+            /// Set the base URL of the API.
+            pub fn with_base_url(mut self, base_url: &str) -> Self {
+                self.client = self.client.with_api_base(base_url);
+                self
+            }
+
+            /// Set the organization ID for the builder.
+            pub fn with_organization_id(mut self, organization_id: &str) -> Self {
+                self.client = self.client.with_org_id(organization_id);
+                self
+            }
+
+            /// Build the model.
+            pub fn build(self) -> $ty {
+                $ty { client: self.client }
+            }
+        }
+
+        impl Default for $ty {
+            fn default() -> Self {
                 Self {
                     client: Client::new(),
                 }


### PR DESCRIPTION
This PR adds an example for openai compatible remote models like litellm.

Closes #81 