### PR TITLE
Add a way to run a task

### DIFF
--- a/interfaces/kalosm-language/src/chat.rs
+++ b/interfaces/kalosm-language/src/chat.rs
@@ -530,7 +530,10 @@ pub struct Chat {
 
 impl Chat {
     /// Creates a new builder for a chat session.
-    pub fn builder<M: ChatModel>(model: &mut M) -> ChatBuilder<'_, M> {
+    pub fn builder<M: ChatModel>(model: &mut M) -> ChatBuilder<'_, M>
+    where
+        <M::SyncModel as SyncModel>::Session: Send,
+    {
         ChatBuilder::new(model)
     }
 

--- a/interfaces/kalosm-language/src/lib.rs
+++ b/interfaces/kalosm-language/src/lib.rs
@@ -22,6 +22,7 @@ pub mod chat;
 pub mod context;
 pub mod index;
 pub mod tool;
+pub mod task;
 
 pub use kalosm_language_model;
 pub use kalosm_llama;
@@ -36,6 +37,7 @@ pub mod prelude {
     pub use crate::context::*;
     pub use crate::index::*;
     pub use crate::tool::*;
+    pub use crate::task::*;
     pub use futures_util::StreamExt as _;
     pub use kalosm_language_model::*;
     pub use kalosm_llama::{Llama, LlamaBuilder, LlamaSession, LlamaSource};

--- a/interfaces/kalosm-language/src/lib.rs
+++ b/interfaces/kalosm-language/src/lib.rs
@@ -21,8 +21,8 @@
 pub mod chat;
 pub mod context;
 pub mod index;
-pub mod tool;
 pub mod task;
+pub mod tool;
 
 pub use kalosm_language_model;
 pub use kalosm_llama;
@@ -36,8 +36,8 @@ pub mod prelude {
     pub use crate::chat::*;
     pub use crate::context::*;
     pub use crate::index::*;
-    pub use crate::tool::*;
     pub use crate::task::*;
+    pub use crate::tool::*;
     pub use futures_util::StreamExt as _;
     pub use kalosm_language_model::*;
     pub use kalosm_llama::{Llama, LlamaBuilder, LlamaSession, LlamaSource};

--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -1,0 +1,272 @@
+//! A chat interface that builds on top of [`kalosm_language_model::ChatModel`]
+
+use kalosm_language_model::Session;
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::Result;
+use kalosm_language_model::{ChatModel, GenerationParameters, ModelExt, SyncModel, SyncModelExt};
+use kalosm_sample::{ArcParser, CreateParserState, ParserExt};
+use kalosm_streams::text_stream::ChannelTextStream;
+use llm_samplers::types::Sampler;
+use tokio::sync::mpsc::unbounded_channel;
+
+/// A task session
+struct TaskSession<Session> {
+    user_marker: String,
+    end_user_marker: String,
+    assistant_marker: String,
+    end_assistant_marker: String,
+    session: Session,
+    sampler: Arc<Mutex<dyn Sampler + Send + Sync>>,
+}
+
+impl<Session> TaskSession<Session> {
+    #[allow(clippy::too_many_arguments)]
+    /// Creates a new [`TaskSession`].
+    pub(crate) fn new<Model: SyncModel<Session = Session>>(
+        model: &mut Model,
+        system_prompt_marker: String,
+        end_system_prompt_marker: String,
+        user_marker: String,
+        end_user_marker: String,
+        assistant_marker: String,
+        end_assistant_marker: String,
+        system_prompt: String,
+        sampler: Arc<Mutex<dyn Sampler + Send + Sync>>,
+    ) -> Self {
+        let session = session.unwrap_or_else(|| model.new_session().unwrap());
+
+        Self {
+            user_marker,
+            end_user_marker,
+            assistant_marker,
+            end_assistant_marker,
+            session,
+            sampler,
+        }
+    }
+
+    /// Adds a message to the history.
+    pub fn add_message<Model: SyncModel<Session = Session>>(
+        &mut self,
+        message: String,
+        model: &mut Model,
+        stream: tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> Result<()> {
+        let mut bot_response = String::new();
+        match constraints {
+                Some(constraints) => {
+                    let mut constraints = constraints.lock().unwrap();
+                    let constraints = constraints(&self.history, model);
+                    let state = constraints.create_parser_state();
+                    let on_token = |tok: String| {
+                        let tok = tok
+                            .strip_suffix(&self.end_assistant_marker)
+                            .unwrap_or(&tok)
+                            .to_string();
+                        bot_response += &tok;
+                        stream.send(tok)?;
+                        Ok(())
+                    };
+                    model.generate_structured(
+                        &mut self.session,
+                        &prompt,
+                        constraints,
+                        state,
+                        self.sampler.clone(),
+                        on_token,
+                    )?;
+                }
+                None => {
+                    let on_token = |tok: String| {
+                        let tok = tok
+                            .strip_suffix(&self.end_assistant_marker)
+                            .unwrap_or(&tok)
+                            .to_string();
+                        bot_response += &tok;
+                        stream.send(tok)?;
+                        Ok(kalosm_language_model::ModelFeedback::Continue)
+                    };
+                    model.stream_text_with_sampler(
+                        &mut self.session,
+                        &prompt,
+                        None,
+                        Some(&self.end_assistant_marker),
+                        self.sampler.clone(),
+                        on_token,
+                    )?;
+                }
+        }
+
+        Ok(())
+    }
+}
+
+/// A builder for [`Task`].
+pub struct ChatBuilder<'a, M: ChatModel> {
+    model: &'a mut M,
+    session: Option<<M::SyncModel as kalosm_language_model::SyncModel>::Session>,
+    system_prompt: String,
+    sampler: Arc<Mutex<dyn Sampler + Send + Sync>>,
+    
+}
+
+impl<'a, M: ChatModel> ChatBuilder<'a, M> {
+    fn new(model: &'a mut M) -> ChatBuilder<M> {
+        ChatBuilder {
+            model,
+            session: None,
+            system_prompt: "Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity.".into(),
+            sampler: Arc::new(Mutex::new(GenerationParameters::default().sampler())),
+        }
+    }
+
+    /// Adds a system prompt to the chat. The system prompt guides the model to respond in a certain way.
+    /// If no system prompt is added, the model will use a default system prompt that instructs the model to respond in a way that is safe and respectful.
+    pub fn with_system_prompt(mut self, system_prompt: impl Into<String>) -> Self {
+        self.system_prompt = system_prompt.into();
+        self
+    }
+
+    /// Sets the [`Sampler`] to use for generating responses.
+    pub fn with_sampler(mut self, sampler: impl Sampler + Send + Sync + 'static) -> Self {
+        self.sampler = Arc::new(Mutex::new(sampler));
+        self
+    }
+
+
+    /// Starts the chat instance with the given session. This can be useful for resuming a chat session.
+    pub fn with_session(
+        mut self,
+        session: <M::SyncModel as kalosm_language_model::SyncModel>::Session,
+    ) -> Self {
+        self.session = Some(session);
+        self
+    }
+
+    /// Starts the chat instance with a session from the given path. This can be useful for resuming a chat session.
+    pub fn with_session_path(self, path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
+        Ok(self.with_session(
+            <M::SyncModel as kalosm_language_model::SyncModel>::Session::load_from(path)?,
+        ))
+    }
+
+    /// Builds a [`Task`] instance.
+    pub fn build(self) -> Task
+    where
+        <M::SyncModel as SyncModel>::Session: Send,
+    {
+        let Self {
+            model,
+            system_prompt,
+            sampler,
+            session
+        } = self;
+        let system_prompt_marker = model.system_prompt_marker().to_string();
+        let end_system_prompt_marker = model.end_system_prompt_marker().to_string();
+        let user_marker = model.user_marker().to_string();
+        let end_user_marker = model.end_user_marker().to_string();
+        let assistant_marker = model.assistant_marker().to_string();
+        let end_assistant_marker = model.end_assistant_marker().to_string();
+        let (sender_tx, mut sender_rx) = unbounded_channel();
+        let (result_tx, result_rx) = unbounded_channel();
+        model
+            .run_sync(move |model| {
+                Box::pin(async move {
+                    let mut session = TaskSession::new(
+                        model,
+                        system_prompt_marker,
+                        end_system_prompt_marker,
+                        user_marker,
+                        end_user_marker,
+                        assistant_marker,
+                        end_assistant_marker,
+                        system_prompt,
+                        sampler,
+                    );
+
+                    while let Some(message) = sender_rx.recv().await {
+                        match message {
+                            Message::AddMessage(message) => {
+                                let (tx, rx) = unbounded_channel();
+                                result_tx.send(Response::AddMessage(rx.into())).unwrap();
+                                session.add_message(message, model, tx).unwrap();
+                            }
+                            Message::SaveSession(path) => {
+                                session.session.save_to(path).unwrap();
+                                result_tx.send(Response::SaveSession).unwrap();
+                            }
+                        }
+                    }
+                })
+            })
+            .unwrap();
+
+        Task {
+            sender: sender_tx,
+            channel: result_rx,
+        }
+    }
+}
+
+enum Message {
+    AddMessage(String),
+    SaveSession(PathBuf),
+}
+
+enum Response {
+    AddMessage(ChannelTextStream<String>),
+    SaveSession,
+}
+
+/// A chat session.
+pub struct Task {
+    sender: tokio::sync::mpsc::UnboundedSender<Message>,
+    channel: tokio::sync::mpsc::UnboundedReceiver<Response>,
+}
+
+impl Task {
+    /// Creates a new builder for a chat session.
+    pub fn builder<M: ChatModel>(model: &mut M) -> ChatBuilder<'_, M> {
+        ChatBuilder::new(model)
+    }
+
+    /// Adds a message to the history.
+    pub async fn add_message(
+        &mut self,
+        message: impl Into<String>,
+    ) -> Result<ChannelTextStream<String>> {
+        let message = message.into();
+        let message = message.trim().to_string();
+        self.sender
+            .send(Message::AddMessage(message))
+            .map_err(|_| anyhow::anyhow!("Model stopped"))?;
+        self.channel
+            .recv()
+            .await
+            .map(|c| match c {
+                Response::AddMessage(c) => c,
+                _ => unreachable!(),
+            })
+            .ok_or(anyhow::anyhow!("Model stopped"))
+    }
+
+    /// Saves the session to the given path.
+    pub async fn save_session(&mut self, path: impl AsRef<std::path::Path>) -> Result<()> {
+        self.sender
+            .send(Message::SaveSession(path.as_ref().to_path_buf()))
+            .map_err(|_| anyhow::anyhow!("Model stopped"))?;
+        self.channel
+            .recv()
+            .await
+            .map(|c| match c {
+                Response::SaveSession => (),
+                _ => unreachable!(),
+            })
+            .ok_or(anyhow::anyhow!("Model stopped"))?;
+        Ok(())
+    }
+}

--- a/interfaces/kalosm/examples/task.rs
+++ b/interfaces/kalosm/examples/task.rs
@@ -36,5 +36,5 @@ async fn main() {
         .to_std_out()
         .await
         .unwrap();
-    println!("third question took: {:?}", start_timestamp.elapsed());
+    println!("\nthird question took: {:?}", start_timestamp.elapsed());
 }

--- a/interfaces/kalosm/examples/task.rs
+++ b/interfaces/kalosm/examples/task.rs
@@ -1,0 +1,40 @@
+use kalosm::language::*;
+
+#[tokio::main]
+async fn main() {
+    let mut llm = Llama::new_chat();
+
+    let mut task = Task::new(&mut llm, "You are a math assistant who helps students with their homework. You solve equations and answer questions. When solving problems, you will always solve problems step by step.");
+
+    let start_timestamp = std::time::Instant::now();
+    println!("question 1");
+    // The first time we use the task, it will load the model and prompt.
+    task.run("What is 2 + 2?")
+        .await
+        .unwrap()
+        .to_std_out()
+        .await
+        .unwrap();
+    println!("\nfirst question took: {:?}", start_timestamp.elapsed());
+
+    let start_timestamp = std::time::Instant::now();
+    println!("question 2");
+    // After the first time, the model and prompt are cached.
+    task.run("What is 4 + 4?")
+        .await
+        .unwrap()
+        .to_std_out()
+        .await
+        .unwrap();
+    println!("\nsecond question took: {:?}", start_timestamp.elapsed());
+
+    let start_timestamp = std::time::Instant::now();
+    println!("question 3");
+    task.run("What is (7 + 4)*2?")
+        .await
+        .unwrap()
+        .to_std_out()
+        .await
+        .unwrap();
+    println!("third question took: {:?}", start_timestamp.elapsed());
+}

--- a/interfaces/kalosm/src/evaluate.rs
+++ b/interfaces/kalosm/src/evaluate.rs
@@ -85,6 +85,11 @@ impl<I> TestCases<I> {
         self
     }
 
+    /// Push a test case to this set of test cases.
+    pub fn push_case(&mut self, input: I, output: I) {
+        self.tests.push(TestCase { input, output });
+    }
+
     /// Evaluate a model using this set of test cases.
     pub async fn evaluate<M: Metric<I>>(&mut self, metric: &mut M) -> EvaluationResult<'_, I> {
         let mut values = Vec::new();

--- a/interfaces/kalosm/src/lib.rs
+++ b/interfaces/kalosm/src/lib.rs
@@ -16,6 +16,7 @@ pub mod language {
     pub use kalosm_language::rbert::{Bert, BertBuilder, BertSource, BertSpace};
     pub use kalosm_language::rmistral::{Mistral, MistralBuilder, MistralSource};
     pub use kalosm_language::rphi::{Phi, PhiBuilder, PhiSource};
+    pub use kalosm_language::task::*;
     pub use kalosm_language::tool::*;
     pub use kalosm_streams::text_stream::*;
 }

--- a/interfaces/language-model/src/model.rs
+++ b/interfaces/language-model/src/model.rs
@@ -596,6 +596,14 @@ pub trait Session {
     {
         Err(anyhow::Error::msg("Not implemented"))
     }
+
+    /// Try to clone the session.
+    fn try_clone(&self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Err(anyhow::Error::msg("Not implemented"))
+    }
 }
 
 impl Session for () {

--- a/models/kalosm-llama/src/session.rs
+++ b/models/kalosm-llama/src/session.rs
@@ -4,6 +4,7 @@ use kalosm_language_model::Session;
 use std::collections::HashMap;
 
 /// A Llama-1.5 session.
+#[derive(Debug, Clone)]
 pub struct LlamaSession {
     pub(crate) cache: LlamaCache,
     pub(crate) current_tokens: Vec<u32>,
@@ -23,6 +24,13 @@ impl Session for LlamaSession {
         let tensors = candle_core::safetensors::load(path, &device)?;
 
         Ok(Self::from_tensor_map(tensors))
+    }
+
+    fn try_clone(&self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(self.clone())
     }
 }
 

--- a/models/rmistral/src/model.rs
+++ b/models/rmistral/src/model.rs
@@ -14,6 +14,7 @@ use tokenizers::Tokenizer;
 use crate::InferenceSettings;
 
 /// A Mistral-1.5 session.
+#[derive(Debug, Clone)]
 pub struct MistralSession {
     cache: MistralCache,
     current_tokens: Vec<u32>,
@@ -33,6 +34,13 @@ impl Session for MistralSession {
         let tensors = candle_core::safetensors::load(path, &device)?;
 
         Ok(Self::from_tensor_map(tensors))
+    }
+
+    fn try_clone(&self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(self.clone())
     }
 }
 

--- a/models/rphi/src/model.rs
+++ b/models/rphi/src/model.rs
@@ -17,6 +17,7 @@ use tokenizers::Tokenizer;
 use crate::InferenceSettings;
 
 /// A Phi-1.5 session.
+#[derive(Debug, Clone)]
 pub struct PhiSession {
     cache: PhiCache,
     current_tokens: Vec<u32>,
@@ -36,6 +37,13 @@ impl Session for PhiSession {
         let tensors = candle_core::safetensors::load(path, &device)?;
 
         Ok(Self::from_tensor_map(tensors))
+    }
+
+    fn try_clone(&self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(self.clone())
     }
 }
 


### PR DESCRIPTION
This PR creates a simpler way to run a task efficiently on an LLM while reusing the prompt cache