### PR TITLE
Add support for the open chat model

### DIFF
--- a/interfaces/kalosm/examples/chat.rs
+++ b/interfaces/kalosm/examples/chat.rs
@@ -6,7 +6,10 @@ async fn main() {
     let mut chat = Chat::new(&mut model, "The assistant will act like a pirate. They only respond as a pirate named Skally Waggs. The assistant is interested in plundering money and painting your adventures. The assistant will never mention this to the user.", GenerationParameters::default().sampler()).await;
 
     loop {
-        let output_stream = chat.add_message(prompt_input("\n> ").unwrap()).await.unwrap();
+        let output_stream = chat
+            .add_message(prompt_input("\n> ").unwrap())
+            .await
+            .unwrap();
         print!("Bot: ");
         output_stream.to_std_out().await.unwrap();
     }

--- a/interfaces/kalosm/src/chat.rs
+++ b/interfaces/kalosm/src/chat.rs
@@ -46,7 +46,7 @@ struct ChatSession<Session> {
 
 impl<Session> ChatSession<Session> {
     #[allow(clippy::too_many_arguments)]
-    /// Creates a new chat history. 
+    /// Creates a new chat history.
     pub(crate) fn new<Model: SyncModel<Session = Session>>(
         model: &Model,
         system_prompt_marker: String,

--- a/interfaces/language-model/src/model.rs
+++ b/interfaces/language-model/src/model.rs
@@ -785,10 +785,16 @@ pub trait Model: Send + 'static {
 pub trait ChatModel: Model {
     /// The marker text for a user message
     fn user_marker(&self) -> &str;
+    /// The marker text after a user message
+    fn end_user_marker(&self) -> &str;
     /// The marker text for an assistant message
     fn assistant_marker(&self) -> &str;
+    /// The marker text after an assistant message
+    fn end_assistant_marker(&self) -> &str;
     /// The marker text for a the system prompt
     fn system_prompt_marker(&self) -> &str;
+    /// The marker text after a the system prompt
+    fn end_system_prompt_marker(&self) -> &str;
 }
 
 /// A trait object for a model.

--- a/models/kalosm-llama/src/lib.rs
+++ b/models/kalosm-llama/src/lib.rs
@@ -90,12 +90,24 @@ impl ChatModel for Llama {
         self.chat_markers.assistant_marker.unwrap_or("")
     }
 
+    fn end_assistant_marker(&self) -> &str {
+        self.chat_markers.end_assistant_marker.unwrap_or("")
+    }
+
     fn user_marker(&self) -> &str {
         self.chat_markers.user_marker.unwrap_or("")
     }
 
+    fn end_user_marker(&self) -> &str {
+        self.chat_markers.end_user_marker.unwrap_or("")
+    }
+
     fn system_prompt_marker(&self) -> &str {
         self.chat_markers.system_prompt_marker.unwrap_or("")
+    }
+
+    fn end_system_prompt_marker(&self) -> &str {
+        self.chat_markers.end_system_marker.unwrap_or("")
     }
 }
 

--- a/models/kalosm-llama/src/source.rs
+++ b/models/kalosm-llama/src/source.rs
@@ -3,8 +3,11 @@ use tokenizers::Tokenizer;
 #[derive(Default)]
 pub(crate) struct ChatMarkers {
     pub(crate) user_marker: Option<&'static str>,
+    pub(crate) end_user_marker: Option<&'static str>,
     pub(crate) assistant_marker: Option<&'static str>,
+    pub(crate) end_assistant_marker: Option<&'static str>,
     pub(crate) system_prompt_marker: Option<&'static str>,
+    pub(crate) end_system_marker: Option<&'static str>,
 }
 
 /// A source for the Llama model.
@@ -29,11 +32,7 @@ impl LlamaSource {
             tokenizer_repo: "hf-internal-testing/llama-tokenizer".to_string(),
             tokenizer_file,
             group_query_attention: 1,
-            markers: ChatMarkers {
-                user_marker: None,
-                assistant_marker: None,
-                system_prompt_marker: None,
-            },
+            markers: ChatMarkers::default()
         }
     }
 
@@ -138,6 +137,9 @@ impl LlamaSource {
                 system_prompt_marker: Some("<|system|>"),
                 user_marker: Some("<|user|>"),
                 assistant_marker: Some("<|assistant|>"),
+                end_system_marker: Some("</s>"),
+                end_user_marker: Some("</s>"),
+                end_assistant_marker: Some("</s>"),
             },
         }
     }
@@ -155,9 +157,33 @@ impl LlamaSource {
                 system_prompt_marker: Some("<|system|>"),
                 user_marker: Some("<|user|>"),
                 assistant_marker: Some("<|assistant|>"),
+                end_system_marker: Some("</s>"),
+                end_user_marker: Some("</s>"),
+                end_assistant_marker: Some("</s>"),
             },
         }
     }
+
+ /// A preset for Open chat 3.5
+ pub fn open_chat_7b() -> Self {
+    Self {
+        model_id: "TheBloke/openchat_3.5-GGUF".to_string(),
+        revision: "main".to_string(),
+        gguf_file: "openchat_3.5.Q4_K_M.gguf".into(),
+        tokenizer_repo: "openchat/openchat_3.5".to_string(),
+        tokenizer_file: "tokenizer.json".to_string(),
+        group_query_attention: 8,
+        markers: ChatMarkers {
+            system_prompt_marker: Some(""),
+            end_system_marker: Some("<|end_of_turn|>"),
+            user_marker: Some("GPT4 Correct User: "),
+            end_user_marker: Some("<|end_of_turn|>"),
+            assistant_marker: Some("GPT4 Correct Assistant: "),
+            end_assistant_marker: Some("<|end_of_turn|>"),
+        },
+    }
+}
+    
 
     /// A preset for Llama7b
     pub fn llama_7b() -> Self {
@@ -211,6 +237,9 @@ impl LlamaSource {
                 system_prompt_marker: Some("<<SYS>>\n"),
                 assistant_marker: Some(" [/INST] "),
                 user_marker: Some("[INST]"),
+                end_system_marker: Some("</s>"),
+                end_user_marker: Some("</s>"),
+                end_assistant_marker: Some("</s>"),
             },
         }
     }
@@ -228,6 +257,9 @@ impl LlamaSource {
                 system_prompt_marker: Some("<<SYS>>\n"),
                 assistant_marker: Some(" [/INST] "),
                 user_marker: Some("[INST]"),
+                end_system_marker: Some("</s>"),
+                end_user_marker: Some("</s>"),
+                end_assistant_marker: Some("</s>"),
             },
         }
     }
@@ -245,6 +277,9 @@ impl LlamaSource {
                 system_prompt_marker: Some("<<SYS>>\n"),
                 assistant_marker: Some(" [/INST] "),
                 user_marker: Some("[INST]"),
+                end_system_marker: Some("</s>"),
+                end_user_marker: Some("</s>"),
+                end_assistant_marker: Some("</s>"),
             },
         }
     }

--- a/models/kalosm-llama/src/source.rs
+++ b/models/kalosm-llama/src/source.rs
@@ -32,7 +32,7 @@ impl LlamaSource {
             tokenizer_repo: "hf-internal-testing/llama-tokenizer".to_string(),
             tokenizer_file,
             group_query_attention: 1,
-            markers: ChatMarkers::default()
+            markers: ChatMarkers::default(),
         }
     }
 
@@ -164,26 +164,25 @@ impl LlamaSource {
         }
     }
 
- /// A preset for Open chat 3.5
- pub fn open_chat_7b() -> Self {
-    Self {
-        model_id: "TheBloke/openchat_3.5-GGUF".to_string(),
-        revision: "main".to_string(),
-        gguf_file: "openchat_3.5.Q4_K_M.gguf".into(),
-        tokenizer_repo: "openchat/openchat_3.5".to_string(),
-        tokenizer_file: "tokenizer.json".to_string(),
-        group_query_attention: 8,
-        markers: ChatMarkers {
-            system_prompt_marker: Some(""),
-            end_system_marker: Some("<|end_of_turn|>"),
-            user_marker: Some("GPT4 Correct User: "),
-            end_user_marker: Some("<|end_of_turn|>"),
-            assistant_marker: Some("GPT4 Correct Assistant: "),
-            end_assistant_marker: Some("<|end_of_turn|>"),
-        },
+    /// A preset for Open chat 3.5
+    pub fn open_chat_7b() -> Self {
+        Self {
+            model_id: "TheBloke/openchat_3.5-GGUF".to_string(),
+            revision: "main".to_string(),
+            gguf_file: "openchat_3.5.Q4_K_M.gguf".into(),
+            tokenizer_repo: "openchat/openchat_3.5".to_string(),
+            tokenizer_file: "tokenizer.json".to_string(),
+            group_query_attention: 8,
+            markers: ChatMarkers {
+                system_prompt_marker: Some(""),
+                end_system_marker: Some("<|end_of_turn|>"),
+                user_marker: Some("GPT4 Correct User: "),
+                end_user_marker: Some("<|end_of_turn|>"),
+                assistant_marker: Some("GPT4 Correct Assistant: "),
+                end_assistant_marker: Some("<|end_of_turn|>"),
+            },
+        }
     }
-}
-    
 
     /// A preset for Llama7b
     pub fn llama_7b() -> Self {


### PR DESCRIPTION
Adds support for the [Open Chat 3.5 model](https://github.com/imoneoi/openchat/) and changes the default chat model to open chat 3.5. From [user rankings](https://chat.lmsys.org), open chat performs very well for a 7b model. It also performs very well in the Kalosm example.