### PR TITLE
Decouple models from tasks

### DIFF
--- a/interfaces/kalosm-sample/src/lib.rs
+++ b/interfaces/kalosm-sample/src/lib.rs
@@ -86,8 +86,14 @@ pub trait Tokenizer {
     fn encode(&self, text: &str, add_special_tokens: bool) -> anyhow::Result<Vec<u32>>;
 
     /// Encode a list of strings into a list of token ids.
-    fn encode_batch(&self, text: &[&str], add_special_tokens: bool) -> anyhow::Result<Vec<Vec<u32>>> {
-        text.iter().map(|text| self.encode(text, add_special_tokens)).collect()
+    fn encode_batch(
+        &self,
+        text: &[&str],
+        add_special_tokens: bool,
+    ) -> anyhow::Result<Vec<Vec<u32>>> {
+        text.iter()
+            .map(|text| self.encode(text, add_special_tokens))
+            .collect()
     }
 
     /// Decode a list of token ids into a string.

--- a/interfaces/kalosm-sample/src/structured_parser/regex.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/regex.rs
@@ -22,7 +22,11 @@ impl RegexParser {
         let config =
             regex_automata::util::start::Config::new().anchored(regex_automata::Anchored::Yes);
 
-        Ok(Self { dfa, config, jump_table: Default::default() })
+        Ok(Self {
+            dfa,
+            config,
+            jump_table: Default::default(),
+        })
     }
 }
 
@@ -66,16 +70,15 @@ impl Parser for RegexParser {
 
         if let Some(string) = jump_table_read.get(&required_next_state) {
             required_next.push_str(string);
-        }
-        else {
+        } else {
             'required_next: loop {
                 let mut one_valid_byte = None;
-    
+
                 if let Some(string) = jump_table_read.get(&required_next_state) {
                     required_next.push_str(string);
                     break;
                 }
-            
+
                 for byte in 0..=255 {
                     let next_state = self.dfa.next_state(required_next_state, byte);
                     if self.dfa.is_dead_state(next_state) || self.dfa.is_quit_state(next_state) {
@@ -86,7 +89,7 @@ impl Parser for RegexParser {
                     }
                     one_valid_byte = Some((byte, next_state));
                 }
-    
+
                 if let Some((byte, new_state)) = one_valid_byte {
                     required_next.push(byte.into());
                     required_next_state = new_state;
@@ -97,7 +100,10 @@ impl Parser for RegexParser {
 
             if !required_next.is_empty() {
                 drop(jump_table_read);
-                self.jump_table.write().unwrap().insert(state, required_next.clone());
+                self.jump_table
+                    .write()
+                    .unwrap()
+                    .insert(state, required_next.clone());
             }
         }
 

--- a/interfaces/kalosm-streams/src/text_stream.rs
+++ b/interfaces/kalosm-streams/src/text_stream.rs
@@ -53,6 +53,20 @@ pub trait TextStream<I: AsRef<str>>: Stream<Item = I> {
         }
     }
 
+    /// Get all the text from the stream.
+    fn all_text(mut self) -> impl std::future::Future<Output = String> + Send
+    where
+        Self: Sized + Unpin + Send,
+    {
+        async move {
+            let mut all_text = String::new();
+            while let Some(text) = self.next().await {
+                all_text.push_str(text.as_ref());
+            }
+            all_text
+        }
+    }
+
     /// Write the stream to standard output.
     fn to_std_out(self) -> impl std::future::Future<Output = std::io::Result<()>> + Send
     where

--- a/interfaces/kalosm/examples/chunking.rs
+++ b/interfaces/kalosm/examples/chunking.rs
@@ -17,7 +17,7 @@ async fn main() {
 
     let mut llm = Llama::new_chat();
 
-    let hypothetical = Hypothetical::builder(&mut llm)
+    let hypothetical = Hypothetical::builder()
         .with_chunking(kalosm_language::search::ChunkStrategy::Paragraph {
             paragraph_count: 1,
             overlap: 0,

--- a/interfaces/kalosm/examples/evaluation.rs
+++ b/interfaces/kalosm/examples/evaluation.rs
@@ -34,7 +34,7 @@ async fn main() {
 
     let mut llm = Llama::new_chat();
 
-    let hypothetical = Hypothetical::builder(&mut llm).build().unwrap();
+    let hypothetical = Hypothetical::builder().build().unwrap();
 
     let mut test_cases = TestCases::new();
 
@@ -57,7 +57,7 @@ async fn main() {
         ("Blockchain technology, beyond cryptocurrencies, is being explored for applications like smart contracts. Smart contracts are self-executing contracts with the terms of the agreement directly written into code.", "How is blockchain technology utilized in the concept of smart contracts?")
     ];
 
-    let hypothetical = Hypothetical::builder(&mut llm)
+    let hypothetical = Hypothetical::builder()
         .with_examples(alternate_examples)
         .build()
         .unwrap();

--- a/interfaces/kalosm/examples/task.rs
+++ b/interfaces/kalosm/examples/task.rs
@@ -9,7 +9,7 @@ async fn main() {
     let constraints =
         RegexParser::new(r"(Step \d: \d+ [+\-*/] \d+ = \d+\n){1,3}Output: \d+").unwrap();
 
-    let task = Task::builder(&llm, "You are an assistant who solves math problems. When solving problems, you will always solve problems step by step with one step per line. Once you have solved the problem, you will output the result in the format 'Output: <result>'.")
+    let task = Task::builder("You are an assistant who solves math problems. When solving problems, you will always solve problems step by step with one step per line. Once you have solved the problem, you will output the result in the format 'Output: <result>'.")
         .with_constraints(constraints)
         .with_example("What is 1 + 2?", "Step 1: 1 + 2 = 3\nOutput: 3")
         .with_example("What is 3 + 4?", "Step 1: 3 + 4 = 7\nOutput: 7")
@@ -20,8 +20,6 @@ async fn main() {
     println!("question 1");
     // The first time we use the task, it will load the model and prompt.
     task.run("What is 2 + 2?", &mut llm)
-        .await
-        .unwrap()
         .split()
         .0
         .to_std_out()
@@ -33,8 +31,6 @@ async fn main() {
     println!("question 2");
     // After the first time, the model and prompt are cached.
     task.run("What is 4 + 4?", &mut llm)
-        .await
-        .unwrap()
         .split()
         .0
         .to_std_out()
@@ -45,8 +41,6 @@ async fn main() {
     let start_timestamp = std::time::Instant::now();
     println!("question 3");
     task.run("What is (7 + 5)/2?", &mut llm)
-        .await
-        .unwrap()
         .split()
         .0
         .to_std_out()


### PR DESCRIPTION
This PR decouples models from tasks (and all abstractions built on tasks like some chunkers). This simplifies the task API and make it possible to use multiple models with one task