### PR TITLE
Add snowflake embedding models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
  "safetensors",
  "thiserror",
  "yoke",
- "zip 1.2.3",
+ "zip 1.3.0",
 ]
 
 [[package]]
@@ -2556,7 +2556,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa 1.0.11",
- "phf 0.8.0",
+ "phf 0.11.2",
  "smallvec",
 ]
 
@@ -14938,9 +14938,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700ea425e148de30c29c580c1f9508b93ca57ad31c9f4e96b83c194c37a7a8f"
+checksum = "f1f4a27345eb6f7aa7bd015ba7eb4175fa4e1b462a29874b779e0bbcf96c6ac7"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/models/rbert/src/lib.rs
+++ b/models/rbert/src/lib.rs
@@ -164,27 +164,72 @@ impl BertSource {
                 "config.json".to_string(),
             ))
     }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-s](https://huggingface.co/Snowflake/snowflake-arctic-embed-s) model
+    pub fn snowflake_arctic_embed_small() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-s".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-s".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-s".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-m](https://huggingface.co/Snowflake/snowflake-arctic-embed-m) model
+    pub fn snowflake_arctic_embed_medium() -> Self {
+        Self {
+            config: FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ),
+            tokenizer: FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ),
+            model: FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ),
+        }
+    }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-l](https://huggingface.co/Snowflake/snowflake-arctic-embed-l) model
+    pub fn snowflake_arctic_embed_large() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-l".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-l".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-l".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ))
+    }
 }
 
 impl Default for BertSource {
     fn default() -> Self {
-        Self {
-            config: FileSource::huggingface(
-                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
-                "refs/pr/21".to_string(),
-                "config.json".to_string(),
-            ),
-            tokenizer: FileSource::huggingface(
-                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
-                "refs/pr/21".to_string(),
-                "tokenizer.json".to_string(),
-            ),
-            model: FileSource::huggingface(
-                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
-                "refs/pr/21".to_string(),
-                "model.safetensors".to_string(),
-            ),
-        }
+        Self::snowflake_arctic_embed_medium()
     }
 }
 


### PR DESCRIPTION
Adds presets for the small, medium, and large snowflake embedding models. These models focus on embeddings for retrieval which make them a good default for kalosm