### PR TITLE
Support starling beta and speed up token generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,9 +1338,8 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f1b20174c1707e20f4cb364a355b449803c03e9b0c9193324623cf9787a4e00"
+version = "0.4.2"
+source = "git+https://github.com/huggingface/candle?rev=cdc8b57b5cf28ad92642b076d67e610bdb958b2d#cdc8b57b5cf28ad92642b076d67e610bdb958b2d"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -1366,15 +1365,14 @@ dependencies = [
 
 [[package]]
 name = "candle-datasets"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4aec640ab558b8e04e2565b243e660e3f880b55e0c4e15e89941246fa9d34e2"
+version = "0.4.2"
+source = "git+https://github.com/huggingface/candle?rev=cdc8b57b5cf28ad92642b076d67e610bdb958b2d#cdc8b57b5cf28ad92642b076d67e610bdb958b2d"
 dependencies = [
  "byteorder",
  "candle-core",
  "candle-nn",
  "hf-hub",
- "image 0.24.8",
+ "image 0.25.0",
  "memmap2 0.9.4",
  "parquet",
  "rand 0.8.5",
@@ -1384,9 +1382,8 @@ dependencies = [
 
 [[package]]
 name = "candle-flash-attn"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75943670542635d12c507dfc52f4362e82a134b8d47e65da7b90a51ca9eb732c"
+version = "0.4.2"
+source = "git+https://github.com/huggingface/candle?rev=cdc8b57b5cf28ad92642b076d67e610bdb958b2d#cdc8b57b5cf28ad92642b076d67e610bdb958b2d"
 dependencies = [
  "anyhow",
  "bindgen_cuda",
@@ -1396,18 +1393,16 @@ dependencies = [
 
 [[package]]
 name = "candle-kernels"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5845911a44164ebb73b56a0e23793ba1b583bad102af7400fe4768babc5815b2"
+version = "0.4.2"
+source = "git+https://github.com/huggingface/candle?rev=cdc8b57b5cf28ad92642b076d67e610bdb958b2d#cdc8b57b5cf28ad92642b076d67e610bdb958b2d"
 dependencies = [
  "bindgen_cuda",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20d6c0d49121e2709ed9faa958ba915ea59526036bcf27558817d1452a4ff09"
+version = "0.4.2"
+source = "git+https://github.com/huggingface/candle?rev=cdc8b57b5cf28ad92642b076d67e610bdb958b2d#cdc8b57b5cf28ad92642b076d67e610bdb958b2d"
 dependencies = [
  "metal",
  "once_cell",
@@ -1417,9 +1412,8 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a27533c8edfc915a6459f9850641ef523a829fa1a181c670766c1f752d873a"
+version = "0.4.2"
+source = "git+https://github.com/huggingface/candle?rev=cdc8b57b5cf28ad92642b076d67e610bdb958b2d#cdc8b57b5cf28ad92642b076d67e610bdb958b2d"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -1436,15 +1430,15 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5847699f0643da05e57fc473672566e93dc36d82c1b7eeb970c6154d3434fe1"
+version = "0.4.2"
+source = "git+https://github.com/huggingface/candle?rev=cdc8b57b5cf28ad92642b076d67e610bdb958b2d#cdc8b57b5cf28ad92642b076d67e610bdb958b2d"
 dependencies = [
  "accelerate-src",
  "byteorder",
  "candle-core",
  "candle-flash-attn",
  "candle-nn",
+ "fancy-regex",
  "intel-mkl-src",
  "num-traits",
  "rand 0.8.5",
@@ -3448,6 +3442,17 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
+]
 
 [[package]]
 name = "fastdivide"
@@ -5699,6 +5704,20 @@ dependencies = [
  "png 0.17.12",
  "qoi",
  "tiff",
+]
+
+[[package]]
+name = "image"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b4f005360d32e9325029b38ba47ebd7a56f3316df09249368939562d518645"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "num-traits",
+ "png 0.17.12",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -12716,7 +12735,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -15020,10 +15039,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,10 +82,10 @@ members = [
 ]
 
 [workspace.dependencies]
-candle-core = { version = "=0.4.1" }
-candle-nn = { version = "=0.4.1" }
-candle-transformers = { version = "=0.4.1" }
-candle-datasets = { version = "=0.4.1" }
+candle-core = { git = "https://github.com/huggingface/candle", rev = "cdc8b57b5cf28ad92642b076d67e610bdb958b2d" }
+candle-nn = { git = "https://github.com/huggingface/candle", rev = "cdc8b57b5cf28ad92642b076d67e610bdb958b2d" }
+candle-transformers = { git = "https://github.com/huggingface/candle", rev = "cdc8b57b5cf28ad92642b076d67e610bdb958b2d" }
+candle-datasets = { git = "https://github.com/huggingface/candle", rev = "cdc8b57b5cf28ad92642b076d67e610bdb958b2d" }
 kalosm = { path = "./interfaces/kalosm", version = "0.2.1" }
 kalosm-sample = { path = "./interfaces/kalosm-sample", version = "0.2.1" }
 kalosm-common = { path = "./interfaces/kalosm-common", version = "0.1.0" }

--- a/models/kalosm-llama/examples/infer.rs
+++ b/models/kalosm-llama/examples/infer.rs
@@ -21,9 +21,15 @@ async fn main() {
     let prompt = "The capital of France is ";
     let mut result = model.stream_text(prompt).await.unwrap();
 
+    let start_time = std::time::Instant::now();
+    let mut tokens = 0;
     print!("{prompt}");
     while let Some(token) = result.next().await {
+        tokens += 1;
         print!("{token}");
         std::io::stdout().flush().unwrap();
     }
+    let elapsed = start_time.elapsed();
+    println!("\n\nGenerated {} tokens in {:?}", tokens, elapsed);
+    println!("Tokens per second: {:.2}", tokens as f64 / elapsed.as_secs_f64());
 }

--- a/models/kalosm-llama/src/lib.rs
+++ b/models/kalosm-llama/src/lib.rs
@@ -98,7 +98,7 @@ impl Llama {
     /// Create a default chat model.
     pub async fn new_chat() -> anyhow::Result<Self> {
         Llama::builder()
-            .with_source(LlamaSource::open_chat_7b())
+            .with_source(LlamaSource::starling_7b_beta())
             .build()
             .await
     }

--- a/models/kalosm-llama/src/raw/attention_layer.rs
+++ b/models/kalosm-llama/src/raw/attention_layer.rs
@@ -2,18 +2,18 @@ use super::cache::{AttentionCache, AttentionCacheValue};
 use super::rope::RopeCache;
 use candle_core::Device;
 use candle_core::{quantized::QMatMul, Module, Tensor};
-use candle_nn::LayerNorm;
+use candle_transformers::quantized_nn::RmsNorm;
 
 pub struct LlamaAttention {
     pub attention_wq: QMatMul,
     pub attention_wk: QMatMul,
     pub attention_wv: QMatMul,
     pub attention_wo: QMatMul,
-    pub attention_norm: LayerNorm,
+    pub attention_norm: RmsNorm,
     pub feed_forward_w1: QMatMul,
     pub feed_forward_w2: QMatMul,
     pub feed_forward_w3: QMatMul,
-    pub ffn_norm: LayerNorm,
+    pub ffn_norm: RmsNorm,
     pub n_head: usize,
     pub n_kv_head: usize,
     pub head_dim: usize,

--- a/models/kalosm-llama/src/raw/rope.rs
+++ b/models/kalosm-llama/src/raw/rope.rs
@@ -1,5 +1,5 @@
 use super::LlamaConfig;
-use candle_core::{DType, Device, Tensor, D};
+use candle_core::{DType, Device, Tensor};
 
 #[derive(Debug, Clone)]
 pub struct RopeCache {
@@ -47,29 +47,10 @@ impl RopeCache {
             x: &Tensor,
             index_pos: usize,
         ) -> candle_core::Result<Tensor> {
-            let (b_sz, n_head, seq_len, n_embd) = x.dims4()?;
-            let cos = cos
-                .narrow(0, index_pos, seq_len)?
-                .reshape((seq_len, n_embd / 2, 1))?;
-            let sin = sin
-                .narrow(0, index_pos, seq_len)?
-                .reshape((seq_len, n_embd / 2, 1))?;
-            let cos = cos.broadcast_as((b_sz, 1, seq_len, n_embd / 2, 1))?;
-            let sin = sin.broadcast_as((b_sz, 1, seq_len, n_embd / 2, 1))?;
-            // This mimics the llama.cpp behavior.
-            // https://github.com/ggerganov/llama.cpp/blob/1f0bccb27929e261744c979bc75114955da49e98/ggml.c#L12104-L12105
-            // The x0 and x1 value are interleaved on the n_embd (= head_dim) dimension.
-            // The resulting y0 and y1 are also interleaved with:
-            //   y0 = x0*cos - x1*sin
-            //   y1 = x0*sin + x1*cos
-            let x = x.reshape((b_sz, n_head, seq_len, n_embd / 2, 2))?;
-            let x0 = x.narrow(D::Minus1, 0, 1)?;
-            let x1 = x.narrow(D::Minus1, 1, 1)?;
-            let y0 = (x0.broadcast_mul(&cos)? - x1.broadcast_mul(&sin)?)?;
-            let y1 = (x0.broadcast_mul(&sin)? + x1.broadcast_mul(&cos)?)?;
-            let rope = Tensor::cat(&[y0, y1], D::Minus1)?;
-            let rope = rope.flatten_from(D::Minus2)?;
-            Ok(rope)
+            let (_b_sz, _n_head, seq_len, _n_embd) = x.dims4()?;
+            let cos = cos.narrow(0, index_pos, seq_len)?;
+            let sin = sin.narrow(0, index_pos, seq_len)?;
+            candle_nn::rotary_emb::rope_i(&x.contiguous()?, &cos, &sin)
         }
 
         let device = q.device();

--- a/models/kalosm-llama/src/source.rs
+++ b/models/kalosm-llama/src/source.rs
@@ -269,6 +269,31 @@ impl LlamaSource {
         }
     }
 
+    /// A preset for Starling 7b Beta
+    pub fn starling_7b_beta() -> Self {
+        Self {
+            model: FileSource::huggingface(
+                "bartowski/Starling-LM-7B-beta-GGUF".to_string(),
+                "main".to_string(),
+                "Starling-LM-7B-beta-Q4_K_M.gguf".to_string(),
+            ),
+            tokenizer: FileSource::huggingface(
+                "Nexusflow/Starling-LM-7B-beta".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ),
+            group_query_attention: 8,
+            markers: Some(ChatMarkers {
+                system_prompt_marker: "",
+                end_system_prompt_marker: "<|end_of_turn|>",
+                user_marker: "GPT4 Correct User: ",
+                end_user_marker: "<|end_of_turn|>",
+                assistant_marker: "GPT4 Correct Assistant: ",
+                end_assistant_marker: "<|end_of_turn|>",
+            })
+        }
+    }
+
     /// A preset for tiny llama 1.1b 1.0 Chat
     pub fn tiny_llama_1_1b_chat() -> Self {
         Self {


### PR DESCRIPTION
This PR adds support for starling beta and upgrades it to the default chat model. It also integrates some improvements in candle which speed up token generation from 20 t/s for a 7b model to 37 t/s for the same model