### PR TITLE
Fix variable length generation and add a map output utility

### DIFF
--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -278,7 +278,7 @@ impl TaskBuilderReturn for NoParser {
 
 impl<P: Parser + CreateParserState, B: FnMut() -> P + Send + 'static> TaskBuilderReturn for B
 where
-    <P as Parser>::Output: Send + 'static,
+    <P as Parser>::Output: Clone + Send + 'static,
     <P as Parser>::PartialState: Sync + Send,
 {
     type Output = Task<StructureParserResult<ChannelTextStream<String>, P::Output>>;

--- a/interfaces/kalosm-sample/src/structured_parser/map.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/map.rs
@@ -1,0 +1,35 @@
+use crate::{ParseResult, Parser};
+
+/// A parser that maps the output of another parser.
+pub struct MapOutputParser<P: Parser, F: Fn(P::Output) -> O, O> {
+    pub(crate) parser: P,
+    pub(crate) map: F,
+    pub(crate) _output: std::marker::PhantomData<O>,
+}
+
+impl<P: Parser, F: Fn(P::Output) -> O, O> Parser for MapOutputParser<P, F, O> {
+    type Error = P::Error;
+    type Output = O;
+    type PartialState = P::PartialState;
+
+    fn parse<'a>(
+        &self,
+        state: &Self::PartialState,
+        input: &'a [u8],
+    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+        let result = self.parser.parse(state, input)?;
+        match result {
+            ParseResult::Finished { result, remaining } => Ok(ParseResult::Finished {
+                result: (self.map)(result),
+                remaining,
+            }),
+            ParseResult::Incomplete {
+                new_state,
+                required_next,
+            } => Ok(ParseResult::Incomplete {
+                new_state,
+                required_next,
+            }),
+        }
+    }
+}

--- a/interfaces/kalosm-sample/src/structured_parser/mod.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/mod.rs
@@ -26,6 +26,8 @@ mod sentence;
 pub use sentence::*;
 mod stop_on;
 pub use stop_on::*;
+mod map;
+pub use map::*;
 
 /// A trait for a parser with a default state.
 pub trait CreateParserState: Parser {
@@ -272,6 +274,18 @@ pub trait ParserExt: Parser {
         Self: Sized,
     {
         RepeatParser::new(self, length_range)
+    }
+
+    /// Map the output of this parser.
+    fn map_output<F: Fn(Self::Output) -> O, O>(self, f: F) -> MapOutputParser<Self, F, O>
+    where
+        Self: Sized,
+    {
+        MapOutputParser {
+            parser: self,
+            map: f,
+            _output: std::marker::PhantomData,
+        }
     }
 
     /// Get a boxed version of this parser.

--- a/interfaces/kalosm/examples/constrained.rs
+++ b/interfaces/kalosm/examples/constrained.rs
@@ -66,10 +66,7 @@ async fn main() {
 
     let index_parser = IndexParser::new(states_parser);
 
-    let validator = index_parser
-        .then(LiteralParser::from(", "))
-        .repeat(5..=5)
-        .then(LiteralParser::from("\n"));
+    let validator = index_parser.then(LiteralParser::from(", ")).repeat(1..=5);
     let stream = llm.stream_structured_text(prompt, validator).await.unwrap();
 
     println!(

--- a/interfaces/kalosm/examples/constrained.rs
+++ b/interfaces/kalosm/examples/constrained.rs
@@ -75,7 +75,6 @@ async fn main() {
             .result()
             .await
             .unwrap()
-            .0
             .iter()
             .map(|x| states[x.0 .0])
             .collect::<Vec<_>>()

--- a/interfaces/language-model/src/structured.rs
+++ b/interfaces/language-model/src/structured.rs
@@ -3,7 +3,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use kalosm_sample::{ParseResult, Parser, Tokenizer};
+use kalosm_sample::{
+    LiteralParser, ParseResult, Parser, ParserExt, SequenceParserState, Tokenizer,
+};
 use llm_samplers::types::{HasSamplerResources, Sampler, SamplerError};
 use rustc_hash::FxHashMap;
 
@@ -15,12 +17,21 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
     llm: &M,
     session: &mut M::Session,
     tokenizer: &Arc<dyn Tokenizer + Send + Sync>,
-    stop_token: Option<u32>,
+    stop_token: String,
     parser: P,
-    mut parser_state: P::PartialState,
+    parser_state: P::PartialState,
     mut sampler: Arc<Mutex<dyn Sampler>>,
     mut on_token: impl FnMut(String) -> anyhow::Result<()>,
-) -> anyhow::Result<P::Output> {
+) -> anyhow::Result<P::Output>
+where
+    P::Output: Clone,
+{
+    // We wrap the parser in a LiteralParser so that we can stop the parser when we reach the stop token automatically if the sequence is unterminated
+    let parser = parser
+        .then(LiteralParser::new(stop_token))
+        .map_output(|(output, _)| output);
+    let mut parser_state = SequenceParserState::FirstParser(parser_state);
+
     let prompt_text = prompt.to_string();
     let mut tokens = tokenizer.encode(&prompt_text)?;
     let mut prev_index = tokens.len();
@@ -48,11 +59,6 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
         };
 
         logits.retain_mut(|logit| {
-            if Some(logit.token_id) == stop_token {
-                // If the current state is not finished, we can't generate a stop token
-                return  current_result.is_some() ;
-            }
-
             let mut potential_new_tokens = tokens[prev_index..].to_vec();
             potential_new_tokens.push(logit.token_id);
             let Ok(token_text) = tokenizer.decode(&potential_new_tokens) else {
@@ -92,14 +98,6 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
             .sample_token(resources, &mut logits)?
             .ok_or(anyhow::anyhow!("Failed to sample constrained tokens"))?;
 
-        // If the LLM returns a stop token, we may already be at a finished state, so try to finish the parser
-        if Some(token_id) == stop_token {
-            if let Some(result) = current_result.take() {
-                return Ok(result);
-            }
-            return Err(anyhow::anyhow!("Stop token produced without finishing parser"));
-        }
-
         unprocessed_token_count = 1;
         tokens.push(token_id);
         if let Some((token, result)) = state_map
@@ -109,7 +107,7 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
             tracing::trace!("Adding token {} to parser", token);
             on_token(token.clone())?;
 
-            current_result = update_state(
+            if let Some(result) = update_state(
                 &parser,
                 &mut parser_state,
                 result,
@@ -117,17 +115,12 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
                 &mut tokens,
                 &mut on_token,
                 &mut unprocessed_token_count,
-            )?;
+            )? {
+                return Ok(result);
+            }
 
             prev_index = current_index;
             current_index = tokens.len();
-
-            // // If we don't have a stop token, we can return the current result immediately
-            // if stop_token.is_none() {
-            if let Some(result) = current_result.take() {
-                return Ok(result);
-            }
-            // }
         }
     }
 }

--- a/models/kalosm-llama/src/raw.rs
+++ b/models/kalosm-llama/src/raw.rs
@@ -386,7 +386,6 @@ impl Model {
 
     fn mask(&self, seq_len: usize, seqlen_offset: usize) -> Result<Tensor> {
         let mask = if let Some(mask) = {
-            
             let masks = self.masks.read().unwrap();
             masks.get(&seq_len).cloned()
         } {
@@ -402,13 +401,13 @@ impl Model {
         };
 
         let mask = if seqlen_offset > 0 {
-                    let mask0 = Tensor::zeros((seq_len, seqlen_offset), DType::U8, &Device::Cpu)?;
-                    Tensor::cat(&[&mask0, &mask], D::Minus1)?
-                } else {
-                    mask
-                };
+            let mask0 = Tensor::zeros((seq_len, seqlen_offset), DType::U8, &Device::Cpu)?;
+            Tensor::cat(&[&mask0, &mask], D::Minus1)?
+        } else {
+            mask
+        };
 
-                Ok(mask)
+        Ok(mask)
     }
 
     pub fn forward(


### PR DESCRIPTION
This PR adds an end of token parser after parsing the users parser in the constrained generation function. This should fix unterminated sequence generation.

It also adds a map output utility function to make controlling the output of a parser easier