### PR TITLE
use the same streaming function everywhere

### DIFF
--- a/interfaces/language-model/src/lib.rs
+++ b/interfaces/language-model/src/lib.rs
@@ -31,9 +31,9 @@ mod local;
 #[cfg(feature = "llamacpp")]
 pub use local::*;
 mod remote;
-pub use remote::*;
 pub use futures_util::StreamExt;
 pub use kalosm_sample;
+pub use remote::*;
 mod structured;
 mod token_stream;
 pub use token_stream::*;

--- a/interfaces/language-model/src/model.rs
+++ b/interfaces/language-model/src/model.rs
@@ -591,6 +591,7 @@ pub trait SyncModelExt: SyncModel {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     /// Stream text, calling the on_token callback every time a new token is generated. For some models, this could be used to implement [`Model::stream_text_with_sampler`].
     fn stream_text_with_sampler(
         &mut self,
@@ -616,8 +617,11 @@ pub trait SyncModelExt: SyncModel {
                     text_matching_buffer.push_str(&new_text);
                     // Check if the string matches the stop_on string
                     if let Some(position) = text_matching_buffer.find(stop_on) {
-                        // If it does, only send the text up to the stop_on string
-                        new_text = text_matching_buffer.split_at(position).0.to_string();
+                        // If it does, only send the text up and including the stop_on string
+                        new_text = text_matching_buffer
+                            .split_at(position + stop_on.len())
+                            .0
+                            .to_string();
                         on_token(new_text)?;
                         // And stop the generation
                         break;

--- a/models/kalosm-llama/src/lib.rs
+++ b/models/kalosm-llama/src/lib.rs
@@ -275,9 +275,6 @@ impl LlamaBuilder {
 pub(crate) struct InferenceSettings {
     prompt: String,
 
-    /// The seed to use when generating random samples.
-    seed: u64,
-
     /// The length of the sample to generate (in tokens).
     sample_len: usize,
 
@@ -289,7 +286,6 @@ impl InferenceSettings {
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
             prompt: prompt.into(),
-            seed: rand::random(),
             sample_len: 100,
             stop_on: None,
         }

--- a/models/kalosm-llama/src/model.rs
+++ b/models/kalosm-llama/src/model.rs
@@ -3,16 +3,12 @@ use crate::{
     session::{LlamaCache, LlamaSession},
 };
 use anyhow::{Error as E, Result};
-use llm_samplers::{
-    prelude::Logits,
-    types::{HasSamplerResources, Sampler, SamplerError},
-};
-use std::fmt::{Debug, Formatter};
+use kalosm_language_model::SyncModelExt;
+use llm_samplers::prelude::Logits;
 use std::sync::Arc;
 
 use candle_core::{DType, Device, Tensor};
 use kalosm_language_model::SyncModel;
-use rand::SeedableRng;
 use tokenizers::Tokenizer;
 
 use crate::InferenceSettings;
@@ -142,171 +138,31 @@ impl LlamaModel {
     pub(crate) fn _infer(
         &mut self,
         settings: InferenceSettings,
-        mut sampler: std::sync::Arc<std::sync::Mutex<dyn llm_samplers::prelude::Sampler>>,
+        sampler: std::sync::Arc<std::sync::Mutex<dyn llm_samplers::prelude::Sampler>>,
         out: tokio::sync::mpsc::UnboundedSender<String>,
     ) -> Result<()> {
         let InferenceSettings {
             prompt,
             sample_len,
-            seed,
+
             stop_on,
         } = settings;
 
-        self.cache.clear();
+        let mut session = self.new_session()?;
 
-        let mut tokens = self
-            .tokenizer
-            .encode(&*prompt, true)
-            .map_err(E::msg)?
-            .get_ids()
-            .to_vec();
-
-        let eos_token = self.stop_token()?;
-        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-        let mut text = String::new();
-        let mut prev_index = tokens.len();
-        let mut current_index = tokens.len();
-        for index in 0..sample_len {
-            let context_size = if index > 0 { 1 } else { tokens.len() };
-            let start_pos = tokens.len().saturating_sub(context_size);
-            let ctxt = &tokens[start_pos..];
-            let logits = Self::forward(
-                &mut self.model,
-                &self.device,
-                ctxt,
-                start_pos,
-                Some(&mut self.cache),
-                Some(1000),
-            )?;
-            let next_token = sample_token(
-                &mut sampler,
-                &mut rng,
-                &tokens,
-                logits,
-                stop_on.as_deref(),
-                &self.tokenizer,
-            )?;
-            if next_token == eos_token {
-                break;
-            }
-            let prev_text = if tokens.is_empty() {
-                String::new()
-            } else {
-                let tokens = &tokens[prev_index..current_index];
-                self.tokenizer.decode(tokens, true).map_err(E::msg)?
-            };
-            tokens.push(next_token);
-            let token_text = self
-                .tokenizer
-                .decode(&tokens[prev_index..], true)
-                .map_err(E::msg)?;
-            let token = if token_text.len() > prev_text.len()
-                && token_text.chars().last().unwrap().is_ascii()
-            {
-                let text = token_text.split_at(prev_text.len());
-                prev_index = current_index;
-                current_index = tokens.len();
-                text.1.to_string()
-            } else {
-                continue;
-            };
-
-            let mut should_stop = false;
-            // We only need to keep as many bytes as the stop_on string
-            if let Some(stop_on) = &stop_on {
-                text.push_str(&token);
-                should_stop = text.ends_with(stop_on);
-
-                if text.len() > stop_on.len() {
-                    text = text[text.len() - stop_on.len()..].to_string();
-                }
-            }
-            out.send(token).unwrap();
-            if should_stop {
-                break;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-struct SamplerResources<'a, 'b, R: rand::Rng> {
-    rng: &'a mut R,
-    previous_tokens: &'b [u32],
-}
-
-impl<R> Debug for SamplerResources<'_, '_, R>
-where
-    R: rand::Rng,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SamplerResources")
-            .field("previous_tokens", &self.previous_tokens)
-            .finish()
-    }
-}
-
-impl<R> HasSamplerResources for SamplerResources<'_, '_, R>
-where
-    R: rand::Rng,
-{
-    fn with_rng_mut(
-        &mut self,
-        fun: &mut dyn FnMut(&mut dyn rand::RngCore),
-    ) -> Result<(), SamplerError> {
-        fun(self.rng);
-        Ok(())
-    }
-
-    fn with_last_tokens(&self, fun: &mut dyn FnMut(&[u32])) -> Result<(), SamplerError> {
-        fun(self.previous_tokens);
-        Ok(())
-    }
-}
-
-pub fn sample_token(
-    sampler: &mut impl Sampler,
-    rng: &mut impl rand::Rng,
-    previous_tokens: &[u32],
-    mut last_logits: Logits,
-    stop_on: Option<&str>,
-    tokenizer: &Tokenizer,
-) -> anyhow::Result<u32> {
-    let mut end_tokens = String::new();
-    // grab as many characters as the stop_on string has from the end of the previous tokens
-    if let Some(stop_on) = stop_on {
-        let required_len = stop_on.len();
-        let mut previous_token_iter = previous_tokens.iter().rev();
-        while end_tokens.len() < required_len {
-            match previous_token_iter.next() {
-                Some(token) => {
-                    end_tokens = tokenizer.decode(&[*token], true).map_err(E::msg)? + &end_tokens;
-                }
-                None => {
-                    break;
-                }
-            }
-        }
-    }
-    for logit in last_logits.iter_mut() {
-        let tid = logit.token_id;
-        if let Some(stop_on) = stop_on {
-            let token = tokenizer.decode(&[tid], true).unwrap();
-            let combined = end_tokens.clone() + &token;
-            if combined.contains(stop_on) && !combined.ends_with(stop_on) {
-                // if the token contains a stop_on token, but not the end of the string, set the probability to 0
-                logit.prob = 0.0;
-            }
-        }
-    }
-    last_logits
-        .sample_token(
-            &mut SamplerResources {
-                previous_tokens,
-                rng,
-            },
+        self.stream_text_with_sampler(
+            &mut session,
+            prompt.as_str(),
+            Some(sample_len as u32),
+            stop_on.as_deref(),
             sampler,
-        )?
-        .ok_or_else(|| anyhow::anyhow!("No token sampled"))
+            |token| {
+                out.send(token)
+                    .map_err(|_| anyhow::anyhow!("Failed to send token to output channel"))
+                    .map(|_| kalosm_language_model::ModelFeedback::Continue)
+            },
+        )?;
+
+        Ok(())
+    }
 }

--- a/models/rmistral/src/lib.rs
+++ b/models/rmistral/src/lib.rs
@@ -220,9 +220,6 @@ impl MistralBuilder {
 pub(crate) struct InferenceSettings {
     prompt: String,
 
-    /// The seed to use when generating random samples.
-    seed: u64,
-
     /// The length of the sample to generate (in tokens).
     sample_len: usize,
 
@@ -234,7 +231,6 @@ impl InferenceSettings {
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
             prompt: prompt.into(),
-            seed: rand::random(),
             sample_len: 100,
             stop_on: None,
         }

--- a/models/rmistral/src/model.rs
+++ b/models/rmistral/src/model.rs
@@ -2,14 +2,13 @@ use crate::raw::{MistralCache, Model};
 use anyhow::{Error as E, Result};
 use llm_samplers::{
     prelude::Logits,
-    types::{HasSamplerResources, Sampler, SamplerError},
+    types::{HasSamplerResources, SamplerError},
 };
 use std::fmt::{Debug, Formatter};
 use std::{collections::HashMap, sync::Arc};
 
 use candle_core::{DType, Device, Tensor};
-use kalosm_language_model::SyncModel;
-use rand::SeedableRng;
+use kalosm_language_model::{SyncModel, SyncModelExt};
 use tokenizers::Tokenizer;
 
 use crate::InferenceSettings;
@@ -144,90 +143,29 @@ impl MistralModel {
     pub(crate) fn _infer(
         &mut self,
         settings: InferenceSettings,
-        mut sampler: std::sync::Arc<std::sync::Mutex<dyn llm_samplers::prelude::Sampler>>,
+        sampler: std::sync::Arc<std::sync::Mutex<dyn llm_samplers::prelude::Sampler>>,
         out: tokio::sync::mpsc::UnboundedSender<String>,
     ) -> Result<()> {
         let InferenceSettings {
             prompt,
             sample_len,
-            seed,
             stop_on,
         } = settings;
 
-        self.cache.clear();
+        let mut session = self.new_session()?;
 
-        let mut tokens = self
-            .tokenizer
-            .encode(&*prompt, true)
-            .map_err(E::msg)?
-            .get_ids()
-            .to_vec();
-
-        let eos_token = self.stop_token()?;
-        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-        let mut text = String::new();
-        let mut prev_index = tokens.len();
-        let mut current_index = tokens.len();
-        for index in 0..sample_len {
-            let context_size = if index > 0 { 1 } else { tokens.len() };
-            let start_pos = tokens.len().saturating_sub(context_size);
-            let ctxt = &tokens[start_pos..];
-            let logits = Self::forward(
-                &mut self.model,
-                &self.device,
-                ctxt,
-                start_pos,
-                Some(&mut self.cache),
-                Some(1000),
-            )?;
-            let next_token = sample_token(
-                &mut sampler,
-                &mut rng,
-                &tokens,
-                logits,
-                stop_on.as_deref(),
-                &self.tokenizer,
-            )?;
-            if next_token == eos_token {
-                break;
-            }
-            let prev_text = if tokens.is_empty() {
-                String::new()
-            } else {
-                let tokens = &tokens[prev_index..current_index];
-                self.tokenizer.decode(tokens, true).map_err(E::msg)?
-            };
-            tokens.push(next_token);
-            let token_text = self
-                .tokenizer
-                .decode(&tokens[prev_index..], true)
-                .map_err(E::msg)?;
-            let token = if token_text.len() > prev_text.len()
-                && token_text.chars().last().unwrap().is_ascii()
-            {
-                let text = token_text.split_at(prev_text.len());
-                prev_index = current_index;
-                current_index = tokens.len();
-                text.1.to_string()
-            } else {
-                continue;
-            };
-
-            let mut should_stop = false;
-            // We only need to keep as many bytes as the stop_on string
-            if let Some(stop_on) = &stop_on {
-                text.push_str(&token);
-                should_stop = text.ends_with(stop_on);
-
-                if text.len() > stop_on.len() {
-                    text = text[text.len() - stop_on.len()..].to_string();
-                }
-            }
-            out.send(token).unwrap();
-            if should_stop {
-                break;
-            }
-        }
+        self.stream_text_with_sampler(
+            &mut session,
+            prompt.as_str(),
+            Some(sample_len as u32),
+            stop_on.as_deref(),
+            sampler,
+            |token| {
+                out.send(token)
+                    .map_err(|_| anyhow::anyhow!("Failed to send token to output channel"))
+                    .map(|_| kalosm_language_model::ModelFeedback::Continue)
+            },
+        )?;
 
         Ok(())
     }
@@ -265,50 +203,4 @@ where
         fun(self.previous_tokens);
         Ok(())
     }
-}
-
-pub fn sample_token(
-    sampler: &mut impl Sampler,
-    rng: &mut impl rand::Rng,
-    previous_tokens: &[u32],
-    mut last_logits: Logits,
-    stop_on: Option<&str>,
-    tokenizer: &Tokenizer,
-) -> anyhow::Result<u32> {
-    let mut end_tokens = String::new();
-    // grab as many characters as the stop_on string has from the end of the previous tokens
-    if let Some(stop_on) = stop_on {
-        let required_len = stop_on.len();
-        let mut previous_token_iter = previous_tokens.iter().rev();
-        while end_tokens.len() < required_len {
-            match previous_token_iter.next() {
-                Some(token) => {
-                    end_tokens = tokenizer.decode(&[*token], true).map_err(E::msg)? + &end_tokens;
-                }
-                None => {
-                    break;
-                }
-            }
-        }
-    }
-    for logit in last_logits.iter_mut() {
-        let tid = logit.token_id;
-        if let Some(stop_on) = stop_on {
-            let token = tokenizer.decode(&[tid], true).unwrap();
-            let combined = end_tokens.clone() + &token;
-            if combined.contains(stop_on) && !combined.ends_with(stop_on) {
-                // if the token contains a stop_on token, but not the end of the string, set the probability to 0
-                logit.prob = 0.0;
-            }
-        }
-    }
-    last_logits
-        .sample_token(
-            &mut SamplerResources {
-                previous_tokens,
-                rng,
-            },
-            sampler,
-        )?
-        .ok_or_else(|| anyhow::anyhow!("No token sampled"))
 }

--- a/models/rphi/src/lib.rs
+++ b/models/rphi/src/lib.rs
@@ -237,9 +237,6 @@ pub(crate) fn device(cpu: bool) -> anyhow::Result<Device> {
 pub(crate) struct InferenceSettings {
     prompt: String,
 
-    /// The seed to use when generating random samples.
-    seed: u64,
-
     /// The length of the sample to generate (in tokens).
     sample_len: usize,
 
@@ -251,7 +248,6 @@ impl InferenceSettings {
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
             prompt: prompt.into(),
-            seed: rand::random(),
             sample_len: 100,
             stop_on: None,
         }

--- a/models/rphi/src/model.rs
+++ b/models/rphi/src/model.rs
@@ -1,7 +1,7 @@
 use anyhow::{Error as E, Result};
 use kalosm_language_model::SyncModel;
+use kalosm_language_model::SyncModelExt;
 use llm_samplers::prelude::*;
-use rand::SeedableRng;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
@@ -149,67 +149,29 @@ impl PhiModel {
     pub(crate) fn _infer(
         &mut self,
         settings: InferenceSettings,
-        mut sampler: std::sync::Arc<std::sync::Mutex<dyn llm_samplers::prelude::Sampler>>,
+        sampler: std::sync::Arc<std::sync::Mutex<dyn llm_samplers::prelude::Sampler>>,
         out: tokio::sync::mpsc::UnboundedSender<String>,
     ) -> Result<()> {
         let InferenceSettings {
             prompt,
             sample_len,
-            seed,
             stop_on,
         } = settings;
 
-        self.cache.clear();
-        let mut tokens = self
-            .tokenizer
-            .encode(&*prompt, true)
-            .map_err(E::msg)?
-            .get_ids()
-            .to_vec();
+        let mut session = self.new_session()?;
 
-        let mut new_tokens = vec![];
-        let eos_token = self.stop_token()?;
-        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-        let mut text = String::new();
-        for index in 0..sample_len {
-            let context_size = if index > 0 { 1 } else { tokens.len() };
-            let ctxt = &tokens[tokens.len().saturating_sub(context_size)..];
-            let logits = Self::forward(
-                &mut self.model,
-                &self.device,
-                ctxt,
-                Some(&mut self.cache),
-                Some(1000),
-            )?;
-            let next_token = sample_token(
-                &mut sampler,
-                &mut rng,
-                &tokens,
-                logits,
-                stop_on.as_deref(),
-                &self.tokenizer,
-            )?;
-            tokens.push(next_token);
-            new_tokens.push(next_token);
-            if next_token == eos_token {
-                break;
-            }
-            let token = self.tokenizer.decode(&[next_token], true).map_err(E::msg)?;
-            let mut should_stop = false;
-            // We only need to keep as many bytes as the stop_on string
-            if let Some(stop_on) = &stop_on {
-                text.push_str(&token);
-                should_stop = text.ends_with(stop_on);
-
-                if text.len() > stop_on.len() {
-                    text = text[text.len() - stop_on.len()..].to_string();
-                }
-            }
-            out.send(token).unwrap();
-            if should_stop {
-                break;
-            }
-        }
+        self.stream_text_with_sampler(
+            &mut session,
+            prompt.as_str(),
+            Some(sample_len as u32),
+            stop_on.as_deref(),
+            sampler,
+            |token| {
+                out.send(token)
+                    .map_err(|_| anyhow::anyhow!("Failed to send token to output channel"))
+                    .map(|_| kalosm_language_model::ModelFeedback::Continue)
+            },
+        )?;
 
         Ok(())
     }
@@ -247,50 +209,4 @@ where
         fun(self.previous_tokens);
         Ok(())
     }
-}
-
-pub fn sample_token(
-    sampler: &mut impl Sampler,
-    rng: &mut impl rand::Rng,
-    previous_tokens: &[u32],
-    mut last_logits: Logits,
-    stop_on: Option<&str>,
-    tokenizer: &Tokenizer,
-) -> anyhow::Result<u32> {
-    let mut end_tokens = String::new();
-    // grab as many characters as the stop_on string has from the end of the previous tokens
-    if let Some(stop_on) = stop_on {
-        let required_len = stop_on.len();
-        let mut previous_token_iter = previous_tokens.iter().rev();
-        while end_tokens.len() < required_len {
-            match previous_token_iter.next() {
-                Some(token) => {
-                    end_tokens = tokenizer.decode(&[*token], true).map_err(E::msg)? + &end_tokens;
-                }
-                None => {
-                    break;
-                }
-            }
-        }
-    }
-    for logit in last_logits.iter_mut() {
-        let tid = logit.token_id;
-        if let Some(stop_on) = stop_on {
-            let token = tokenizer.decode(&[tid], true).unwrap();
-            let combined = end_tokens.clone() + &token;
-            if combined.contains(stop_on) && !combined.ends_with(stop_on) {
-                // if the token contains a stop_on token, but not the end of the string, set the probability to 0
-                logit.prob = 0.0;
-            }
-        }
-    }
-    last_logits
-        .sample_token(
-            &mut SamplerResources {
-                previous_tokens,
-                rng,
-            },
-            sampler,
-        )?
-        .ok_or_else(|| anyhow::anyhow!("No token sampled"))
 }


### PR DESCRIPTION
This PR changes all candle based models to use the same function to stream text. This fixes a few bugs with the model specific streaming functions including fixing the stop token and splitting text in the middle of a character 