### PR TITLE
Fix constrained generation and make sampling faster

### DIFF
--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -94,7 +94,7 @@ impl<Session: kalosm_language_model::Session> TaskSession<Session> {
         model.feed_text(
             &mut session,
             &format!("{}{}{}", message, end_user_marker, self.assistant_marker),
-            Some(0)
+            Some(0),
         )?;
 
         // Generate a response.

--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -53,7 +53,7 @@ impl<Session: kalosm_language_model::Session> TaskSession<Session> {
         model: &mut impl SyncModel<Session = Session>,
     ) -> Result<Session> {
         let mut session = model.new_session()?;
-        model.feed_text(&mut session, &self.cached_prompt)?;
+        model.feed_text(&mut session, &self.cached_prompt, Some(0))?;
 
         self.session = session.try_clone().ok();
 
@@ -94,6 +94,7 @@ impl<Session: kalosm_language_model::Session> TaskSession<Session> {
         model.feed_text(
             &mut session,
             &format!("{}{}{}", message, end_user_marker, self.assistant_marker),
+            Some(0)
         )?;
 
         // Generate a response.

--- a/interfaces/kalosm/examples/constrained-rust-types.rs
+++ b/interfaces/kalosm/examples/constrained-rust-types.rs
@@ -2,7 +2,7 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let llm = Phi::v2().unwrap();
+    let llm = Llama::default();
     let prompt = "Realistic mock user names for a chat application: ";
 
     let validator = <[Word<1, 10>; 10] as HasParser>::new_parser();

--- a/interfaces/kalosm/examples/constrained.rs
+++ b/interfaces/kalosm/examples/constrained.rs
@@ -2,7 +2,7 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let llm = Phi::default();
+    let llm = Llama::default();
     let prompt = "Five US states in central US are ";
 
     println!("# with constraints");

--- a/interfaces/kalosm/examples/tools.rs
+++ b/interfaces/kalosm/examples/tools.rs
@@ -2,7 +2,7 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let llm = Phi::v2().unwrap();
+    let llm = Llama::default();
 
     println!("Loading local documents...");
     let mut document_database = DocumentDatabase::new(

--- a/interfaces/language-model/src/model.rs
+++ b/interfaces/language-model/src/model.rs
@@ -569,11 +569,11 @@ pub trait SyncModel {
     /// Create a new session for this model.
     fn new_session(&self) -> anyhow::Result<Self::Session>;
 
-    /// Run the model synchronously.
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str) -> anyhow::Result<Logits>;
+    /// Run the model synchronously. The model implementation may choose to return only the top k logits.
+    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits>;
 
-    /// Run the model synchronously with a pre-tokenized input.
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32]) -> anyhow::Result<Logits>;
+    /// Run the model synchronously with a pre-tokenized input. The model implementation may choose to return only the top k logits.
+    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits>;
 
     /// Get the token ID that represents the end of a sequence.
     fn stop_token(&self) -> anyhow::Result<u32>;
@@ -654,7 +654,7 @@ pub trait SyncModelExt: SyncModel {
         let tokens = self.tokenizer().encode(prompt)?;
         let mut text_stream = TokenOutputStream::new(self.tokenizer(), tokens.clone());
 
-        let mut logits = self.feed_tokens(session, &tokens)?;
+        let mut logits = self.feed_tokens(session, &tokens, Some(512))?;
         let mut tokens_generated = 0;
         // This stores a buffer of text that has been generated to check against the stop_on string. It should never be longer than the stop_on string.
         let mut queued_text_matching_stop_on = String::new();
@@ -722,7 +722,7 @@ pub trait SyncModelExt: SyncModel {
                     break;
                 }
             }
-            logits = self.feed_tokens(session, &[new_token])?;
+            logits = self.feed_tokens(session, &[new_token], Some(512))?;
         }
 
         // Flush the queued text
@@ -756,11 +756,11 @@ impl SyncModel for SyncModelNotSupported {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
-    fn feed_text(&self, _session: &mut (), _prompt: &str) -> anyhow::Result<Logits> {
+    fn feed_text(&self, _session: &mut (), _prompt: &str, _: Option<usize>) -> anyhow::Result<Logits> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
-    fn feed_tokens(&self, _session: &mut (), _tokens: &[u32]) -> anyhow::Result<Logits> {
+    fn feed_tokens(&self, _session: &mut (), _tokens: &[u32], _: Option<usize>) -> anyhow::Result<Logits> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
@@ -964,14 +964,14 @@ impl SyncModel for BoxedSyncModel {
         self_ref.new_session()
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str) -> anyhow::Result<Logits> {
+    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
         let self_ref: &(dyn SyncModel<Session = AnySession>) = self.as_ref();
-        self_ref.feed_text(session, prompt)
+        self_ref.feed_text(session, prompt, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32]) -> anyhow::Result<Logits> {
+    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
         let self_ref: &(dyn SyncModel<Session = AnySession>) = self.as_ref();
-        self_ref.feed_tokens(session, tokens)
+        self_ref.feed_tokens(session, tokens, top_k)
     }
 
     fn stop_token(&self) -> anyhow::Result<u32> {
@@ -996,7 +996,7 @@ impl<M: SyncModel<Session = S>, S: Session + Any> SyncModel for AnySyncModel<M, 
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str) -> anyhow::Result<Logits> {
+    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
         self.0.feed_text(
             match session.as_any_mut().downcast_mut() {
                 Some(s) => s,
@@ -1008,10 +1008,11 @@ impl<M: SyncModel<Session = S>, S: Session + Any> SyncModel for AnySyncModel<M, 
                 }
             },
             prompt,
+            top_k,
         )
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32]) -> anyhow::Result<Logits> {
+    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
         self.0.feed_tokens(
             match session.as_any_mut().downcast_mut() {
                 Some(s) => s,
@@ -1023,6 +1024,7 @@ impl<M: SyncModel<Session = S>, S: Session + Any> SyncModel for AnySyncModel<M, 
                 }
             },
             tokens,
+            top_k,
         )
     }
 

--- a/interfaces/language-model/src/model.rs
+++ b/interfaces/language-model/src/model.rs
@@ -570,10 +570,20 @@ pub trait SyncModel {
     fn new_session(&self) -> anyhow::Result<Self::Session>;
 
     /// Run the model synchronously. The model implementation may choose to return only the top k logits.
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits>;
+    fn feed_text(
+        &self,
+        session: &mut Self::Session,
+        prompt: &str,
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits>;
 
     /// Run the model synchronously with a pre-tokenized input. The model implementation may choose to return only the top k logits.
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits>;
+    fn feed_tokens(
+        &self,
+        session: &mut Self::Session,
+        tokens: &[u32],
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits>;
 
     /// Get the token ID that represents the end of a sequence.
     fn stop_token(&self) -> anyhow::Result<u32>;
@@ -756,11 +766,21 @@ impl SyncModel for SyncModelNotSupported {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
-    fn feed_text(&self, _session: &mut (), _prompt: &str, _: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_text(
+        &self,
+        _session: &mut (),
+        _prompt: &str,
+        _: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
-    fn feed_tokens(&self, _session: &mut (), _tokens: &[u32], _: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_tokens(
+        &self,
+        _session: &mut (),
+        _tokens: &[u32],
+        _: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 
@@ -964,12 +984,22 @@ impl SyncModel for BoxedSyncModel {
         self_ref.new_session()
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_text(
+        &self,
+        session: &mut Self::Session,
+        prompt: &str,
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         let self_ref: &(dyn SyncModel<Session = AnySession>) = self.as_ref();
         self_ref.feed_text(session, prompt, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_tokens(
+        &self,
+        session: &mut Self::Session,
+        tokens: &[u32],
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         let self_ref: &(dyn SyncModel<Session = AnySession>) = self.as_ref();
         self_ref.feed_tokens(session, tokens, top_k)
     }
@@ -996,7 +1026,12 @@ impl<M: SyncModel<Session = S>, S: Session + Any> SyncModel for AnySyncModel<M, 
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_text(
+        &self,
+        session: &mut Self::Session,
+        prompt: &str,
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         self.0.feed_text(
             match session.as_any_mut().downcast_mut() {
                 Some(s) => s,
@@ -1012,7 +1047,12 @@ impl<M: SyncModel<Session = S>, S: Session + Any> SyncModel for AnySyncModel<M, 
         )
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_tokens(
+        &self,
+        session: &mut Self::Session,
+        tokens: &[u32],
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         self.0.feed_tokens(
             match session.as_any_mut().downcast_mut() {
                 Some(s) => s,

--- a/interfaces/language-model/src/structured.rs
+++ b/interfaces/language-model/src/structured.rs
@@ -29,7 +29,7 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
 
     loop {
         let mut logits =
-            llm.feed_tokens(session, &tokens[tokens.len() - unprocessed_token_count..])?;
+            llm.feed_tokens(session, &tokens[tokens.len() - unprocessed_token_count..], None)?;
         let resources = &mut SamplerResources {
             previous_tokens: &tokens,
             rng: &mut rng,

--- a/interfaces/language-model/src/structured.rs
+++ b/interfaces/language-model/src/structured.rs
@@ -28,8 +28,11 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
     let mut rng = rand::thread_rng();
 
     loop {
-        let mut logits =
-            llm.feed_tokens(session, &tokens[tokens.len() - unprocessed_token_count..], None)?;
+        let mut logits = llm.feed_tokens(
+            session,
+            &tokens[tokens.len() - unprocessed_token_count..],
+            None,
+        )?;
         let resources = &mut SamplerResources {
             previous_tokens: &tokens,
             rng: &mut rng,

--- a/models/kalosm-llama/examples/bench.rs
+++ b/models/kalosm-llama/examples/bench.rs
@@ -1,54 +1,57 @@
-#![allow(non_snake_case, non_upper_case_globals)]
-
 use std::sync::{Arc, Mutex};
 
-use criterion::{criterion_group, criterion_main, Criterion};
-use kalosm_llama::{prelude::*, LlamaModel};
+use kalosm_language_model::{SyncModel, SyncModelExt, GenerationParameters};
+use kalosm_llama::*;
 
-criterion_group!(mbenches, generation);
-criterion_main!(mbenches);
 
-fn generation(c: &mut Criterion) {
-    c.bench_function("feed text short", |b| {
+fn main() {
+    #[inline(never)]
+    fn load_small() {
         let model =
             LlamaModel::from_builder(Llama::builder().with_source(LlamaSource::mistral_7b()))
                 .unwrap();
         let prompt = "Hello world";
 
-        b.iter(|| {
+        for _ in 0..100{
             let mut session = model.new_session().unwrap();
-            model.feed_text(&mut session, prompt, Some(0))
-        })
-    });
+            model.feed_text(&mut session, prompt, Some(0)).unwrap();
+        }
+    }
 
-    c.bench_function("feed text long", |b| {
+    #[inline(never)]
+    fn load_large() {
         let model =
             LlamaModel::from_builder(Llama::builder().with_source(LlamaSource::mistral_7b()))
                 .unwrap();
         let prompt = "Hello world".repeat(10);
 
-        b.iter(|| {
+        for _ in 0..100{
             let mut session = model.new_session().unwrap();
-            model.feed_text(&mut session, &prompt, Some(0))
-        })
-    });
+            model.feed_text(&mut session, &prompt, Some(0)).unwrap();
+        }
+    }
 
-    c.bench_function("generate text", |b| {
+    #[inline(never)]
+    fn generate() {
         let model =
             LlamaModel::from_builder(Llama::builder().with_source(LlamaSource::mistral_7b()))
                 .unwrap();
         let prompt = "Hello world";
 
-        b.iter(|| {
+        for _ in 0..100{
             let mut session = model.new_session().unwrap();
             model.stream_text_with_sampler(
                 &mut session,
                 prompt,
-                Some(10),
+                Some(100),
                 None,
                 Arc::new(Mutex::new(GenerationParameters::default().sampler())),
                 |_| Ok(kalosm_language_model::ModelFeedback::Continue),
-            )
-        })
-    });
+            ).unwrap();
+        }
+    }
+
+    load_small();
+    load_large();
+    generate();
 }

--- a/models/kalosm-llama/examples/bench.rs
+++ b/models/kalosm-llama/examples/bench.rs
@@ -1,8 +1,7 @@
 use std::sync::{Arc, Mutex};
 
-use kalosm_language_model::{SyncModel, SyncModelExt, GenerationParameters};
+use kalosm_language_model::{GenerationParameters, SyncModel, SyncModelExt};
 use kalosm_llama::*;
-
 
 fn main() {
     #[inline(never)]
@@ -12,7 +11,7 @@ fn main() {
                 .unwrap();
         let prompt = "Hello world";
 
-        for _ in 0..100{
+        for _ in 0..100 {
             let mut session = model.new_session().unwrap();
             model.feed_text(&mut session, prompt, Some(0)).unwrap();
         }
@@ -25,7 +24,7 @@ fn main() {
                 .unwrap();
         let prompt = "Hello world".repeat(10);
 
-        for _ in 0..100{
+        for _ in 0..100 {
             let mut session = model.new_session().unwrap();
             model.feed_text(&mut session, &prompt, Some(0)).unwrap();
         }
@@ -38,16 +37,18 @@ fn main() {
                 .unwrap();
         let prompt = "Hello world";
 
-        for _ in 0..100{
+        for _ in 0..100 {
             let mut session = model.new_session().unwrap();
-            model.stream_text_with_sampler(
-                &mut session,
-                prompt,
-                Some(100),
-                None,
-                Arc::new(Mutex::new(GenerationParameters::default().sampler())),
-                |_| Ok(kalosm_language_model::ModelFeedback::Continue),
-            ).unwrap();
+            model
+                .stream_text_with_sampler(
+                    &mut session,
+                    prompt,
+                    Some(100),
+                    None,
+                    Arc::new(Mutex::new(GenerationParameters::default().sampler())),
+                    |_| Ok(kalosm_language_model::ModelFeedback::Continue),
+                )
+                .unwrap();
         }
     }
 

--- a/models/kalosm-llama/examples/sync.rs
+++ b/models/kalosm-llama/examples/sync.rs
@@ -11,11 +11,11 @@ async fn main() {
             Box::pin(async move {
                 let prompt = "The capital of France is ";
                 let mut session = model.new_session().unwrap();
-                let logits = model.feed_text(&mut session, prompt).unwrap();
+                let logits = model.feed_text(&mut session, prompt, Some(2048)).unwrap();
                 println!("{:?}", logits);
                 let prompt = "paris";
                 println!("{:?}", model.tokenizer().encode(prompt));
-                let logits = model.feed_text(&mut session, prompt).unwrap();
+                let logits = model.feed_text(&mut session, prompt, Some(2048)).unwrap();
                 println!("{:?}", logits);
             })
         })

--- a/models/kalosm-llama/src/model.rs
+++ b/models/kalosm-llama/src/model.rs
@@ -36,13 +36,23 @@ impl SyncModel for LlamaModel {
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_text(
+        &self,
+        session: &mut Self::Session,
+        prompt: &str,
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         let encoded = self.tokenizer.encode(prompt, true).map_err(E::msg)?;
         let tokens = encoded.get_ids();
         self.feed_tokens(session, tokens, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_tokens(
+        &self,
+        session: &mut Self::Session,
+        tokens: &[u32],
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         let first_token = session.current_tokens.is_empty();
 
         if first_token {
@@ -77,7 +87,7 @@ impl SyncModel for LlamaModel {
                 &[tid],
                 seq_len_offset,
                 Some(&mut session.cache),
-                top_k
+                top_k,
             )
         }
     }

--- a/models/kalosm-llama/src/model.rs
+++ b/models/kalosm-llama/src/model.rs
@@ -36,13 +36,13 @@ impl SyncModel for LlamaModel {
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str) -> anyhow::Result<Logits> {
+    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
         let encoded = self.tokenizer.encode(prompt, true).map_err(E::msg)?;
         let tokens = encoded.get_ids();
-        self.feed_tokens(session, tokens)
+        self.feed_tokens(session, tokens, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32]) -> anyhow::Result<Logits> {
+    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
         let first_token = session.current_tokens.is_empty();
 
         if first_token {
@@ -53,7 +53,7 @@ impl SyncModel for LlamaModel {
                 &session.current_tokens,
                 0,
                 Some(&mut session.cache),
-                None,
+                top_k,
             )
         } else {
             for tid in tokens.iter().copied().take(tokens.len() - 1) {
@@ -65,7 +65,7 @@ impl SyncModel for LlamaModel {
                     &[tid],
                     seq_len_offset,
                     Some(&mut session.cache),
-                    None,
+                    Some(0),
                 )?;
             }
             let tid = *tokens.last().unwrap();
@@ -77,7 +77,7 @@ impl SyncModel for LlamaModel {
                 &[tid],
                 seq_len_offset,
                 Some(&mut session.cache),
-                None,
+                top_k
             )
         }
     }
@@ -110,6 +110,11 @@ impl LlamaModel {
 
         let input = Tensor::new(tokens, device)?.unsqueeze(0)?;
         let logits = model.forward(&input, seqlen_offset, cache)?;
+
+        if top_k == Some(0) {
+            return Ok(Logits::default());
+        }
+
         let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
         let logits: Vec<f32> = logits.to_vec1()?;
         match top_k {

--- a/models/rmistral/src/model.rs
+++ b/models/rmistral/src/model.rs
@@ -99,13 +99,13 @@ impl SyncModel for MistralModel {
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str) -> anyhow::Result<Logits> {
+    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k:Option<usize>) -> anyhow::Result<Logits> {
         let encoded = self.tokenizer.encode(prompt, true).map_err(E::msg)?;
         let tokens = encoded.get_ids();
-        self.feed_tokens(session, tokens)
+        self.feed_tokens(session, tokens, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32]) -> anyhow::Result<Logits> {
+    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k:Option<usize>) -> anyhow::Result<Logits> {
         session.current_tokens.extend(tokens);
 
         let token_count = tokens.len();
@@ -115,7 +115,7 @@ impl SyncModel for MistralModel {
             tokens,
             session.current_tokens.len() - token_count,
             Some(&mut session.cache),
-            None,
+            top_k,
         )
     }
 

--- a/models/rmistral/src/model.rs
+++ b/models/rmistral/src/model.rs
@@ -99,13 +99,23 @@ impl SyncModel for MistralModel {
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k:Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_text(
+        &self,
+        session: &mut Self::Session,
+        prompt: &str,
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         let encoded = self.tokenizer.encode(prompt, true).map_err(E::msg)?;
         let tokens = encoded.get_ids();
         self.feed_tokens(session, tokens, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k:Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_tokens(
+        &self,
+        session: &mut Self::Session,
+        tokens: &[u32],
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         session.current_tokens.extend(tokens);
 
         let token_count = tokens.len();

--- a/models/rphi/src/model.rs
+++ b/models/rphi/src/model.rs
@@ -102,7 +102,12 @@ impl SyncModel for PhiModel {
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_text(
+        &self,
+        session: &mut Self::Session,
+        prompt: &str,
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         let tokens = self
             .tokenizer
             .encode(prompt, true)
@@ -112,7 +117,12 @@ impl SyncModel for PhiModel {
         self.feed_tokens(session, &tokens, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
+    fn feed_tokens(
+        &self,
+        session: &mut Self::Session,
+        tokens: &[u32],
+        top_k: Option<usize>,
+    ) -> anyhow::Result<Logits> {
         session.current_tokens.extend(tokens.iter().copied());
 
         Self::forward(

--- a/models/rphi/src/model.rs
+++ b/models/rphi/src/model.rs
@@ -102,17 +102,17 @@ impl SyncModel for PhiModel {
         })
     }
 
-    fn feed_text(&self, session: &mut Self::Session, prompt: &str) -> anyhow::Result<Logits> {
+    fn feed_text(&self, session: &mut Self::Session, prompt: &str, top_k: Option<usize>) -> anyhow::Result<Logits> {
         let tokens = self
             .tokenizer
             .encode(prompt, true)
             .map_err(E::msg)?
             .get_ids()
             .to_vec();
-        self.feed_tokens(session, &tokens)
+        self.feed_tokens(session, &tokens, top_k)
     }
 
-    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32]) -> anyhow::Result<Logits> {
+    fn feed_tokens(&self, session: &mut Self::Session, tokens: &[u32], top_k: Option<usize>) -> anyhow::Result<Logits> {
         session.current_tokens.extend(tokens.iter().copied());
 
         Self::forward(
@@ -120,7 +120,7 @@ impl SyncModel for PhiModel {
             &self.device,
             tokens,
             Some(&mut session.cache),
-            None,
+            top_k,
         )
     }
 


### PR DESCRIPTION
Followup to #122. This makes sampling 2x faster by only sampling the top 512 tokens (outside of constrained generation) and fixes constrained generation by making all tensors contiguous before matrix multiplication