### PR TITLE
Improve Bert model

### DIFF
--- a/models/rbert/src/language_model.rs
+++ b/models/rbert/src/language_model.rs
@@ -56,11 +56,11 @@ impl Embedder for Bert {
     type VectorSpace = BertSpace;
 
     async fn embed(&self, input: &str) -> anyhow::Result<Embedding<BertSpace>> {
-        self.embed_with_pooling(input, Pooling::CLS)
+        self.embed_with_pooling(input, Pooling::Mean)
     }
 
     async fn embed_batch(&self, inputs: &[&str]) -> anyhow::Result<Vec<Embedding<BertSpace>>> {
-        self.embed_batch_with_pooling(inputs, Pooling::CLS)
+        self.embed_batch_with_pooling(inputs, Pooling::Mean)
     }
 }
 

--- a/models/rbert/src/language_model.rs
+++ b/models/rbert/src/language_model.rs
@@ -1,5 +1,6 @@
 pub use crate::Bert;
 use crate::BertBuilder;
+use crate::Pooling;
 use kalosm_common::*;
 use kalosm_language_model::Embedding;
 use kalosm_language_model::VectorSpace;
@@ -21,17 +22,25 @@ impl ModelBuilder for BertBuilder {
     }
 }
 
-#[async_trait::async_trait]
-impl Embedder for Bert {
-    type VectorSpace = BertSpace;
+impl Bert {
+    /// Embed a sentence with a specific pooling strategy.
+    pub fn embed_with_pooling(
+        &self,
+        input: &str,
+        pooling: Pooling,
+    ) -> anyhow::Result<Embedding<BertSpace>> {
+        let mut tensors = self.embed_batch_raw(&[input], pooling)?;
 
-    async fn embed(&self, input: &str) -> anyhow::Result<Embedding<BertSpace>> {
-        let tensor = self.embed_batch_raw(&[input])?.pop().unwrap();
-        Ok(Embedding::new(tensor))
+        Ok(Embedding::new(tensors.pop().unwrap()))
     }
 
-    async fn embed_batch(&self, inputs: &[&str]) -> anyhow::Result<Vec<Embedding<BertSpace>>> {
-        let tensors = self.embed_batch_raw(inputs)?;
+    /// Embed a batch of sentences with a specific pooling strategy.
+    pub fn embed_batch_with_pooling(
+        &self,
+        inputs: &[&str],
+        pooling: Pooling,
+    ) -> anyhow::Result<Vec<Embedding<BertSpace>>> {
+        let tensors = self.embed_batch_raw(inputs, pooling)?;
 
         let mut embeddings = Vec::with_capacity(tensors.len());
         for tensor in tensors {
@@ -39,6 +48,19 @@ impl Embedder for Bert {
         }
 
         Ok(embeddings)
+    }
+}
+
+#[async_trait::async_trait]
+impl Embedder for Bert {
+    type VectorSpace = BertSpace;
+
+    async fn embed(&self, input: &str) -> anyhow::Result<Embedding<BertSpace>> {
+        self.embed_with_pooling(input, Pooling::CLS)
+    }
+
+    async fn embed_batch(&self, inputs: &[&str]) -> anyhow::Result<Vec<Embedding<BertSpace>>> {
+        self.embed_batch_with_pooling(inputs, Pooling::CLS)
     }
 }
 

--- a/models/rbert/src/lib.rs
+++ b/models/rbert/src/lib.rs
@@ -48,232 +48,22 @@ extern crate intel_mkl_src;
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src;
 
-mod language_model;
 use kalosm_common::*;
-pub use language_model::*;
+use sysinfo::System;
 
 use std::sync::RwLock;
 
-use candle_core::Tensor;
+use candle_core::{Device, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::bert::{BertModel, Config, DTYPE};
 use tokenizers::{PaddingParams, Tokenizer};
 
-/// A the source of a [`Bert`] model
-pub struct BertSource {
-    config: FileSource,
-    tokenizer: FileSource,
-    model: FileSource,
-}
+mod language_model;
+mod raw;
+mod source;
 
-impl BertSource {
-    /// Set the model to use, check out available models: <https://huggingface.co/models?library=sentence-transformers&sort=trending>
-    pub fn with_model(mut self, model: FileSource) -> Self {
-        self.model = model;
-        self
-    }
-
-    /// Set the tokenizer to use
-    pub fn with_tokenizer(mut self, tokenizer: FileSource) -> Self {
-        self.tokenizer = tokenizer;
-        self
-    }
-
-    /// Set the config to use
-    pub fn with_config(mut self, config: FileSource) -> Self {
-        self.config = config;
-        self
-    }
-
-    /// Create a new [`BertSource`] with the BGE large english preset
-    pub fn bge_large_en() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "BAAI/bge-large-en-v1.5".to_string(),
-                "refs/pr/5".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "BAAI/bge-large-en-v1.5".to_string(),
-                "refs/pr/5".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "BAAI/bge-large-en-v1.5".to_string(),
-                "refs/pr/5".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-
-    /// Create a new [`BertSource`] with the BGE base english preset
-    pub fn bge_base_en() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "BAAI/bge-base-en-v1.5".to_string(),
-                "refs/pr/1".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "BAAI/bge-base-en-v1.5".to_string(),
-                "refs/pr/1".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "BAAI/bge-base-en-v1.5".to_string(),
-                "refs/pr/1".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-
-    /// Create a new [`BertSource`] with the BGE small english preset
-    pub fn bge_small_en() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "BAAI/bge-small-en-v1.5".to_string(),
-                "refs/pr/3".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "BAAI/bge-small-en-v1.5".to_string(),
-                "refs/pr/3".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "BAAI/bge-small-en-v1.5".to_string(),
-                "refs/pr/3".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-
-    /// Create a new [`BertSource`] with the MiniLM-L6-v2 preset
-    pub fn mini_lm_l6_v2() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
-                "refs/pr/21".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
-                "refs/pr/21".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
-                "refs/pr/21".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-
-    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs) model
-    pub fn snowflake_arctic_embed_extra_small() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-xs".to_string(),
-                "main".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-xs".to_string(),
-                "main".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-xs".to_string(),
-                "main".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-
-    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-s](https://huggingface.co/Snowflake/snowflake-arctic-embed-s) model
-    pub fn snowflake_arctic_embed_small() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-s".to_string(),
-                "main".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-s".to_string(),
-                "main".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-s".to_string(),
-                "main".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-
-    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-m](https://huggingface.co/Snowflake/snowflake-arctic-embed-m) model
-    pub fn snowflake_arctic_embed_medium() -> Self {
-        Self {
-            config: FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-m".to_string(),
-                "main".to_string(),
-                "config.json".to_string(),
-            ),
-            tokenizer: FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-m".to_string(),
-                "main".to_string(),
-                "tokenizer.json".to_string(),
-            ),
-            model: FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-m".to_string(),
-                "main".to_string(),
-                "model.safetensors".to_string(),
-            ),
-        }
-    }
-
-    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-m-long](https://huggingface.co/Snowflake/snowflake-arctic-embed-m-long) model
-    ///
-    /// This model is slightly larger than [`Self::snowflake_arctic_embed_medium`] and supports longer contexts (up to 2048 tokens).
-    pub fn snowflake_arctic_embed_medium_long() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-m-long".to_string(),
-                "main".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-m-long".to_string(),
-                "main".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-m-long".to_string(),
-                "main".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-
-    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-l](https://huggingface.co/Snowflake/snowflake-arctic-embed-l) model
-    pub fn snowflake_arctic_embed_large() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-l".to_string(),
-                "main".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-l".to_string(),
-                "main".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
-                "Snowflake/snowflake-arctic-embed-l".to_string(),
-                "main".to_string(),
-                "config.json".to_string(),
-            ))
-    }
-}
-
-impl Default for BertSource {
-    fn default() -> Self {
-        Self::snowflake_arctic_embed_medium()
-    }
-}
+pub use crate::language_model::*;
+pub use crate::raw::{BertModel, Config, DTYPE};
+pub use crate::source::*;
 
 /// A builder for a [`Bert`] model
 #[derive(Default)]
@@ -301,6 +91,16 @@ impl BertBuilder {
     ) -> anyhow::Result<Bert> {
         Bert::from_builder(self, loading_handler).await
     }
+}
+
+
+/// The pooling strategy to use when embedding text.
+#[derive(Debug, Clone, Copy)]
+pub enum Pooling {
+    /// Take the mean embedding value for all tokens (except padding)
+    Mean,
+    /// Take the embedding of the CLS token for each sequence
+    CLS,
 }
 
 /// A bert model
@@ -363,16 +163,25 @@ impl Bert {
     }
 
     /// Embed a batch of sentences
-    pub(crate) fn embed_batch_raw(&self, sentences: &[&str]) -> anyhow::Result<Vec<Tensor>> {
+    pub(crate) fn embed_batch_raw(
+        &self,
+        sentences: &[&str],
+        pooling: Pooling,
+    ) -> anyhow::Result<Vec<Tensor>> {
         let mut combined = Vec::new();
-        for batch in sentences.chunks(4) {
-            let embeddings = self.embed_batch_raw_inner(batch)?;
+        let chunk_size = 18;
+        for batch in sentences.chunks(chunk_size) {
+            let embeddings = self.embed_batch_raw_inner(batch, pooling)?;
             combined.extend(embeddings);
         }
         Ok(combined)
     }
 
-    fn embed_batch_raw_inner(&self, sentences: &[&str]) -> anyhow::Result<Vec<Tensor>> {
+    fn embed_batch_raw_inner(
+        &self,
+        sentences: &[&str],
+        pooling: Pooling,
+    ) -> anyhow::Result<Vec<Tensor>> {
         let device = &self.model.device;
 
         let n_sentences = sentences.len();
@@ -398,20 +207,88 @@ impl Bert {
                 Ok(Tensor::new(tokens.as_slice(), device)?)
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-
         let token_ids = Tensor::stack(&token_ids, 0)?;
-        let token_type_ids = token_ids.zeros_like()?;
-        let embeddings = self.model.forward(&token_ids, &token_type_ids)?;
-        // Apply some avg-pooling by taking the mean embedding value for all tokens (including padding)
-        let (_n_sentence, n_tokens, _hidden_size) = embeddings.dims3()?;
-        let embeddings = (embeddings.sum(1)? / (n_tokens as f64))?;
-        let embeddings = normalize_l2(&embeddings)?;
-        let embeddings = embeddings.chunk(n_sentences, 0)?;
 
-        Ok(embeddings)
+        let attention_masks = tokens
+            .iter()
+            .map(|tokens| {
+                let attention_mask = tokens.get_attention_mask();
+                let attention_mask = Tensor::new(attention_mask, device)?;
+                Ok(attention_mask)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let attention_mask = Tensor::stack(&attention_masks, 0)?;
+
+        // The token type ids are only used for next sentence prediction. We can just set them to zero for embedding tasks.
+        let token_type_ids = token_ids.zeros_like()?;
+        let embeddings =
+            self.model
+                .forward(&token_ids, &token_type_ids, Some(&attention_mask), false)?;
+
+        let (_n_sentence, n_tokens, _hidden_size) = embeddings.dims3()?;
+
+        match pooling {
+            Pooling::Mean => {
+                // Take the mean embedding value for all tokens (except padding)
+                let embeddings = embeddings.mul(
+                    &attention_mask
+                        .to_dtype(candle_core::DType::F32)?
+                        .unsqueeze(2)?
+                        .broadcast_as(embeddings.shape())?,
+                )?;
+                let embeddings = (embeddings.sum(1)? / (n_tokens as f64))?;
+                let embeddings = normalize_l2(&embeddings)?;
+                Ok(embeddings.chunk(n_sentences, 0)?)
+            }
+            Pooling::CLS => {
+                // Index into the first token of each sentence which is the CLS token that contains the sentence embedding
+                let indexed_embeddings = embeddings.i((.., 0, ..))?;
+                Ok(indexed_embeddings.chunk(n_sentences, 0)?)
+            }
+        }
     }
 }
 
 fn normalize_l2(v: &Tensor) -> anyhow::Result<Tensor> {
     Ok(v.broadcast_div(&v.sqr()?.sum_keepdim(1)?.sqrt()?)?)
+}
+
+fn allocated_memory(device: &Device) -> Option<u64> {
+    match device {
+        Device::Metal(metal) => {
+            #[cfg(feature = "metal")]
+            {
+                Some(metal.current_allocated_size())
+            }
+            #[cfg(not(feature = "metal"))]
+            {
+                None
+            }
+        }
+        Device::Cuda(_) => None,
+        Device::Cpu => {
+            let system = System::new_all();
+            Some(system.used_memory())
+        }
+    }
+}
+
+fn available_memory(device: &Device) -> Option<u64> {
+    match device {
+        Device::Metal(metal) => {
+            #[cfg(feature = "metal")]
+            {
+                Some(metal.recommended_max_working_set_size())
+            }
+            #[cfg(not(feature = "metal"))]
+            {
+                None
+            }
+        }
+        Device::Cuda(_) => None,
+        Device::Cpu => {
+            let system = System::new_all();
+            Some(system.available_memory())
+        }
+    }
 }

--- a/models/rbert/src/lib.rs
+++ b/models/rbert/src/lib.rs
@@ -62,7 +62,8 @@ mod raw;
 mod source;
 
 pub use crate::language_model::*;
-pub use crate::raw::{BertModel, Config, DTYPE};
+use crate::raw::DTYPE;
+pub use crate::raw::{BertModel, Config};
 pub use crate::source::*;
 
 /// A builder for a [`Bert`] model
@@ -92,7 +93,6 @@ impl BertBuilder {
         Bert::from_builder(self, loading_handler).await
     }
 }
-
 
 /// The pooling strategy to use when embedding text.
 #[derive(Debug, Clone, Copy)]
@@ -169,7 +169,7 @@ impl Bert {
         pooling: Pooling,
     ) -> anyhow::Result<Vec<Tensor>> {
         let mut combined = Vec::new();
-        let chunk_size = 18;
+        let chunk_size = 36;
         for batch in sentences.chunks(chunk_size) {
             let embeddings = self.embed_batch_raw_inner(batch, pooling)?;
             combined.extend(embeddings);
@@ -232,7 +232,7 @@ impl Bert {
                 // Take the mean embedding value for all tokens (except padding)
                 let embeddings = embeddings.mul(
                     &attention_mask
-                        .to_dtype(candle_core::DType::F32)?
+                        .to_dtype(DTYPE)?
                         .unsqueeze(2)?
                         .broadcast_as(embeddings.shape())?,
                 )?;

--- a/models/rbert/src/raw/attention.rs
+++ b/models/rbert/src/raw/attention.rs
@@ -1,0 +1,41 @@
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+use super::{BertSelfAttention, BertSelfOutput};
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L392
+pub(crate) struct BertAttention {
+    self_attention: BertSelfAttention,
+    self_output: BertSelfOutput,
+    span: tracing::Span,
+}
+
+impl BertAttention {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let self_attention = BertSelfAttention::load(vb.pp("self"), config)?;
+        let self_output = BertSelfOutput::load(vb.pp("output"), config)?;
+        Ok(Self {
+            self_attention,
+            self_output,
+            span: tracing::span!(tracing::Level::TRACE, "attn"),
+        })
+    }
+
+    pub(crate) fn forward(
+        &self,
+        hidden_states: &Tensor,
+        attention_mask: Option<&Tensor>,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let self_outputs = self
+            .self_attention
+            .forward(hidden_states, attention_mask, train)?;
+        let attention_output = self
+            .self_output
+            .forward(&self_outputs, hidden_states, train)?;
+        Ok(attention_output)
+    }
+}

--- a/models/rbert/src/raw/embeddings.rs
+++ b/models/rbert/src/raw/embeddings.rs
@@ -1,0 +1,73 @@
+//! Calculates the embeddings for a given input.
+//!
+//! Bert embeddings contain word embeddings, embeddings about the token type and position information.
+
+use super::Config;
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::Dropout;
+use candle_nn::{embedding, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L180
+pub(crate) struct BertEmbeddings {
+    word_embeddings: Embedding,
+    position_embeddings: Option<Embedding>,
+    token_type_embeddings: Embedding,
+    layer_norm: LayerNorm,
+    dropout: Dropout,
+    span: tracing::Span,
+}
+
+impl BertEmbeddings {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let word_embeddings = embedding(
+            config.vocab_size,
+            config.hidden_size,
+            vb.pp("word_embeddings"),
+        )?;
+        let position_embeddings = embedding(
+            config.max_position_embeddings,
+            config.hidden_size,
+            vb.pp("position_embeddings"),
+        )?;
+        let token_type_embeddings = embedding(
+            config.type_vocab_size,
+            config.hidden_size,
+            vb.pp("token_type_embeddings"),
+        )?;
+        let layer_norm = layer_norm(
+            config.hidden_size,
+            config.layer_norm_eps,
+            vb.pp("LayerNorm"),
+        )?;
+        Ok(Self {
+            word_embeddings,
+            position_embeddings: Some(position_embeddings),
+            token_type_embeddings,
+            layer_norm,
+            dropout: Dropout::new(config.hidden_dropout_prob),
+            span: tracing::span!(tracing::Level::TRACE, "embeddings"),
+        })
+    }
+
+    pub(crate) fn forward(
+        &self,
+        input_ids: &Tensor,
+        token_type_ids: &Tensor,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let (_bsize, seq_len) = input_ids.dims2()?;
+        let input_embeddings = self.word_embeddings.forward(input_ids)?;
+        let token_type_embeddings = self.token_type_embeddings.forward(token_type_ids)?;
+        let mut embeddings = (&input_embeddings + token_type_embeddings)?;
+        if let Some(position_embeddings) = &self.position_embeddings {
+            let position_ids = Tensor::arange(0, seq_len as u32, input_ids.device())?;
+            embeddings = embeddings.broadcast_add(&position_embeddings.forward(&position_ids)?)?
+        }
+        let embeddings = self.layer_norm.forward(&embeddings)?;
+        let embeddings = self.dropout.forward_t(&embeddings, train)?;
+        Ok(embeddings)
+    }
+}

--- a/models/rbert/src/raw/encoder.rs
+++ b/models/rbert/src/raw/encoder.rs
@@ -1,0 +1,37 @@
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+use super::BertLayer;
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L556
+pub(crate) struct BertEncoder {
+    layers: Vec<BertLayer>,
+    span: tracing::Span,
+}
+
+impl BertEncoder {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let layers = (0..config.num_hidden_layers)
+            .map(|index| BertLayer::load(vb.pp(&format!("layer.{index}")), config))
+            .collect::<Result<Vec<_>>>()?;
+        let span = tracing::span!(tracing::Level::TRACE, "encoder");
+        Ok(BertEncoder { layers, span })
+    }
+
+    pub fn forward(
+        &self,
+        hidden_states: &Tensor,
+        attention_mask: Option<&Tensor>,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let mut hidden_states = hidden_states.clone();
+        // Use a loop rather than a fold as it's easier to modify when adding debug/...
+        for layer in self.layers.iter() {
+            hidden_states = layer.forward(&hidden_states, attention_mask, train)?
+        }
+        Ok(hidden_states)
+    }
+}

--- a/models/rbert/src/raw/intermediate_layer.rs
+++ b/models/rbert/src/raw/intermediate_layer.rs
@@ -1,0 +1,33 @@
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+use super::HiddenActLayer;
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L441
+pub(crate) struct BertIntermediate {
+    dense: Linear,
+    intermediate_act: HiddenActLayer,
+    span: tracing::Span,
+}
+
+impl BertIntermediate {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let dense = linear(config.hidden_size, config.intermediate_size, vb.pp("dense"))?;
+        Ok(Self {
+            dense,
+            intermediate_act: HiddenActLayer::new(config.hidden_act),
+            span: tracing::span!(tracing::Level::TRACE, "inter"),
+        })
+    }
+}
+
+impl Module for BertIntermediate {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let hidden_states = self.dense.forward(hidden_states)?;
+        let ys = self.intermediate_act.forward(&hidden_states)?;
+        Ok(ys)
+    }
+}

--- a/models/rbert/src/raw/layer.rs
+++ b/models/rbert/src/raw/layer.rs
@@ -1,0 +1,45 @@
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+use super::{BertAttention, BertIntermediate, BertOutput};
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L470
+pub(crate) struct BertLayer {
+    attention: BertAttention,
+    intermediate: BertIntermediate,
+    output: BertOutput,
+    span: tracing::Span,
+}
+
+impl BertLayer {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let attention = BertAttention::load(vb.pp("attention"), config)?;
+        let intermediate = BertIntermediate::load(vb.pp("intermediate"), config)?;
+        let output = BertOutput::load(vb.pp("output"), config)?;
+        Ok(Self {
+            attention,
+            intermediate,
+            output,
+            span: tracing::span!(tracing::Level::TRACE, "layer"),
+        })
+    }
+
+    pub(crate) fn forward(
+        &self,
+        hidden_states: &Tensor,
+        attention_mask: Option<&Tensor>,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let attention_output = self
+            .attention
+            .forward(hidden_states, attention_mask, train)?;
+        let intermediate_output = self.intermediate.forward(&attention_output)?;
+        let layer_output = self
+            .output
+            .forward(&intermediate_output, &attention_output, train)?;
+        Ok(layer_output)
+    }
+}

--- a/models/rbert/src/raw/mod.rs
+++ b/models/rbert/src/raw/mod.rs
@@ -1,0 +1,139 @@
+// Forked from https://github.com/huggingface/candle/blob/main/candle-transformers/src/models/bert.rs
+
+mod embeddings;
+use embeddings::*;
+mod attention;
+use attention::*;
+mod encoder;
+use encoder::*;
+mod layer;
+use layer::*;
+mod output_layer;
+use output_layer::*;
+mod self_attention;
+use self_attention::*;
+mod self_output;
+use self_output::*;
+mod intermediate_layer;
+use intermediate_layer::*;
+
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+pub const DTYPE: DType = DType::F32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HiddenAct {
+    Gelu,
+    GeluApproximate,
+    Relu,
+}
+
+struct HiddenActLayer {
+    act: HiddenAct,
+    span: tracing::Span,
+}
+
+impl HiddenActLayer {
+    fn new(act: HiddenAct) -> Self {
+        let span = tracing::span!(tracing::Level::TRACE, "hidden-act");
+        Self { act, span }
+    }
+
+    fn forward(&self, xs: &Tensor) -> candle_core::Result<Tensor> {
+        let _enter = self.span.enter();
+        match self.act {
+            // https://github.com/huggingface/transformers/blob/cd4584e3c809bb9e1392ccd3fe38b40daba5519a/src/transformers/activations.py#L213
+            HiddenAct::Gelu => xs.gelu_erf(),
+            HiddenAct::GeluApproximate => xs.gelu(),
+            HiddenAct::Relu => xs.relu(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+enum PositionEmbeddingType {
+    #[default]
+    Absolute,
+}
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/configuration_bert.py#L1
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Config {
+    vocab_size: usize,
+    hidden_size: usize,
+    num_hidden_layers: usize,
+    num_attention_heads: usize,
+    intermediate_size: usize,
+    pub hidden_act: HiddenAct,
+    hidden_dropout_prob: f32,
+    max_position_embeddings: usize,
+    type_vocab_size: usize,
+    initializer_range: f64,
+    layer_norm_eps: f64,
+    pad_token_id: usize,
+    #[serde(default)]
+    position_embedding_type: PositionEmbeddingType,
+    #[serde(default)]
+    use_cache: bool,
+    classifier_dropout: Option<f64>,
+    model_type: Option<String>,
+}
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L874
+pub struct BertModel {
+    embeddings: BertEmbeddings,
+    encoder: BertEncoder,
+    pub device: Device,
+    span: tracing::Span,
+}
+
+impl BertModel {
+    pub fn load(vb: VarBuilder, config: &Config) -> Result<Self> {
+        let (embeddings, encoder) = match (
+            BertEmbeddings::load(vb.pp("embeddings"), config),
+            BertEncoder::load(vb.pp("encoder"), config),
+        ) {
+            (Ok(embeddings), Ok(encoder)) => (embeddings, encoder),
+            (Err(err), _) | (_, Err(err)) => {
+                if let Some(model_type) = &config.model_type {
+                    if let (Ok(embeddings), Ok(encoder)) = (
+                        BertEmbeddings::load(vb.pp(&format!("{model_type}.embeddings")), config),
+                        BertEncoder::load(vb.pp(&format!("{model_type}.encoder")), config),
+                    ) {
+                        (embeddings, encoder)
+                    } else {
+                        return Err(err);
+                    }
+                } else {
+                    return Err(err);
+                }
+            }
+        };
+        Ok(Self {
+            embeddings,
+            encoder,
+            device: vb.device().clone(),
+            span: tracing::span!(tracing::Level::TRACE, "model"),
+        })
+    }
+
+    pub fn forward(
+        &self,
+        input_ids: &Tensor,
+        token_type_ids: &Tensor,
+        attention_mask: Option<&Tensor>,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let embedding_output = self.embeddings.forward(input_ids, token_type_ids, train)?;
+        let sequence_output = self
+            .encoder
+            .forward(&embedding_output, attention_mask, train)?;
+        Ok(sequence_output)
+    }
+}

--- a/models/rbert/src/raw/mod.rs
+++ b/models/rbert/src/raw/mod.rs
@@ -22,7 +22,7 @@ use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
 use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
 use serde::Deserialize;
 
-pub const DTYPE: DType = DType::F32;
+pub(crate) const DTYPE: DType = DType::F32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/models/rbert/src/raw/output_layer.rs
+++ b/models/rbert/src/raw/output_layer.rs
@@ -1,0 +1,42 @@
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+// https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L456
+pub(crate) struct BertOutput {
+    dense: Linear,
+    layer_norm: LayerNorm,
+    dropout: Dropout,
+    span: tracing::Span,
+}
+
+impl BertOutput {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let dense = linear(config.intermediate_size, config.hidden_size, vb.pp("dense"))?;
+        let layer_norm = layer_norm(
+            config.hidden_size,
+            config.layer_norm_eps,
+            vb.pp("LayerNorm"),
+        )?;
+        let dropout = Dropout::new(config.hidden_dropout_prob);
+        Ok(Self {
+            dense,
+            layer_norm,
+            dropout,
+            span: tracing::span!(tracing::Level::TRACE, "out"),
+        })
+    }
+
+    pub(crate) fn forward(
+        &self,
+        hidden_states: &Tensor,
+        input_tensor: &Tensor,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let hidden_states = self.dense.forward(hidden_states)?;
+        let hidden_states = self.dropout.forward_t(&hidden_states, train)?;
+        self.layer_norm.forward(&(hidden_states + input_tensor)?)
+    }
+}

--- a/models/rbert/src/raw/self_attention.rs
+++ b/models/rbert/src/raw/self_attention.rs
@@ -1,0 +1,92 @@
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::{
+    stable_diffusion::attention,
+    with_tracing::{layer_norm, linear, LayerNorm, Linear},
+};
+use serde::Deserialize;
+
+pub(crate) struct BertSelfAttention {
+    query: Linear,
+    key: Linear,
+    value: Linear,
+    dropout: Dropout,
+    num_attention_heads: usize,
+    attention_head_size: usize,
+    span: tracing::Span,
+    span_softmax: tracing::Span,
+}
+
+impl BertSelfAttention {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let attention_head_size = config.hidden_size / config.num_attention_heads;
+        let all_head_size = config.num_attention_heads * attention_head_size;
+        let dropout = Dropout::new(config.hidden_dropout_prob);
+        let hidden_size = config.hidden_size;
+        let query = linear(hidden_size, all_head_size, vb.pp("query"))?;
+        let value = linear(hidden_size, all_head_size, vb.pp("value"))?;
+        let key = linear(hidden_size, all_head_size, vb.pp("key"))?;
+        Ok(Self {
+            query,
+            key,
+            value,
+            dropout,
+            num_attention_heads: config.num_attention_heads,
+            attention_head_size,
+            span: tracing::span!(tracing::Level::TRACE, "self-attn"),
+            span_softmax: tracing::span!(tracing::Level::TRACE, "softmax"),
+        })
+    }
+
+    pub(crate) fn transpose_for_scores(&self, xs: &Tensor) -> Result<Tensor> {
+        let mut new_x_shape = xs.dims().to_vec();
+        new_x_shape.pop();
+        new_x_shape.push(self.num_attention_heads);
+        new_x_shape.push(self.attention_head_size);
+        let xs = xs.reshape(new_x_shape.as_slice())?.transpose(1, 2)?;
+        xs.contiguous()
+    }
+
+    pub(crate) fn forward(
+        &self,
+        hidden_states: &Tensor,
+        attention_mask: Option<&Tensor>,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let query_layer = self.query.forward(hidden_states)?;
+        let key_layer = self.key.forward(hidden_states)?;
+        let value_layer = self.value.forward(hidden_states)?;
+
+        let query_layer = self.transpose_for_scores(&query_layer)?;
+        let key_layer = self.transpose_for_scores(&key_layer)?;
+        let value_layer = self.transpose_for_scores(&value_layer)?;
+
+        let attention_scores = query_layer.matmul(&key_layer.t()?)?;
+        let attention_scores = (attention_scores / (self.attention_head_size as f64).sqrt())?;
+        let attention_probs = {
+            let _enter_sm = self.span_softmax.enter();
+            candle_nn::ops::softmax(&attention_scores, candle_core::D::Minus1)?
+        };
+        let mut attention_probs = self.dropout.forward_t(&attention_probs, train)?;
+
+        // If there is an attention mask, filter the attention scores by that mask
+        if let Some(attention_mask) = attention_mask {
+            // The attention mask is a tensor of shape (bsize, seq_len)
+            // the attention probs are a tensor of shape (bsize, _, seq_len, seq_len)
+            // We expand the attention mask to (bsize, 1, 1, seq_len)
+            let mask = attention_mask.unsqueeze(1)?.unsqueeze(2)?;
+            let shape = attention_probs.shape();
+            let mask = mask.broadcast_as(shape)?.to_dtype(DType::U8)?;
+            // We use a value slightly larger that the true f32 min value to avoid NaN
+            const FALSE_MIN: f32 = -3.4028235e30f32;
+            let on_false = Tensor::new(FALSE_MIN, mask.device())?.broadcast_as(shape)?;
+            attention_probs = mask.where_cond(&attention_probs, &on_false)?;
+        }
+
+        let context_layer = attention_probs.matmul(&value_layer)?;
+        let context_layer = context_layer.transpose(1, 2)?.contiguous()?;
+        let context_layer = context_layer.flatten_from(candle_core::D::Minus2)?;
+        Ok(context_layer)
+    }
+}

--- a/models/rbert/src/raw/self_output.rs
+++ b/models/rbert/src/raw/self_output.rs
@@ -1,0 +1,41 @@
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{embedding, Dropout, Embedding, Module, ModuleT, VarBuilder};
+use candle_transformers::models::with_tracing::{layer_norm, linear, LayerNorm, Linear};
+use serde::Deserialize;
+
+pub(crate) struct BertSelfOutput {
+    dense: Linear,
+    layer_norm: LayerNorm,
+    dropout: Dropout,
+    span: tracing::Span,
+}
+
+impl BertSelfOutput {
+    pub(crate) fn load(vb: VarBuilder, config: &super::Config) -> Result<Self> {
+        let dense = linear(config.hidden_size, config.hidden_size, vb.pp("dense"))?;
+        let layer_norm = layer_norm(
+            config.hidden_size,
+            config.layer_norm_eps,
+            vb.pp("LayerNorm"),
+        )?;
+        let dropout = Dropout::new(config.hidden_dropout_prob);
+        Ok(Self {
+            dense,
+            layer_norm,
+            dropout,
+            span: tracing::span!(tracing::Level::TRACE, "self-out"),
+        })
+    }
+
+    pub(crate) fn forward(
+        &self,
+        hidden_states: &Tensor,
+        input_tensor: &Tensor,
+        train: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let hidden_states = self.dense.forward(hidden_states)?;
+        let hidden_states = self.dropout.forward_t(&hidden_states, train)?;
+        self.layer_norm.forward(&(hidden_states + input_tensor)?)
+    }
+}

--- a/models/rbert/src/source.rs
+++ b/models/rbert/src/source.rs
@@ -1,0 +1,217 @@
+use kalosm_common::FileSource;
+
+/// A the source of a [`Bert`] model
+pub struct BertSource {
+    pub(crate) config: FileSource,
+    pub(crate) tokenizer: FileSource,
+    pub(crate) model: FileSource,
+}
+
+impl BertSource {
+    /// Set the model to use, check out available models: <https://huggingface.co/models?library=sentence-transformers&sort=trending>
+    pub fn with_model(mut self, model: FileSource) -> Self {
+        self.model = model;
+        self
+    }
+
+    /// Set the tokenizer to use
+    pub fn with_tokenizer(mut self, tokenizer: FileSource) -> Self {
+        self.tokenizer = tokenizer;
+        self
+    }
+
+    /// Set the config to use
+    pub fn with_config(mut self, config: FileSource) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Create a new [`BertSource`] with the BGE large english preset
+    pub fn bge_large_en() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "BAAI/bge-large-en-v1.5".to_string(),
+                "refs/pr/5".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "BAAI/bge-large-en-v1.5".to_string(),
+                "refs/pr/5".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "BAAI/bge-large-en-v1.5".to_string(),
+                "refs/pr/5".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the BGE base english preset
+    pub fn bge_base_en() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "BAAI/bge-base-en-v1.5".to_string(),
+                "refs/pr/1".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "BAAI/bge-base-en-v1.5".to_string(),
+                "refs/pr/1".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "BAAI/bge-base-en-v1.5".to_string(),
+                "refs/pr/1".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the BGE small english preset
+    pub fn bge_small_en() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "BAAI/bge-small-en-v1.5".to_string(),
+                "refs/pr/3".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "BAAI/bge-small-en-v1.5".to_string(),
+                "refs/pr/3".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "BAAI/bge-small-en-v1.5".to_string(),
+                "refs/pr/3".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the MiniLM-L6-v2 preset
+    pub fn mini_lm_l6_v2() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+                "refs/pr/21".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+                "refs/pr/21".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+                "refs/pr/21".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs) model
+    pub fn snowflake_arctic_embed_extra_small() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-xs".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-xs".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-xs".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-s](https://huggingface.co/Snowflake/snowflake-arctic-embed-s) model
+    pub fn snowflake_arctic_embed_small() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-s".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-s".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-s".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-m](https://huggingface.co/Snowflake/snowflake-arctic-embed-m) model
+    pub fn snowflake_arctic_embed_medium() -> Self {
+        Self {
+            config: FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ),
+            tokenizer: FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ),
+            model: FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ),
+        }
+    }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-m-long](https://huggingface.co/Snowflake/snowflake-arctic-embed-m-long) model
+    ///
+    /// This model is slightly larger than [`Self::snowflake_arctic_embed_medium`] and supports longer contexts (up to 2048 tokens).
+    pub fn snowflake_arctic_embed_medium_long() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m-long".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m-long".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-m-long".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+
+    /// Create a new [`BertSource`] with the [snowflake-arctic-embed-l](https://huggingface.co/Snowflake/snowflake-arctic-embed-l) model
+    pub fn snowflake_arctic_embed_large() -> Self {
+        Self::default()
+            .with_model(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-l".to_string(),
+                "main".to_string(),
+                "model.safetensors".to_string(),
+            ))
+            .with_tokenizer(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-l".to_string(),
+                "main".to_string(),
+                "tokenizer.json".to_string(),
+            ))
+            .with_config(FileSource::huggingface(
+                "Snowflake/snowflake-arctic-embed-l".to_string(),
+                "main".to_string(),
+                "config.json".to_string(),
+            ))
+    }
+}
+
+impl Default for BertSource {
+    fn default() -> Self {
+        Self::snowflake_arctic_embed_medium()
+    }
+}


### PR DESCRIPTION
A couple different improvements for the bert model:
- Don't embed padding tokens when you are using a batch. This should make batch embeddings more accurate
- Expose options for pooling embeddings: mean embeddings or the new default cls embeddings