### PR TITLE
Simplify Parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6230,7 +6230,6 @@ dependencies = [
  "serde",
  "serde_json",
  "slab",
- "spinoff 0.7.0",
  "tantivy",
  "tempfile",
  "texting_robots",
@@ -6368,6 +6367,7 @@ dependencies = [
  "rand 0.8.5",
  "regex-automata 0.4.6",
  "rustc-hash",
+ "thiserror",
  "tokenizers 0.13.4",
  "tracing",
 ]

--- a/floneum/plugin/src/llm.rs
+++ b/floneum/plugin/src/llm.rs
@@ -212,7 +212,7 @@ impl main::types::HostModel for State {
         input: String,
         regex: String,
     ) -> wasmtime::Result<String> {
-        let structure = RegexParser::new(&regex)?;
+        let structure = RegexParser::new(&regex).map_err(|e| wasmtime::Error::msg(format!("{e:?}")))?;
         let model = &mut self.models[self_.rep() as usize];
 
         Ok(model

--- a/interfaces/kalosm-language/Cargo.toml
+++ b/interfaces/kalosm-language/Cargo.toml
@@ -15,7 +15,6 @@ llm-samplers = { workspace = true }
 log = "0.4.17"
 rand = "0.8.5"
 reqwest = { version = "0.11.18", features = ["stream", "json"] }
-spinoff = "0.7.0"
 tokio = { version = "1.28.1", features = ["full"] }
 slab = { version = "0.4.8", features = ["serde"] }
 arroy = "0.2.0"

--- a/interfaces/kalosm-language/src/search/preprocessing/hypothetical.rs
+++ b/interfaces/kalosm-language/src/search/preprocessing/hypothetical.rs
@@ -23,12 +23,7 @@ type Constraints = kalosm_sample::SequenceParser<
     LiteralParser<&'static str>,
     kalosm_sample::RepeatParser<
         kalosm_sample::SequenceParser<
-            IndexParser<
-                LiteralParser<&'static str>,
-                kalosm_sample::LiteralMismatchError,
-                (),
-                kalosm_sample::LiteralParserOffset,
-            >,
+            IndexParser<LiteralParser<&'static str>, (), kalosm_sample::LiteralParserOffset>,
             StopOn<&'static str>,
         >,
     >,

--- a/interfaces/kalosm-language/src/tool/calculator.rs
+++ b/interfaces/kalosm-language/src/tool/calculator.rs
@@ -1,13 +1,15 @@
-use kalosm_sample::LiteralMismatchError;
+use kalosm_sample::{ArcParser, ParseResult};
 use kalosm_sample::{
-    ChoiceParser, ChoiceParserState, CreateParserState, Either, FloatParser, FloatParserState,
-    LiteralParser, LiteralParserOffset, ParseResult, Parser, ParserExt, SequenceParser,
-    SequenceParserState,
+    CreateParserState, FloatParser, LiteralParser, ParseStatus, Parser, ParserExt,
 };
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::Lazy;
+use std::fmt::Debug;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use crate::tool::Tool;
+
+use super::IndexParser;
 
 #[derive(Debug)]
 struct LazyParser<T>(Box<Lazy<T>>);
@@ -26,8 +28,6 @@ impl<T: Parser + Default> Default for LazyParser<T> {
 }
 
 impl<T: Parser> Parser for LazyParser<T> {
-    type Error = T::Error;
-
     type Output = T::Output;
 
     type PartialState = T::PartialState;
@@ -36,51 +36,53 @@ impl<T: Parser> Parser for LazyParser<T> {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         self.0.parse(state, input)
     }
 }
 
-type InnerParser = ChoiceParser<ChoiceParser<FloatParser, SequenceParser<SequenceParser<SequenceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<ChoiceParser<LiteralParser<&'static str>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LazyParser<EquationParser>>, LiteralParser<&'static str>>>, SequenceParser<SequenceParser<SequenceParser<SequenceParser<LiteralParser<&'static str>, LazyParser<EquationParser>>, ChoiceParser<ChoiceParser<ChoiceParser<LiteralParser<&'static str>, LiteralParser<&'static str>>, LiteralParser<&'static str>>, LiteralParser<&'static str>>>, LazyParser<EquationParser>>, LiteralParser<&'static str>>> ;
-type InnerParserState =ChoiceParserState<ChoiceParserState<FloatParserState, SequenceParserState<SequenceParserState<SequenceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<ChoiceParserState<LiteralParserOffset, LiteralParserOffset, LiteralMismatchError, LiteralMismatchError>, LiteralParserOffset, Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<(), ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>>, EquationParserState, (Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<(), ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ())>, LiteralParserOffset, ((Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<(), ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()>, ()), String)>, (), Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, EquationParserParseError>, LiteralMismatchError>>, SequenceParserState<SequenceParserState<SequenceParserState<SequenceParserState<LiteralParserOffset, EquationParserState, ()>, ChoiceParserState<ChoiceParserState<ChoiceParserState<LiteralParserOffset, LiteralParserOffset, LiteralMismatchError, LiteralMismatchError>, LiteralParserOffset, Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralParserOffset, Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, ((), String)>, EquationParserState, (((), String), Either<Either<Either<(), ()>, ()>, ()>)>, LiteralParserOffset, ((((), String), Either<Either<Either<(), ()>, ()>, ()>), String)>, Either<(), Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>, EquationParserParseError>, LiteralMismatchError>>, Either<Either<Either<Either<LiteralMismatchError, EquationParserParseError>, Either<Either<Either<LiteralMismatchError, LiteralMismatchError>, LiteralMismatchError>, LiteralMismatchError>>, EquationParserParseError>, LiteralMismatchError>>;
-
 /// A parser for mathematical equations
 pub struct EquationParser {
-    parser: InnerParser,
+    parser: ArcParser,
 }
 
 impl CreateParserState for EquationParser {
     fn create_parser_state(&self) -> <Self as Parser>::PartialState {
-        Default::default()
+        EquationParserState {
+            state: self.parser.create_parser_state(),
+            current_text: String::new(),
+        }
     }
 }
 
 impl Default for EquationParser {
     fn default() -> Self {
         let number = FloatParser::new(f64::MIN..=f64::MAX);
-        let function = LiteralParser::new("sqrt")
-            .or(LiteralParser::new("abs"))
-            .or(LiteralParser::new("exp"))
-            .or(LiteralParser::new("ln"))
-            .or(LiteralParser::new("sin"))
-            .or(LiteralParser::new("cos"))
-            .or(LiteralParser::new("tan"))
-            .or(LiteralParser::new("asin"))
-            .or(LiteralParser::new("acos"))
-            .or(LiteralParser::new("atan"))
-            .or(LiteralParser::new("atan2"))
-            .or(LiteralParser::new("sinh"))
-            .or(LiteralParser::new("cosh"))
-            .or(LiteralParser::new("tanh"))
-            .or(LiteralParser::new("asinh"))
-            .or(LiteralParser::new("acosh"))
-            .or(LiteralParser::new("atanh"))
-            .or(LiteralParser::new("floor"))
-            .or(LiteralParser::new("ceil"))
-            .or(LiteralParser::new("round"))
-            .or(LiteralParser::new("signum"))
-            .or(LiteralParser::new("pi"))
-            .or(LiteralParser::new("e"));
+        let function = IndexParser::new(vec![
+            LiteralParser::new("sqrt"),
+            LiteralParser::new("abs"),
+            LiteralParser::new("exp"),
+            LiteralParser::new("ln"),
+            LiteralParser::new("sin"),
+            LiteralParser::new("cos"),
+            LiteralParser::new("tan"),
+            LiteralParser::new("asin"),
+            LiteralParser::new("acos"),
+            LiteralParser::new("atan"),
+            LiteralParser::new("atan2"),
+            LiteralParser::new("sinh"),
+            LiteralParser::new("cosh"),
+            LiteralParser::new("tanh"),
+            LiteralParser::new("asinh"),
+            LiteralParser::new("acosh"),
+            LiteralParser::new("atanh"),
+            LiteralParser::new("floor"),
+            LiteralParser::new("ceil"),
+            LiteralParser::new("round"),
+            LiteralParser::new("signum"),
+            LiteralParser::new("pi"),
+            LiteralParser::new("e"),
+        ]);
 
         let addition = LiteralParser::new(" + ");
         let subtraction = LiteralParser::new(" - ");
@@ -101,7 +103,9 @@ impl Default for EquationParser {
 
         let expression = number.or(function_call).or(binary_operation);
 
-        Self { parser: expression }
+        Self {
+            parser: expression.map_output(|_| ()).boxed(),
+        }
     }
 }
 
@@ -118,8 +122,6 @@ impl std::fmt::Display for EquationParserParseError {
 impl std::error::Error for EquationParserParseError {}
 
 impl Parser for EquationParser {
-    type Error = EquationParserParseError;
-
     type Output = String;
 
     type PartialState = EquationParserState;
@@ -128,53 +130,41 @@ impl Parser for EquationParser {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
-        self.parser
-            .parse(&*state.state, input)
-            .map(|result| {
-                let new_text = state.current_text.clone() + std::str::from_utf8(input).unwrap();
-                match result {
-                    ParseResult::Incomplete {
-                        new_state,
-                        required_next,
-                    } => ParseResult::Incomplete {
-                        new_state: EquationParserState {
-                            state: LazyState(Box::new(OnceCell::from(new_state))),
-                            current_text: new_text,
-                        },
-                        required_next,
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
+        self.parser.parse(&state.state, input).map(|result| {
+            let new_text = state.current_text.clone() + std::str::from_utf8(input).unwrap();
+            match result {
+                ParseStatus::Incomplete {
+                    new_state,
+                    required_next,
+                } => ParseStatus::Incomplete {
+                    new_state: EquationParserState {
+                        state: new_state,
+                        current_text: new_text,
                     },
-                    ParseResult::Finished { remaining, .. } => ParseResult::Finished {
-                        remaining,
-                        result: new_text,
-                    },
-                }
-            })
-            .map_err(|_| EquationParserParseError)
+                    required_next,
+                },
+                ParseStatus::Finished { remaining, .. } => ParseStatus::Finished {
+                    remaining,
+                    result: new_text,
+                },
+            }
+        })
     }
 }
 
 /// The state of an equation parser.
-#[derive(Default, Debug, Clone)]
+#[derive(Clone)]
 pub struct EquationParserState {
-    state: LazyState<InnerParserState>,
+    state: Arc<dyn std::any::Any + Send + Sync>,
     current_text: String,
 }
 
-#[derive(Debug, Clone, Default)]
-struct LazyState<T>(Box<OnceCell<T>>);
-
-impl<T: Default> Deref for LazyState<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        match self.0.get() {
-            Some(state) => state,
-            None => {
-                let _ = self.0.set(Default::default());
-                self.0.get().unwrap()
-            }
-        }
+impl Debug for EquationParserState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EquationParserState")
+            .field("current_text", &self.current_text)
+            .finish()
     }
 }
 
@@ -229,6 +219,7 @@ impl Tool for CalculatorTool {
     }
 
     async fn run(&mut self, expr: String) -> String {
+        println!("{expr}");
         match meval::eval_str(expr){
             Ok(result) => result.to_string(),
             Err(e) => format!("Input was invalid, try again making sure to only use numbers and one of the prebuilt math functions. {e}"),

--- a/interfaces/kalosm-language/src/tool/mod.rs
+++ b/interfaces/kalosm-language/src/tool/mod.rs
@@ -10,8 +10,8 @@ use std::{
 
 use kalosm_language_model::{GenerationParameters, SyncModel, SyncModelExt};
 use kalosm_sample::{
-    ArcParser, ChoiceParser, CreateParserState, Either, LiteralMismatchError, LiteralParser,
-    LiteralParserOffset, ParseResult, Parser, ParserExt, SequenceParser, SequenceParserState,
+    ArcParser, CreateParserState, Either, LiteralParser, ParseResult, ParseStatus, Parser,
+    ParserExt,
 };
 pub use search::*;
 mod calculator;
@@ -53,7 +53,6 @@ struct DynToolWrapper<T: Tool>
 where
     <T::Constraint as Parser>::Output: Clone + Send + Sync + 'static,
     <T::Constraint as Parser>::PartialState: Send + Sync + 'static,
-    <T::Constraint as Parser>::Error: Error + Send + Sync + 'static,
     <T as Tool>::Constraint: std::marker::Send + std::marker::Sync + 'static,
 {
     tool: T,
@@ -64,12 +63,15 @@ impl<T: Tool + Send> Tool for DynToolWrapper<T>
 where
     <T::Constraint as Parser>::Output: Clone + Send + Sync + 'static,
     <T::Constraint as Parser>::PartialState: Send + Sync + 'static,
-    <T::Constraint as Parser>::Error: Error + Send + Sync + 'static,
     <T as Tool>::Constraint: std::marker::Send + std::marker::Sync + 'static,
 {
-    type Constraint = ArcParser;
+    type Constraint = ArcParser<Box<dyn Any + Send + Sync>>;
+
     fn constraints(&self) -> Self::Constraint {
-        self.tool.constraints().boxed()
+        self.tool
+            .constraints()
+            .map_output(|out| Box::new(out) as Box<dyn Any + Send + Sync>)
+            .boxed()
     }
 
     fn name(&self) -> String {
@@ -82,16 +84,16 @@ where
         self.tool.description()
     }
     async fn run(&mut self, args: <<Self as Tool>::Constraint as Parser>::Output) -> String {
-        let args = args
-            .downcast_ref::<<T::Constraint as Parser>::Output>()
-            .unwrap()
-            .clone();
+        let args = *args
+            .downcast::<<T::Constraint as Parser>::Output>()
+            .unwrap();
         self.tool.run(args).await
     }
 }
 
 /// A dynamic tool that can be used by a [`kalosm_language_model::Model`]
-pub type BoxedTool = Box<dyn Tool<Constraint = ArcParser> + Sync + Send>;
+pub type BoxedTool =
+    Box<dyn Tool<Constraint = ArcParser<Box<dyn Any + Send + Sync>>> + Sync + Send>;
 
 /// A set of tools that can be used by a [`kalosm_language_model::Model`]
 #[derive(Default)]
@@ -110,6 +112,20 @@ impl std::fmt::Debug for ToolManager {
     }
 }
 
+/// The type of action that can be taken
+#[derive(Debug)]
+pub(crate) enum Action {
+    /// The chatbot has thought
+    Thought(String),
+    /// The chatbot interacts with a tool
+    Tool {
+        index: usize,
+        input: Box<dyn Any + Send + Sync>,
+    },
+    /// The chatbot answers the question
+    Answer(String),
+}
+
 impl ToolManager {
     /// Create a new tool empty manager
     pub fn new() -> Self {
@@ -122,7 +138,6 @@ impl ToolManager {
         T: Tool + Send + Sync + 'static,
         <T::Constraint as Parser>::Output: Clone + Send + Sync + 'static,
         <T::Constraint as Parser>::PartialState: Send + Sync + 'static,
-        <T::Constraint as Parser>::Error: Error + Send + Sync + 'static,
         <T as Tool>::Constraint: std::marker::Send + std::marker::Sync + 'static,
     {
         self.add_tool(tool);
@@ -135,7 +150,6 @@ impl ToolManager {
         T: Tool + Send + Sync + 'static,
         <T::Constraint as Parser>::Output: Clone + Send + Sync + 'static,
         <T::Constraint as Parser>::PartialState: Send + Sync + 'static,
-        <T::Constraint as Parser>::Error: Error + Send + Sync + 'static,
         <T as Tool>::Constraint: std::marker::Send + std::marker::Sync + 'static,
     {
         self.tools.push(Box::new(DynToolWrapper { tool }));
@@ -203,110 +217,58 @@ Question: {question}
     }
 
     /// Get the constraints for the tools in the manager
-    pub fn tool_choices(
-        &self,
-    ) -> Option<
-        IndexParser<
-            SequenceParser<LiteralParser<String>, ArcParser>,
-            Either<LiteralMismatchError, Arc<dyn Error + Send + Sync>>,
-            (
-                (),
-                Arc<(dyn std::any::Any + std::marker::Send + std::marker::Sync + 'static)>,
-            ),
-            SequenceParserState<LiteralParserOffset, Arc<dyn Any + Send + Sync>, ()>,
-        >,
-    > {
+    pub fn tool_choices(&self) -> Option<ArcParser<(usize, Box<dyn Any + Send + Sync>)>> {
         let mut parsers = Vec::with_capacity(self.tools.len());
         for tool in self.tools.iter() {
             let name = tool.name();
             let prompt = tool.input_prompt();
             let input_constraint = tool.constraints();
-            let tool_input_parser =
-                LiteralParser::from(format!("{name}\n{prompt}")).then(input_constraint);
+            let tool_input_parser = LiteralParser::from(format!("{name}\n{prompt}"))
+                .then(input_constraint)
+                .map_output(|(_, out)| out);
             parsers.push(tool_input_parser);
         }
-        (!parsers.is_empty()).then_some(IndexParser { parsers })
+        (!parsers.is_empty()).then_some(IndexParser { parsers }.boxed())
     }
 
     /// Get the constraints for the thought action
-    pub fn thought_constraints(
-        &self,
-    ) -> impl CreateParserState<
-        Error = Either<LiteralMismatchError, OneLineError>,
-        Output = ((), String),
-        PartialState = SequenceParserState<LiteralParserOffset, OneLineState, ()>,
-    > + Send
-           + Sync
-           + 'static {
+    pub(crate) fn thought_constraints(&self) -> ArcParser<String> {
         let constraints = "Thought: ";
-        LiteralParser::from(constraints).then(OneLine)
+        LiteralParser::from(constraints)
+            .then(OneLine)
+            .map_output(|(_, result)| result)
+            .boxed()
     }
 
     /// Get the constraints for the action action
-    pub fn action_constraints(
-        &self,
-    ) -> SequenceParser<
-        LiteralParser<&'static str>,
-        IndexParser<
-            SequenceParser<LiteralParser<String>, ArcParser>,
-            Either<LiteralMismatchError, Arc<dyn Error + Send + Sync>>,
-            ((), Arc<dyn Any + Send + Sync>),
-            SequenceParserState<LiteralParserOffset, Arc<dyn Any + Send + Sync>, ()>,
-        >,
-    > {
+    pub(crate) fn action_constraints(&self) -> ArcParser<(usize, Box<dyn Any + Send + Sync>)> {
         let constraints = LiteralParser::from("Action: ");
-        constraints.then(self.tool_choices().unwrap())
+        constraints
+            .then(self.tool_choices().unwrap())
+            .map_output(|(_, value)| value)
+            .boxed()
     }
 
     /// Get the constraints for the answer action
-    pub fn answer_constraints(
-        &self,
-    ) -> impl CreateParserState<
-        Error = Either<LiteralMismatchError, OneLineError>,
-        Output = ((), String),
-        PartialState = SequenceParserState<LiteralParserOffset, OneLineState, ()>,
-    > + Send
-           + Sync
-           + 'static {
+    pub(crate) fn answer_constraints(&self) -> ArcParser<String> {
         let constraints = LiteralParser::from("Final Answer: ");
-        constraints.then(OneLine)
+        constraints
+            .then(OneLine)
+            .map_output(|(_, result)| result)
+            .boxed()
     }
 
     /// Get the constraints for any action
-    pub fn any_action_constraint(
-        &self,
-    ) -> ChoiceParser<
-        ChoiceParser<
-            impl Parser<
-                    Error = Either<LiteralMismatchError, OneLineError>,
-                    Output = ((), String),
-                    PartialState = SequenceParserState<LiteralParserOffset, OneLineState, ()>,
-                > + CreateParserState
-                + Send
-                + Sync
-                + 'static,
-            SequenceParser<
-                LiteralParser<&'static str>,
-                IndexParser<
-                    SequenceParser<LiteralParser<String>, ArcParser>,
-                    Either<LiteralMismatchError, Arc<dyn Error + Send + Sync>>,
-                    ((), Arc<dyn Any + Send + Sync>),
-                    SequenceParserState<LiteralParserOffset, Arc<dyn Any + Send + Sync>, ()>,
-                >,
-            >,
-        >,
-        impl Parser<
-                Error = Either<LiteralMismatchError, OneLineError>,
-                Output = ((), String),
-                PartialState = SequenceParserState<LiteralParserOffset, OneLineState, ()>,
-            > + CreateParserState
-            + Send
-            + Sync
-            + 'static,
-    > {
+    pub(crate) fn any_action_constraint(&self) -> ArcParser<Action> {
         self.thought_constraints()
             .or(self.action_constraints())
             .or(self.answer_constraints())
+            .map_output(|action| match action {
+                Either::Left(Either::Left(thought)) => Action::Thought(thought),
+                Either::Left(Either::Right((index, input))) => Action::Tool { index, input },
+                Either::Right(answer) => Action::Answer(answer),
+            })
+            .boxed()
     }
 
     /// Run one step of the tool manager
@@ -332,24 +294,23 @@ Question: {question}
         )?;
 
         Ok(match result {
-            Either::Left(Either::Left(thought)) => {
-                new_text += &thought.1;
+            Action::Thought(thought) => {
+                new_text += &thought;
                 new_text += "\n";
                 add_token(new_text)?;
-                ToolManagerStepResult::Thought(thought.1)
+                ToolManagerStepResult::Thought(thought)
             }
-            Either::Left(Either::Right(((), (tool_index, ((), left))))) => {
-                let result = self
-                    .get_tool_mut_by_index(tool_index)
-                    .unwrap()
-                    .run(left)
-                    .await;
+            Action::Tool { index, input } => {
+                let result = self.get_tool_mut_by_index(index).unwrap().run(input).await;
                 new_text += &result;
                 new_text += "\n";
                 add_token(new_text)?;
-                ToolManagerStepResult::Action(result)
+                ToolManagerStepResult::Action {
+                    index,
+                    output: result,
+                }
             }
-            Either::Right(right) => ToolManagerStepResult::Finished(right.1),
+            Action::Answer(answer) => ToolManagerStepResult::Finished(answer),
         })
     }
 }
@@ -361,32 +322,36 @@ pub enum ToolManagerStepResult {
     /// The model produced a new thought
     Thought(String),
     /// The model produced a new action result
-    Action(String),
+    Action {
+        /// The index of the tool that produced the action
+        index: usize,
+        /// The output of the action
+        output: String,
+    },
 }
 
 /// The state of the [`IndexParser`] parser
 #[derive(Debug, Clone)]
-pub struct IndexParserState<PA, E> {
-    states: Vec<Result<PA, E>>,
+pub struct IndexParserState<PA> {
+    states: Vec<ParseResult<PA>>,
 }
 
 /// A parser that parses a sequence of parsers and returns the index of the first parser that succeeds
 #[derive(Debug, Clone)]
-pub struct IndexParser<S: Parser<Error = E, Output = O, PartialState = PA>, E, O, PA> {
+pub struct IndexParser<S: Parser<Output = O, PartialState = PA>, O, PA> {
     parsers: Vec<S>,
 }
 
-impl<S: Parser<Error = E, Output = O, PartialState = PA>, E, O, PA> IndexParser<S, E, O, PA> {
+impl<S: Parser<Output = O, PartialState = PA>, O, PA> IndexParser<S, O, PA> {
     /// Create a new index parser
     pub fn new(parsers: Vec<S>) -> Self {
         Self { parsers }
     }
 }
 
-impl<S, E, O, PA> CreateParserState for IndexParser<S, E, O, PA>
+impl<S, O, PA> CreateParserState for IndexParser<S, O, PA>
 where
-    S: Parser<Error = E, Output = O, PartialState = PA> + CreateParserState,
-    E: Clone,
+    S: Parser<Output = O, PartialState = PA> + CreateParserState,
     PA: Clone,
 {
     fn create_parser_state(&self) -> Self::PartialState {
@@ -400,21 +365,19 @@ where
     }
 }
 
-impl<S, E, O, PA> Parser for IndexParser<S, E, O, PA>
+impl<S, O, PA> Parser for IndexParser<S, O, PA>
 where
-    S: Parser<Error = E, Output = O, PartialState = PA>,
-    E: Clone,
+    S: Parser<Output = O, PartialState = PA>,
     PA: Clone,
 {
-    type Error = E;
     type Output = (usize, S::Output);
-    type PartialState = IndexParserState<PA, E>;
+    type PartialState = IndexParserState<PA>;
 
     fn parse<'a>(
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<kalosm_sample::ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<kalosm_sample::ParseStatus<'a, Self::PartialState, Self::Output>> {
         let mut states = state.states.clone();
         let mut has_incomplete_option = false;
         let mut required_next: Option<Cow<'static, str>> = None;
@@ -424,16 +387,16 @@ where
                 Ok(state) => {
                     let result = parser.parse(state, input);
                     match result {
-                        Ok(ParseResult::Finished {
+                        Ok(ParseStatus::Finished {
                             result,
                             remaining: r,
                         }) => {
-                            return Ok(ParseResult::Finished {
+                            return Ok(ParseStatus::Finished {
                                 result: (i, result),
                                 remaining: r,
                             })
                         }
-                        Ok(ParseResult::Incomplete {
+                        Ok(ParseStatus::Incomplete {
                             new_state: s,
                             required_next: new_required_next,
                         }) => {
@@ -481,7 +444,7 @@ where
                 }
             }
         }
-        Ok(ParseResult::Incomplete {
+        Ok(ParseStatus::Incomplete {
             new_state: IndexParserState { states },
             required_next: required_next.unwrap_or_default(),
         })
@@ -521,7 +484,6 @@ impl std::fmt::Display for OneLineError {
 impl Error for OneLineError {}
 
 impl Parser for OneLine {
-    type Error = OneLineError;
     type Output = String;
     type PartialState = OneLineState;
 
@@ -529,9 +491,9 @@ impl Parser for OneLine {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<kalosm_sample::ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<kalosm_sample::ParseStatus<'a, Self::PartialState, Self::Output>> {
         if input.is_empty() {
-            return Ok(ParseResult::Incomplete {
+            return Ok(ParseStatus::Incomplete {
                 new_state: state.clone(),
                 required_next: Default::default(),
             });
@@ -539,17 +501,20 @@ impl Parser for OneLine {
         let mut state = state.clone();
         let mut iter = input.iter();
         while let Some(&c) = iter.next() {
+            if !c.is_ascii_alphanumeric() || matches!(c, b' ' | b'.' | b'\n') {
+                kalosm_sample::bail!(OneLineError);
+            }
             if state.all_whitespace {
                 let c = char::from(c);
                 if !c.is_whitespace() {
                     state.all_whitespace = false;
                 }
             }
-            if c == b'\n' || c == b'\r' {
+            if c == b'\n' {
                 if state.all_whitespace {
-                    return Err(OneLineError);
+                    kalosm_sample::bail!(OneLineError);
                 } else {
-                    return Ok(ParseResult::Finished {
+                    return Ok(ParseStatus::Finished {
                         result: String::from_utf8_lossy(&state.bytes).to_string(),
                         remaining: iter.as_slice(),
                     });
@@ -557,7 +522,7 @@ impl Parser for OneLine {
             }
             state.bytes.push(c);
         }
-        Ok(ParseResult::Incomplete {
+        Ok(ParseStatus::Incomplete {
             new_state: state,
             required_next: Default::default(),
         })
@@ -571,7 +536,6 @@ macro_rules! impl_from_tool_tuple {
             $(
                 <$name::Constraint as Parser>::Output: Clone+Send + Sync + 'static,
                 <$name::Constraint as Parser>::PartialState: Send + Sync + 'static,
-                <$name::Constraint as Parser>::Error: Error + Send + Sync + 'static,
                 <$name as Tool>::Constraint: std::marker::Send + std::marker::Sync + 'static,
             )*
         {

--- a/interfaces/kalosm-sample/Cargo.toml
+++ b/interfaces/kalosm-sample/Cargo.toml
@@ -18,6 +18,7 @@ candle-core.workspace = true
 tokenizers = { version = "0.13.4" }
 rustc-hash = "1.1.0"
 regex-automata = "0.4.5"
+thiserror = "1.0.58"
 
 [features]
 llamacpp = []

--- a/interfaces/kalosm-sample/src/lib.rs
+++ b/interfaces/kalosm-sample/src/lib.rs
@@ -20,6 +20,9 @@ use tokenizers::PreTokenizer;
 use tokenizers::PreTokenizerWrapper;
 use tokenizers::TokenizerImpl;
 
+#[doc(hidden)]
+pub use anyhow;
+
 mod structured_parser;
 pub use structured_parser::*;
 #[cfg(feature = "llamacpp")]

--- a/interfaces/kalosm-sample/src/structured_parser/mod.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/mod.rs
@@ -1,7 +1,14 @@
 #![allow(clippy::type_complexity)]
 
 mod integer;
-use std::{any::Any, borrow::Cow, error::Error, sync::Arc};
+use std::{
+    any::Any,
+    borrow::Cow,
+    error::Error,
+    fmt::{Debug, Display},
+    ops::Deref,
+    sync::Arc,
+};
 
 pub use integer::*;
 mod float;
@@ -31,6 +38,74 @@ pub use map::*;
 mod regex;
 pub use regex::*;
 
+/// A parser error.
+#[derive(Debug, Clone)]
+pub struct ParserError(Arc<anyhow::Error>);
+
+/// Bail out with the given error.
+#[macro_export]
+macro_rules! bail {
+    ($msg:literal $(,)?) => {
+        return $crate::ParseResult::Err($crate::ParserError::msg($msg))
+    };
+    ($err:expr $(,)?) => {
+        return $crate::ParseResult::Err($crate::ParserError::from($err))
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        return $crate::ParseResult::Err($crate::ParserError::msg(format!($fmt, $($arg)*)))
+    };
+}
+
+impl ParserError {
+    /// Create a new error with the given message.
+    pub fn msg(msg: impl Display + Debug + Send + Sync + 'static) -> Self {
+        Self(Arc::new(anyhow::Error::msg(msg)))
+    }
+}
+
+impl PartialEq for ParserError {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for ParserError {}
+
+impl AsRef<dyn Error> for ParserError {
+    fn as_ref(&self) -> &(dyn Error + 'static) {
+        let err: &anyhow::Error = self.0.as_ref();
+        err.as_ref()
+    }
+}
+
+impl AsRef<dyn std::error::Error + Send + Sync + 'static> for ParserError {
+    fn as_ref(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+        let err: &anyhow::Error = self.0.as_ref();
+        err.as_ref()
+    }
+}
+
+impl Deref for ParserError {
+    type Target = (dyn Error + Send + Sync + 'static);
+
+    fn deref(&self) -> &(dyn Error + Send + Sync + 'static) {
+        let err: &anyhow::Error = self.0.as_ref();
+        err.deref()
+    }
+}
+
+impl<E> From<E> for ParserError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn from(value: E) -> Self {
+        Self(Arc::new(anyhow::Error::from(value)))
+    }
+}
+
+/// A result type for parsers.
+pub type ParseResult<T> = std::result::Result<T, ParserError>;
+
 /// A trait for a parser with a default state.
 pub trait CreateParserState: Parser {
     /// Create the default state of the parser.
@@ -55,7 +130,7 @@ impl<P: ?Sized + CreateParserState> CreateParserState for Arc<P> {
     }
 }
 
-impl CreateParserState for ArcParser {
+impl<O> CreateParserState for ArcParser<O> {
     fn create_parser_state(&self) -> <Self as Parser>::PartialState {
         self.0.create_parser_state()
     }
@@ -63,8 +138,6 @@ impl CreateParserState for ArcParser {
 
 /// An incremental parser for a structured input.
 pub trait Parser {
-    /// The error type of the parser.
-    type Error;
     /// The output of the parser.
     type Output;
     /// The state of the parser.
@@ -75,11 +148,10 @@ pub trait Parser {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error>;
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>>;
 }
 
 impl Parser for () {
-    type Error = ();
     type Output = ();
     type PartialState = ();
 
@@ -87,8 +159,8 @@ impl Parser for () {
         &self,
         _state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
-        Ok(ParseResult::Finished {
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
+        Ok(ParseStatus::Finished {
             result: (),
             remaining: input,
         })
@@ -96,7 +168,6 @@ impl Parser for () {
 }
 
 impl<P: ?Sized + Parser> Parser for &P {
-    type Error = P::Error;
     type Output = P::Output;
     type PartialState = P::PartialState;
 
@@ -104,13 +175,12 @@ impl<P: ?Sized + Parser> Parser for &P {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         (*self).parse(state, input)
     }
 }
 
 impl<P: ?Sized + Parser> Parser for Box<P> {
-    type Error = P::Error;
     type Output = P::Output;
     type PartialState = P::PartialState;
 
@@ -118,14 +188,13 @@ impl<P: ?Sized + Parser> Parser for Box<P> {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         let _self: &P = self;
         _self.parse(state, input)
     }
 }
 
 impl<P: ?Sized + Parser> Parser for Arc<P> {
-    type Error = P::Error;
     type Output = P::Output;
     type PartialState = P::PartialState;
 
@@ -133,46 +202,41 @@ impl<P: ?Sized + Parser> Parser for Arc<P> {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         let _self: &P = self;
         _self.parse(state, input)
     }
 }
 
-trait AnyCreateParserState:
-    Parser<
-        Error = Arc<dyn Error + Send + Sync>,
-        Output = Arc<dyn Any + Send + Sync>,
-        PartialState = Arc<dyn Any + Send + Sync>,
-    > + CreateParserState
-    + Send
-    + Sync
+trait AnyCreateParserState<O>:
+    Parser<Output = O, PartialState = Arc<dyn Any + Send + Sync>> + CreateParserState + Send + Sync
 {
 }
 
 impl<
-        P: Parser<
-                Error = Arc<dyn Error + Send + Sync>,
-                Output = Arc<dyn Any + Send + Sync>,
-                PartialState = Arc<dyn Any + Send + Sync>,
-            > + CreateParserState
+        O,
+        P: Parser<Output = O, PartialState = Arc<dyn Any + Send + Sync>>
+            + CreateParserState
             + Send
             + Sync,
-    > AnyCreateParserState for P
+    > AnyCreateParserState<O> for P
 {
 }
 
 /// A boxed parser.
-pub struct ArcParser(Arc<dyn AnyCreateParserState + Send + Sync>);
+pub struct ArcParser<O = ()>(Arc<dyn AnyCreateParserState<O> + Send + Sync>);
 
-impl ArcParser {
+impl<O> Clone for ArcParser<O> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<O> ArcParser<O> {
     fn new<P>(parser: P) -> Self
     where
-        P: Parser<
-                Error = Arc<dyn Error + Send + Sync>,
-                Output = Arc<dyn Any + Send + Sync>,
-                PartialState = Arc<dyn Any + Send + Sync>,
-            > + CreateParserState
+        P: Parser<Output = O, PartialState = Arc<dyn Any + Send + Sync>>
+            + CreateParserState
             + Send
             + Sync
             + 'static,
@@ -181,21 +245,16 @@ impl ArcParser {
     }
 }
 
-impl Parser for ArcParser {
-    type Error = Arc<dyn Error + Send + Sync>;
-    type Output = Arc<dyn Any + Send + Sync>;
+impl<O> Parser for ArcParser<O> {
+    type Output = O;
     type PartialState = Arc<dyn Any + Send + Sync>;
 
     fn parse<'a>(
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
-        let _self: &dyn Parser<
-            Error = Arc<dyn Error + Send + Sync>,
-            Output = Arc<dyn Any + Send + Sync>,
-            PartialState = Arc<dyn Any + Send + Sync>,
-        > = &self.0;
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
+        let _self: &dyn Parser<Output = O, PartialState = Arc<dyn Any + Send + Sync>> = &self.0;
         _self.parse(state, input)
     }
 }
@@ -206,19 +265,16 @@ struct AnyParser<P>(P);
 impl<P> Parser for AnyParser<P>
 where
     P: Parser,
-    P::Error: Error + Send + Sync + 'static,
-    P::Output: Send + Sync + 'static,
     P::PartialState: Send + Sync + 'static,
 {
-    type Error = Arc<dyn Error + Send + Sync>;
-    type Output = Arc<dyn Any + Sync + Send>;
+    type Output = P::Output;
     type PartialState = Arc<dyn Any + Sync + Send>;
 
     fn parse<'a>(
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         let state = state.downcast_ref::<P::PartialState>().ok_or_else(|| {
             struct StateIsNotOfTheCorrectType;
             impl std::fmt::Display for StateIsNotOfTheCorrectType {
@@ -232,21 +288,17 @@ where
                 }
             }
             impl Error for StateIsNotOfTheCorrectType {}
-            Arc::new(StateIsNotOfTheCorrectType) as Arc<dyn Error + Send + Sync>
+            StateIsNotOfTheCorrectType
         })?;
-        match self.0.parse(state, input) {
-            Ok(result) => Ok(result
-                .map_state(|state| Arc::new(state) as Arc<dyn Any + Sync + Send>)
-                .map(|output| Arc::new(output) as Arc<dyn Any + Sync + Send>)),
-            Err(err) => Err(Arc::new(err)),
-        }
+        self.0
+            .parse(state, input)
+            .map(|result| result.map_state(|state| Arc::new(state) as Arc<dyn Any + Sync + Send>))
     }
 }
 
 impl<P: CreateParserState> CreateParserState for AnyParser<P>
 where
     P: Parser,
-    P::Error: Error + Send + Sync + 'static,
     P::Output: Send + Sync + 'static,
     P::PartialState: Send + Sync + 'static,
 {
@@ -258,10 +310,7 @@ where
 /// An extension trait for parsers.
 pub trait ParserExt: Parser {
     /// Parse this parser, or another other parser.
-    fn or<V: Parser<Error = E, Output = O, PartialState = PA>, E, O, PA>(
-        self,
-        other: V,
-    ) -> ChoiceParser<Self, V>
+    fn or<V: Parser<Output = O, PartialState = PA>, O, PA>(self, other: V) -> ChoiceParser<Self, V>
     where
         Self: Sized,
     {
@@ -272,7 +321,7 @@ pub trait ParserExt: Parser {
     }
 
     /// Parse this parser, then the other parser.
-    fn then<V: Parser<Error = E, Output = O, PartialState = PA>, E, O, PA>(
+    fn then<V: Parser<Output = O, PartialState = PA>, O, PA>(
         self,
         other: V,
     ) -> SequenceParser<Self, V>
@@ -291,9 +340,10 @@ pub trait ParserExt: Parser {
     }
 
     /// Map the output of this parser.
-    fn map_output<F: Fn(Self::Output) -> O, O>(self, f: F) -> MapOutputParser<Self, F, O>
+    fn map_output<F, O>(self, f: F) -> MapOutputParser<Self, F, O>
     where
         Self: Sized,
+        F: Fn(Self::Output) -> O,
     {
         MapOutputParser {
             parser: self,
@@ -303,10 +353,9 @@ pub trait ParserExt: Parser {
     }
 
     /// Get a boxed version of this parser.
-    fn boxed(self) -> ArcParser
+    fn boxed(self) -> ArcParser<Self::Output>
     where
         Self: CreateParserState + Sized + Send + Sync + 'static,
-        Self::Error: Error + Send + Sync + 'static,
         Self::Output: Send + Sync + 'static,
         Self::PartialState: Send + Sync + 'static,
     {
@@ -335,17 +384,17 @@ pub enum OwnedParseResult<P, R> {
     },
 }
 
-impl<P, R> From<ParseResult<'_, P, R>> for OwnedParseResult<P, R> {
-    fn from(result: ParseResult<P, R>) -> Self {
+impl<P, R> From<ParseStatus<'_, P, R>> for OwnedParseResult<P, R> {
+    fn from(result: ParseStatus<P, R>) -> Self {
         match result {
-            ParseResult::Incomplete {
+            ParseStatus::Incomplete {
                 new_state,
                 required_next,
             } => OwnedParseResult::Incomplete {
                 new_state,
                 required_next,
             },
-            ParseResult::Finished { result, remaining } => OwnedParseResult::Finished {
+            ParseStatus::Finished { result, remaining } => OwnedParseResult::Finished {
                 result,
                 remaining: remaining.to_vec(),
             },
@@ -355,7 +404,7 @@ impl<P, R> From<ParseResult<'_, P, R>> for OwnedParseResult<P, R> {
 
 /// The state of a parser.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum ParseResult<'a, P, R> {
+pub enum ParseStatus<'a, P, R> {
     /// The parser is incomplete.
     Incomplete {
         /// The new state of the parser.
@@ -372,18 +421,18 @@ pub enum ParseResult<'a, P, R> {
     },
 }
 
-impl<'a, P, R> ParseResult<'a, P, R> {
+impl<'a, P, R> ParseStatus<'a, P, R> {
     /// Take the remaining bytes from the parser.
-    pub fn without_remaining(self) -> ParseResult<'static, P, R> {
+    pub fn without_remaining(self) -> ParseStatus<'static, P, R> {
         match self {
-            ParseResult::Finished { result, .. } => ParseResult::Finished {
+            ParseStatus::Finished { result, .. } => ParseStatus::Finished {
                 result,
                 remaining: &[],
             },
-            ParseResult::Incomplete {
+            ParseStatus::Incomplete {
                 new_state,
                 required_next,
-            } => ParseResult::Incomplete {
+            } => ParseStatus::Incomplete {
                 new_state,
                 required_next,
             },
@@ -393,9 +442,9 @@ impl<'a, P, R> ParseResult<'a, P, R> {
     /// Unwrap the parser to a finished result.
     pub fn unwrap_finished(self) -> R {
         match self {
-            ParseResult::Finished { result, .. } => result,
-            ParseResult::Incomplete { .. } => {
-                panic!("called `ParseResult::unwrap_finished()` on an `Incomplete` value")
+            ParseStatus::Finished { result, .. } => result,
+            ParseStatus::Incomplete { .. } => {
+                panic!("called `ParseStatus::unwrap_finished()` on an `Incomplete` value")
             }
         }
     }
@@ -403,10 +452,10 @@ impl<'a, P, R> ParseResult<'a, P, R> {
     /// Unwrap the parser to an incomplete result.
     pub fn unwrap_incomplete(self) -> (P, Cow<'static, str>) {
         match self {
-            ParseResult::Finished { .. } => {
-                panic!("called `ParseResult::unwrap_incomplete()` on a `Finished` value")
+            ParseStatus::Finished { .. } => {
+                panic!("called `ParseStatus::unwrap_incomplete()` on a `Finished` value")
             }
-            ParseResult::Incomplete {
+            ParseStatus::Incomplete {
                 new_state,
                 required_next,
             } => (new_state, required_next),
@@ -414,19 +463,19 @@ impl<'a, P, R> ParseResult<'a, P, R> {
     }
 
     /// Map the result of the parser.
-    pub fn map<F, O>(self, f: F) -> ParseResult<'a, P, O>
+    pub fn map<F, O>(self, f: F) -> ParseStatus<'a, P, O>
     where
         F: FnOnce(R) -> O,
     {
         match self {
-            ParseResult::Finished { result, remaining } => ParseResult::Finished {
+            ParseStatus::Finished { result, remaining } => ParseStatus::Finished {
                 result: f(result),
                 remaining,
             },
-            ParseResult::Incomplete {
+            ParseStatus::Incomplete {
                 new_state,
                 required_next,
-            } => ParseResult::Incomplete {
+            } => ParseStatus::Incomplete {
                 new_state,
                 required_next,
             },
@@ -434,18 +483,18 @@ impl<'a, P, R> ParseResult<'a, P, R> {
     }
 
     /// Map the state of the parser.
-    pub fn map_state<F, O>(self, f: F) -> ParseResult<'a, O, R>
+    pub fn map_state<F, O>(self, f: F) -> ParseStatus<'a, O, R>
     where
         F: FnOnce(P) -> O,
     {
         match self {
-            ParseResult::Finished { result, remaining } => {
-                ParseResult::Finished { result, remaining }
+            ParseStatus::Finished { result, remaining } => {
+                ParseStatus::Finished { result, remaining }
             }
-            ParseResult::Incomplete {
+            ParseStatus::Incomplete {
                 new_state,
                 required_next,
-            } => ParseResult::Incomplete {
+            } => ParseStatus::Incomplete {
                 new_state: f(new_state),
                 required_next,
             },
@@ -490,7 +539,7 @@ pub enum StructureParserState {
     Literal(LiteralParserOffset),
     NumInt(IntegerParserState),
     Num(FloatParserState),
-    Either(ChoiceParserState<Box<StructureParserState>, Box<StructureParserState>, (), ()>),
+    Either(ChoiceParserState<Box<StructureParserState>, Box<StructureParserState>>),
     Then(SequenceParserState<Box<StructureParserState>, Box<StructureParserState>, ()>),
 }
 
@@ -523,7 +572,6 @@ impl CreateParserState for StructureParser {
 }
 
 impl Parser for StructureParser {
-    type Error = ();
     type Output = ();
     type PartialState = StructureParserState;
 
@@ -531,13 +579,12 @@ impl Parser for StructureParser {
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         match (self, state) {
             (StructureParser::Literal(lit_parser), StructureParserState::Literal(state)) => {
                 LiteralParser::from(lit_parser)
                     .parse(state, input)
                     .map(|result| result.map(|_| ()).map_state(StructureParserState::Literal))
-                    .map_err(|_| ())
             }
             (
                 StructureParser::Num {
@@ -561,32 +608,31 @@ impl Parser for StructureParser {
                 .map(|result| result.map(|_| ()).map_state(StructureParserState::NumInt)),
             (StructureParser::Either { first, second }, StructureParserState::Either(state)) => {
                 let state = ChoiceParserState {
-                    state1: match &state.state1 {
-                        Ok(state) => Ok((**state).clone()),
-                        Err(()) => Err(()),
-                    },
-                    state2: match &state.state2 {
-                        Ok(state) => Ok((**state).clone()),
-                        Err(()) => Err(()),
-                    },
+                    state1: state
+                        .state1
+                        .as_ref()
+                        .map(|state| (**state).clone())
+                        .map_err(Clone::clone),
+                    state2: state
+                        .state2
+                        .as_ref()
+                        .map(|state| (**state).clone())
+                        .map_err(Clone::clone),
                 };
                 let parser = ChoiceParser::new(first.clone(), second.clone());
-                match parser.parse(&state, input) {
-                    Ok(ParseResult::Incomplete { required_next, .. }) => {
-                        Ok(ParseResult::Incomplete {
-                            new_state: StructureParserState::Either(ChoiceParserState {
-                                state1: state.state1.map(Box::new),
-                                state2: state.state2.map(Box::new),
-                            }),
-                            required_next,
-                        })
-                    }
-                    Ok(ParseResult::Finished { remaining, .. }) => Ok(ParseResult::Finished {
+                parser.parse(&state, input).map(|result| match result {
+                    ParseStatus::Incomplete { required_next, .. } => ParseStatus::Incomplete {
+                        new_state: StructureParserState::Either(ChoiceParserState {
+                            state1: state.state1.map(Box::new),
+                            state2: state.state2.map(Box::new),
+                        }),
+                        required_next,
+                    },
+                    ParseStatus::Finished { remaining, .. } => ParseStatus::Finished {
                         result: (),
                         remaining,
-                    }),
-                    Err(_) => Err(()),
-                }
+                    },
+                })
             }
             (StructureParser::Then { first, second }, StructureParserState::Then(state)) => {
                 let state = SequenceParserState::FirstParser(match &state {
@@ -594,26 +640,23 @@ impl Parser for StructureParser {
                     SequenceParserState::SecondParser(state, _) => (**state).clone(),
                 });
                 let parser = SequenceParser::new(first.clone(), second.clone());
-                match parser.parse(&state, input) {
-                    Ok(ParseResult::Incomplete { required_next, .. }) => {
-                        Ok(ParseResult::Incomplete {
-                            new_state: StructureParserState::Then(match state {
-                                SequenceParserState::FirstParser(state) => {
-                                    SequenceParserState::FirstParser(Box::new(state))
-                                }
-                                SequenceParserState::SecondParser(state, _) => {
-                                    SequenceParserState::SecondParser(Box::new(state), ())
-                                }
-                            }),
-                            required_next,
-                        })
-                    }
-                    Ok(ParseResult::Finished { remaining, .. }) => Ok(ParseResult::Finished {
+                parser.parse(&state, input).map(|result| match result {
+                    ParseStatus::Incomplete { required_next, .. } => ParseStatus::Incomplete {
+                        new_state: StructureParserState::Then(match state {
+                            SequenceParserState::FirstParser(state) => {
+                                SequenceParserState::FirstParser(Box::new(state))
+                            }
+                            SequenceParserState::SecondParser(state, _) => {
+                                SequenceParserState::SecondParser(Box::new(state), ())
+                            }
+                        }),
+                        required_next,
+                    },
+                    ParseStatus::Finished { remaining, .. } => ParseStatus::Finished {
                         result: (),
                         remaining,
-                    }),
-                    Err(_) => Err(()),
-                }
+                    },
+                })
             }
             _ => unreachable!(),
         }

--- a/interfaces/kalosm-sample/src/structured_parser/sentence.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/sentence.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::{CreateParserState, HasParser};
-use crate::{ParseResult, Parser, StringParser};
+use crate::{ParseStatus, Parser, StringParser};
 
 #[derive(Clone, Debug)]
 /// A single word.
@@ -76,7 +76,6 @@ impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> CreateParserState
 impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> Parser
     for SentenceParser<MIN_LENGTH, MAX_LENGTH>
 {
-    type Error = <StringParser<fn(char) -> bool> as Parser>::Error;
     type Output = Sentence<MIN_LENGTH, MAX_LENGTH>;
     type PartialState = <StringParser<fn(char) -> bool> as Parser>::PartialState;
 
@@ -84,7 +83,7 @@ impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> Parser
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> crate::ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         self.parser
             .parse(state, input)
             .map(|result| result.map(Into::into))

--- a/interfaces/kalosm-sample/src/structured_parser/word.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/word.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::{CreateParserState, HasParser};
-use crate::{ParseResult, Parser, StringParser};
+use crate::{ParseStatus, Parser, StringParser};
 
 #[derive(Clone, Debug)]
 /// A single word.
@@ -47,8 +47,15 @@ impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> DerefMut for Word<MIN_LEN
 }
 
 /// A parser for a word.
-pub struct WordParser<const MIN_LENGTH: usize, const MAX_LENGTH: usize> {
+pub struct WordParser<const MIN_LENGTH: usize = 1, const MAX_LENGTH: usize = 20> {
     parser: StringParser<fn(char) -> bool>,
+}
+
+impl WordParser {
+    /// Create a new default word parser
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> Default
@@ -73,7 +80,6 @@ impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> CreateParserState
 impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> Parser
     for WordParser<MIN_LENGTH, MAX_LENGTH>
 {
-    type Error = <StringParser<fn(char) -> bool> as Parser>::Error;
     type Output = Word<MIN_LENGTH, MAX_LENGTH>;
     type PartialState = <StringParser<fn(char) -> bool> as Parser>::PartialState;
 
@@ -81,7 +87,7 @@ impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> Parser
         &self,
         state: &Self::PartialState,
         input: &'a [u8],
-    ) -> Result<ParseResult<'a, Self::PartialState, Self::Output>, Self::Error> {
+    ) -> crate::ParseResult<ParseStatus<'a, Self::PartialState, Self::Output>> {
         self.parser
             .parse(state, input)
             .map(|result| result.map(Into::into))

--- a/interfaces/kalosm/examples/tools.rs
+++ b/interfaces/kalosm/examples/tools.rs
@@ -21,9 +21,12 @@ async fn main() {
                         println!("\n\nAnswer: {}", result);
                         break;
                     }
-                    ToolManagerStepResult::Action(result) => {
+                    ToolManagerStepResult::Action {
+                        index,
+                        output: result,
+                    } => {
                         prompt = format!("{result}\n");
-                        println!("Action Result: {}", result)
+                        println!("Action {index} Result: {}", result)
                     }
                     ToolManagerStepResult::Thought(thought) => {
                         prompt = format!("{thought}\n");

--- a/interfaces/language-model/src/model.rs
+++ b/interfaces/language-model/src/model.rs
@@ -656,10 +656,7 @@ pub trait SyncModelExt: SyncModel {
         sampler: Arc<Mutex<dyn Sampler>>,
         on_token: impl FnMut(String) -> anyhow::Result<()>,
         top_k: Option<usize>,
-    ) -> anyhow::Result<P::Output>
-    where
-        P::Output: Clone,
-    {
+    ) -> anyhow::Result<P::Output> {
         generate_structured(
             prompt,
             self,

--- a/models/kalosm-llama/examples/structured.rs
+++ b/models/kalosm-llama/examples/structured.rs
@@ -11,13 +11,36 @@ async fn main() {
 { name: "bob", description: "An adorable cute cat", color: "black", size: "small", diet: "carnivore", breeds: ["Persian", "Maine Coon"] },
 
 "#;
-    let regex = r#"(\{ name: "\w+", description: "[\w ]+", color: "\w+", size: "\w+", diet: "\w+", breeds: \[("[\w ]+", )*"[\w ]+"\] \},\n){4}\n\]"#;
 
     {
         println!("# with constraints");
         print!("{}", prompt);
 
+        let regex = r#"(\{ name: "\w+", description: "[\w ]+", color: "\w+", size: "\w+", diet: "\w+", breeds: \[("[\w ]+", )*"[\w ]+"\] \},\n){4}\n\]"#;
         let validator = RegexParser::new(regex).unwrap();
+        let stream = llm.stream_structured_text(prompt, validator).await.unwrap();
+
+        time_stream(stream).await;
+    }
+
+    {
+        println!("# with constraints 2");
+        print!("{}", prompt);
+
+        let validator = LiteralParser::new("{ name: ")
+            .then(WordParser::new())
+            .then(LiteralParser::new(", description: "))
+            .then(StringParser::new(0..=50))
+            .then(LiteralParser::new(", color: "))
+            .then(WordParser::new())
+            .then(LiteralParser::new(", size: "))
+            .then(WordParser::new())
+            .then(LiteralParser::new(", diet: "))
+            .then(WordParser::new())
+            .then(LiteralParser::new(", breeds: "))
+            .then(RegexParser::new(r#"\[("[\w ]+", )*"[\w ]+"\]"#).unwrap())
+            .then(LiteralParser::new(" },\n"))
+            .repeat(4..=4);
         let stream = llm.stream_structured_text(prompt, validator).await.unwrap();
 
         time_stream(stream).await;


### PR DESCRIPTION
This PR simplifies parser by unifying the error type and producing a typed output from ArcParser. Most typed parsers should use `ArcParser<Type>` instead of the longer exact parser type