### PR TITLE
Reference count language models

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,24 +18,6 @@ on:
       - .github/**
       - Cargo.toml
 
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
-    paths:
-      - interfaces/*/src/**
-      - interfaces/*/examples/**
-      - interfaces/*/Cargo.toml
-      - models/*/src/**
-      - models/*/examples/**
-      - models/*/Cargo.toml
-      - floneum/*/src/**
-      - floneum/*/examples/**
-      - floneum/*/Cargo.toml
-      - src/**
-      - .github/**
-      - Cargo.toml
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -373,7 +373,7 @@ where
 {
     type Output = StructureParserResult<ChannelTextStream<String>, P::Output>;
 
-    fn run<M: Model>(&self, input: String, model: & M) -> Self::Output where <<M as kalosm_language_model::Model>::SyncModel as kalosm_language_model::SyncModel>::Session: Send + Sync{
+    fn run<M: Model>(&self, input: String, model: &M) -> Self::Output where <<M as kalosm_language_model::Model>::SyncModel as kalosm_language_model::SyncModel>::Session: Send + Sync{
         let (tx, rx) = unbounded_channel();
         let (parsed_tx, parsed_rx) = oneshot::channel();
         let arc_parser = self.parser.clone();

--- a/interfaces/kalosm/README.md
+++ b/interfaces/kalosm/README.md
@@ -323,7 +323,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     let mut model = Llama::new_chat();
-    let mut chat = Chat::builder(&mut model).with_system_prompt("The assistant help answer questions based on the context given by the user. The model knows that the information the user gives it is always true.").build();
+    let mut chat = Chat::builder(model).with_system_prompt("The assistant help answer questions based on the context given by the user. The model knows that the information the user gives it is always true.").build();
 
     loop {
         let user_question = prompt_input("\n> ").unwrap();

--- a/interfaces/kalosm/examples/chat-mistral-2.rs
+++ b/interfaces/kalosm/examples/chat-mistral-2.rs
@@ -2,12 +2,12 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let mut model = Llama::builder()
+    let model = Llama::builder()
         .with_source(LlamaSource::mistral_7b_instruct_2())
         .build()
         .await
         .unwrap();
-    let mut chat = Chat::builder(&mut model)
+    let mut chat = Chat::builder(model)
         .with_system_prompt("The assistant will act like a pirate")
         .build();
 

--- a/interfaces/kalosm/examples/chat-tiny-llama.rs
+++ b/interfaces/kalosm/examples/chat-tiny-llama.rs
@@ -2,12 +2,12 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let mut model = Llama::builder()
+    let model = Llama::builder()
         .with_source(LlamaSource::tiny_llama_1_1b_chat())
         .build()
         .await
         .unwrap();
-    let mut chat = Chat::builder(&mut model)
+    let mut chat = Chat::builder(model)
         .with_system_prompt("The assistant will act like a pirate")
         .build();
 

--- a/interfaces/kalosm/examples/chat-with-character.rs
+++ b/interfaces/kalosm/examples/chat-with-character.rs
@@ -7,11 +7,11 @@ async fn main() {
     let character_description =
         format!("{description} The assistant will never reveal that it is an AI or assistant.");
 
-    let mut model = Llama::new_chat().await.unwrap();
+    let model = Llama::new_chat().await.unwrap();
     let constraints = LiteralParser::new(format!("(Responding as {}) ", character_name)).then(
         StopOn::new(model.chat_markers().unwrap().end_assistant_marker),
     );
-    let mut chat = Chat::builder(&mut model)
+    let mut chat = Chat::builder(model)
         .with_system_prompt(character_description)
         .constrain_response(move |_, _| constraints.clone())
         .build();

--- a/interfaces/kalosm/examples/chat.rs
+++ b/interfaces/kalosm/examples/chat.rs
@@ -2,8 +2,8 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let mut model = Llama::new_chat().await.unwrap();
-    let mut chat = Chat::builder(&mut model)
+    let model = Llama::new_chat().await.unwrap();
+    let mut chat = Chat::builder(model)
         .with_system_prompt("The assistant will act like a pirate")
         .build();
 

--- a/interfaces/kalosm/examples/live_qa.rs
+++ b/interfaces/kalosm/examples/live_qa.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a llama chat model
     let mut model = Llama::new_chat().await.unwrap();
-    let mut chat = Chat::builder(&mut model).with_system_prompt("The assistant help answer questions based on the context given by the user. The model knows that the information the user gives it is always true.").build();
+    let mut chat = Chat::builder(model).with_system_prompt("The assistant help answer questions based on the context given by the user. The model knows that the information the user gives it is always true.").build();
 
     loop {
         // Ask the user for a question

--- a/interfaces/kalosm/examples/live_qa.rs
+++ b/interfaces/kalosm/examples/live_qa.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     // Create a llama chat model
-    let mut model = Llama::new_chat().await.unwrap();
+    let model = Llama::new_chat().await.unwrap();
     let mut chat = Chat::builder(model).with_system_prompt("The assistant help answer questions based on the context given by the user. The model knows that the information the user gives it is always true.").build();
 
     loop {

--- a/interfaces/kalosm/examples/phi-chat.rs
+++ b/interfaces/kalosm/examples/phi-chat.rs
@@ -4,12 +4,12 @@ use kalosm::language::*;
 async fn main() {
     let description = prompt_input("What is your character like? ").unwrap();
 
-    let mut model = Phi::builder()
+    let model = Phi::builder()
         .with_source(PhiSource::dolphin_phi_v2())
         .build()
         .await
         .unwrap();
-    let mut chat = Chat::builder(&mut model)
+    let mut chat = Chat::builder(model)
         .with_system_prompt(description)
         .build();
 

--- a/interfaces/kalosm/examples/phi-chat.rs
+++ b/interfaces/kalosm/examples/phi-chat.rs
@@ -9,9 +9,7 @@ async fn main() {
         .build()
         .await
         .unwrap();
-    let mut chat = Chat::builder(model)
-        .with_system_prompt(description)
-        .build();
+    let mut chat = Chat::builder(model).with_system_prompt(description).build();
 
     loop {
         chat.add_message(prompt_input("\n> ").unwrap())

--- a/interfaces/kalosm/examples/resume-chat.rs
+++ b/interfaces/kalosm/examples/resume-chat.rs
@@ -2,15 +2,15 @@ use kalosm::language::*;
 
 #[tokio::main]
 async fn main() {
-    let mut model = Llama::new_chat().await.unwrap();
+    let model = Llama::new_chat().await.unwrap();
     let save_path = std::path::PathBuf::from("./chat.llama");
     let mut chat = if save_path.exists() {
-        Chat::builder(&mut model)
+        Chat::builder(model)
             .with_session_path(&save_path)
             .unwrap()
             .build()
     } else {
-        Chat::builder(&mut model).with_system_prompt("The assistant will act like a pirate. They only respond as a pirate named Skally Waggs. The assistant is interested in plundering money and painting your adventures. The assistant will never mention this to the user.").build()
+        Chat::builder(model).with_system_prompt("The assistant will act like a pirate. They only respond as a pirate named Skally Waggs. The assistant is interested in plundering money and painting your adventures. The assistant will never mention this to the user.").build()
     };
 
     for _ in 0..2 {

--- a/interfaces/kalosm/examples/self-chat.rs
+++ b/interfaces/kalosm/examples/self-chat.rs
@@ -7,10 +7,10 @@ use std::io::Write;
 async fn main() {
     let model = Llama::new_chat().await.unwrap();
     let mut agent1 = Chat::builder(model.clone())
-        .with_system_prompt("The assistant will act like a pirate")
+        .with_system_prompt("The assistant will act like a pirate.")
         .build();
     let mut agent2 = Chat::builder(model)
-        .with_system_prompt("The assistant will act like a user who asks questions about the world")
+        .with_system_prompt("The assistant is curious and will ask questions about the world.")
         .build();
 
     let mut response = String::from("Is there anything you want to know about the world?");

--- a/interfaces/kalosm/examples/self-chat.rs
+++ b/interfaces/kalosm/examples/self-chat.rs
@@ -1,0 +1,33 @@
+use kalosm::language::*;
+use std::io::Write;
+
+#[tokio::main]
+async fn main() {
+    let model = Llama::new_chat().await.unwrap();
+    let mut agent1 = Chat::builder(model.clone())
+        .with_system_prompt("The assistant will act like a pirate")
+        .build();
+    let mut agent2 = Chat::builder(model)
+        .with_system_prompt("The assistant will act like a user who asks questions about the world")
+        .build();
+
+    let mut response = String::from("Do you have any questions?");
+    loop {
+        let mut stream = agent2.add_message(&response).await.unwrap();
+        print!("User: ");
+        let mut user_question = String::new();
+        while let Some(token) = stream.next().await {
+            print!("{token}");
+            std::io::stdout().flush().unwrap();
+            user_question += &token;
+        }
+        println!();
+        let mut stream = agent1.add_message(user_question).await.unwrap();
+        response.clear();
+        while let Some(token) = stream.next().await {
+            print!("{token}");
+            std::io::stdout().flush().unwrap();
+            response += &token;
+        }
+    }
+}

--- a/interfaces/kalosm/examples/self-chat.rs
+++ b/interfaces/kalosm/examples/self-chat.rs
@@ -1,3 +1,5 @@
+//! You can have multiple chat instances with the same model.
+
 use kalosm::language::*;
 use std::io::Write;
 
@@ -11,10 +13,10 @@ async fn main() {
         .with_system_prompt("The assistant will act like a user who asks questions about the world")
         .build();
 
-    let mut response = String::from("Do you have any questions?");
+    let mut response = String::from("Is there anything you want to know about the world?");
     loop {
+        println!("User:");
         let mut stream = agent2.add_message(&response).await.unwrap();
-        print!("User: ");
         let mut user_question = String::new();
         while let Some(token) = stream.next().await {
             print!("{token}");
@@ -22,6 +24,8 @@ async fn main() {
             user_question += &token;
         }
         println!();
+
+        println!("Assistant:");
         let mut stream = agent1.add_message(user_question).await.unwrap();
         response.clear();
         while let Some(token) = stream.next().await {
@@ -29,5 +33,6 @@ async fn main() {
             std::io::stdout().flush().unwrap();
             response += &token;
         }
+        println!();
     }
 }

--- a/models/kalosm-llama/src/language_model.rs
+++ b/models/kalosm-llama/src/language_model.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
 pub use crate::Llama;
@@ -82,6 +83,6 @@ impl Model for Llama {
     }
 
     fn chat_markers(&self) -> Option<ChatMarkers> {
-        self.chat_markers.clone()
+        self.chat_markers.deref().clone()
     }
 }

--- a/models/kalosm-llama/src/lib.rs
+++ b/models/kalosm-llama/src/lib.rs
@@ -80,6 +80,7 @@ type SyncCallback = Box<
 >;
 
 /// A quantized Llama language model with support for streaming generation.
+#[derive(Clone)]
 pub struct Llama {
     task_sender: tokio::sync::mpsc::UnboundedSender<Task>,
     tokenizer: Arc<Tokenizer>,

--- a/models/kalosm-llama/src/lib.rs
+++ b/models/kalosm-llama/src/lib.rs
@@ -82,15 +82,15 @@ type SyncCallback = Box<
 /// A quantized Llama language model with support for streaming generation.
 pub struct Llama {
     task_sender: tokio::sync::mpsc::UnboundedSender<Task>,
-    thread_handle: Option<std::thread::JoinHandle<()>>,
     tokenizer: Arc<Tokenizer>,
-    chat_markers: Option<ChatMarkers>,
+    chat_markers: Arc<Option<ChatMarkers>>,
 }
 
 impl Drop for Llama {
     fn drop(&mut self) {
-        self.task_sender.send(Task::Kill).unwrap();
-        self.thread_handle.take().unwrap().join().unwrap();
+        if std::sync::Arc::strong_count(&self.chat_markers) == 1 {
+            self.task_sender.send(Task::Kill).unwrap();
+        }
     }
 }
 
@@ -127,7 +127,7 @@ impl Llama {
         let (task_sender, mut task_receiver) = tokio::sync::mpsc::unbounded_channel();
         let arc_tokenizer = Arc::new(tokenizer);
 
-        let thread_handle = std::thread::spawn({
+        std::thread::spawn({
             let arc_tokenizer = arc_tokenizer.clone();
             move || {
                 let mut inner = LlamaModel::new(model, arc_tokenizer, device, cache);
@@ -158,9 +158,8 @@ impl Llama {
         });
         Self {
             task_sender,
-            thread_handle: Some(thread_handle),
             tokenizer: arc_tokenizer,
-            chat_markers,
+            chat_markers: chat_markers.into(),
         }
     }
 

--- a/models/rphi/src/language_model.rs
+++ b/models/rphi/src/language_model.rs
@@ -6,6 +6,7 @@ use crate::Task;
 use kalosm_common::ModelLoadingProgress;
 use kalosm_language_model::*;
 use kalosm_streams::text_stream::ChannelTextStream;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -83,7 +84,7 @@ impl Model for Phi {
     }
 
     fn chat_markers(&self) -> Option<ChatMarkers> {
-        self.chat_markers.clone()
+        self.chat_markers.deref().clone()
     }
 }
 

--- a/models/rphi/src/lib.rs
+++ b/models/rphi/src/lib.rs
@@ -82,15 +82,15 @@ type SyncCallback = Box<
 /// A quantized Phi-1.5 language model with support for streaming generation.
 pub struct Phi {
     task_sender: tokio::sync::mpsc::UnboundedSender<Task>,
-    thread_handle: Option<std::thread::JoinHandle<()>>,
     tokenizer: Arc<Tokenizer>,
-    chat_markers: Option<ChatMarkers>,
+    chat_markers: Arc<Option<ChatMarkers>>,
 }
 
 impl Drop for Phi {
     fn drop(&mut self) {
-        self.task_sender.send(Task::Kill).unwrap();
-        self.thread_handle.take().unwrap().join().unwrap();
+        if std::sync::Arc::strong_count(&self.chat_markers) == 1 {
+            self.task_sender.send(Task::Kill).unwrap();
+        }
     }
 }
 
@@ -124,7 +124,7 @@ impl Phi {
         let (task_sender, mut task_receiver) = tokio::sync::mpsc::unbounded_channel();
         let arc_tokenizer = Arc::new(tokenizer);
 
-        let thread_handle = std::thread::spawn({
+        std::thread::spawn({
             let arc_tokenizer = arc_tokenizer.clone();
             move || {
                 let mut inner = PhiModel::new(model, arc_tokenizer, device, cache);
@@ -153,11 +153,11 @@ impl Phi {
                     })
             }
         });
+
         Self {
             task_sender,
-            thread_handle: Some(thread_handle),
             tokenizer: arc_tokenizer,
-            chat_markers,
+            chat_markers: chat_markers.into(),
         }
     }
 

--- a/models/rphi/src/lib.rs
+++ b/models/rphi/src/lib.rs
@@ -80,6 +80,7 @@ type SyncCallback = Box<
 >;
 
 /// A quantized Phi-1.5 language model with support for streaming generation.
+#[derive(Clone)]
 pub struct Phi {
     task_sender: tokio::sync::mpsc::UnboundedSender<Task>,
     tokenizer: Arc<Tokenizer>,


### PR DESCRIPTION
This changes language models to be cheaply clonable so that interfaces like chat can own a reference to them instead of using channels. This makes it possible to use chat after you drop the model and makes it possible to chat with multiple instances of the same model

Closes #179 