### PR TITLE
Add Tiny Llama 1.0

### DIFF
--- a/interfaces/kalosm/examples/chat-tiny-llama.rs
+++ b/interfaces/kalosm/examples/chat-tiny-llama.rs
@@ -1,0 +1,21 @@
+use kalosm::language::*;
+
+#[tokio::main]
+async fn main() {
+    let mut model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b())
+        .build()
+        .unwrap();
+    let mut chat = Chat::builder(&mut model)
+        .with_system_prompt("The assistant will act like a pirate")
+        .build();
+
+    loop {
+        chat.add_message(prompt_input("\n> ").unwrap())
+            .await
+            .unwrap()
+            .to_std_out()
+            .await
+            .unwrap();
+    }
+}

--- a/interfaces/kalosm/examples/chat-tiny-llama.rs
+++ b/interfaces/kalosm/examples/chat-tiny-llama.rs
@@ -3,7 +3,7 @@ use kalosm::language::*;
 #[tokio::main]
 async fn main() {
     let mut model = Llama::builder()
-        .with_source(LlamaSource::tiny_llama_1_1b())
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
         .build()
         .unwrap();
     let mut chat = Chat::builder(&mut model)

--- a/interfaces/kalosm/examples/constrained-rust-types.rs
+++ b/interfaces/kalosm/examples/constrained-rust-types.rs
@@ -2,8 +2,11 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let llm = Llama::default();
-    let prompt = "Realistic mock user names for a chat application: ";
+    let llm = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b())
+        .build()
+        .unwrap();
+    let prompt = "An array of realistic single word reddit user names: ";
 
     let validator = <[Word<1, 10>; 10] as HasParser>::new_parser();
     let words = llm.stream_structured_text(prompt, validator).await.unwrap();

--- a/interfaces/kalosm/examples/constrained.rs
+++ b/interfaces/kalosm/examples/constrained.rs
@@ -64,15 +64,25 @@ async fn main() {
         .map(LiteralParser::from)
         .collect::<Vec<_>>();
 
-    let states = IndexParser::new(states_parser);
+    let index_parser = IndexParser::new(states_parser);
 
-    let validator = states
+    let validator = index_parser
         .then(LiteralParser::from(", "))
         .repeat(5..=5)
         .then(LiteralParser::from("\n"));
     let stream = llm.stream_structured_text(prompt, validator).await.unwrap();
 
-    println!("{:#?}", stream.result().await);
+    println!(
+        "{:#?}",
+        stream
+            .result()
+            .await
+            .unwrap()
+            .0
+            .iter()
+            .map(|x| states[x.0 .0])
+            .collect::<Vec<_>>()
+    );
 
     println!("\n\n# without constraints");
     print!("{}", prompt);

--- a/models/kalosm-llama/src/source.rs
+++ b/models/kalosm-llama/src/source.rs
@@ -231,8 +231,8 @@ impl LlamaSource {
         }
     }
 
-    /// A preset for tiny llama 1.1b 1.0
-    pub fn tiny_llama_1_1b() -> Self {
+    /// A preset for tiny llama 1.1b 1.0 Chat
+    pub fn tiny_llama_1_1b_chat() -> Self {
         Self {
             model_id: "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF".to_string(),
             revision: "main".to_string(),
@@ -248,6 +248,19 @@ impl LlamaSource {
                 end_user_marker: Some("</s>"),
                 end_assistant_marker: Some("</s>"),
             },
+        }
+    }
+
+    /// A preset for tiny llama 1.1b 1.0
+    pub fn tiny_llama_1_1b() -> Self {
+        Self {
+            model_id: "TheBloke/TinyLlama-1.1B-intermediate-step-1431k-3T-GGUF".to_string(),
+            revision: "main".to_string(),
+            gguf_file: "tinyllama-1.1b-intermediate-step-1431k-3t.Q4_K_M.gguf".into(),
+            tokenizer_repo: "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T".to_string(),
+            tokenizer_file: "tokenizer.json".to_string(),
+            group_query_attention: 4,
+            ..Default::default()
         }
     }
 

--- a/models/kalosm-llama/src/source.rs
+++ b/models/kalosm-llama/src/source.rs
@@ -231,6 +231,26 @@ impl LlamaSource {
         }
     }
 
+    /// A preset for tiny llama 1.1b 1.0
+    pub fn tiny_llama_1_1b() -> Self {
+        Self {
+            model_id: "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF".to_string(),
+            revision: "main".to_string(),
+            gguf_file: "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf".into(),
+            tokenizer_repo: "TinyLlama/TinyLlama-1.1B-Chat-v1.0".to_string(),
+            tokenizer_file: "tokenizer.json".to_string(),
+            group_query_attention: 4,
+            markers: ChatMarkers {
+                system_prompt_marker: Some("<|system|>\n"),
+                assistant_marker: Some("<|user|>\n"),
+                user_marker: Some("<|assistant|>\n"),
+                end_system_marker: Some("</s>"),
+                end_user_marker: Some("</s>"),
+                end_assistant_marker: Some("</s>"),
+            },
+        }
+    }
+
     /// A preset for Llama7b
     pub fn llama_7b() -> Self {
         Self {


### PR DESCRIPTION
Adds support for tiny llama 1.0: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0

It is a 1.1b chat model pre-trained on 3 trillion tokens. I am hoping this will be useful for either constrained generation or speculative sampling