### PR TITLE
wuerstchen resolution warnings and accelerator support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
-[build]
-rustflags = ["-C", "target-cpu=native"]
+# [build]
+# rustflags = ["-C", "target-cpu=native"]
 
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "target-feature=-avx,-avx2"]
+# [target.x86_64-apple-darwin]
+# rustflags = ["-C", "target-feature=-avx,-avx2"]
 
 # [unstable]
 # build-std = ["std", "core", "alloc"]


### PR DESCRIPTION
This PR adds some warnings about low resolution quality and errors for resolutions that are not supported by the wuerstchen model.

Any resolutions outside of the range 1024x1024 and 1536x1536 may have poor quality and any resolutions that are not a multiple of 128 are not supported

It also adds support for accelerators like metal and cuda if they are available now that candle has wider support for quantized accelerator operations