### PR TITLE
fix the call to unsafe function error

### DIFF
--- a/interfaces/kalosm-language/src/vector_db.rs
+++ b/interfaces/kalosm-language/src/vector_db.rs
@@ -95,9 +95,11 @@ impl<S: VectorSpace + Sync> VectorDB<S> {
 
         std::fs::create_dir_all(&path)?;
 
-        let env = EnvOpenOptions::new()
-            .map_size(TWENTY_HUNDRED_MIB)
-            .open(path)?;
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(TWENTY_HUNDRED_MIB)
+                .open(path)
+        }?;
 
         let mut wtxn = env.write_txn()?;
         let db: ArroyDatabase<Euclidean> = env.create_database(&mut wtxn, None)?;


### PR DESCRIPTION
```
kalosm-language-0.2.2/src/vector_db.rs:98:19
    |
98  |           let env = EnvOpenOptions::new()
    |  ___________________^
99  | |             .map_size(TWENTY_HUNDRED_MIB)
100 | |             .open(path)?;
    | |_______________________^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior

For more information about this error, try `rustc --explain E0133`.
error: could not compile `kalosm-language` (lib) due to 1 previous error
```