### PR TITLE
Use the in place kv cache for faster long context token generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1302,13 +1302,13 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.5.1"
-source = "git+https://github.com/huggingface/candle?rev=d9bc5ec15164ecb583dbb25653edd89e08e6cbd0#d9bc5ec15164ecb583dbb25653edd89e08e6cbd0"
+source = "git+https://github.com/huggingface/candle?rev=f3fade3b03d8ce9e832c8ed57be8dfee74b8822a#f3fade3b03d8ce9e832c8ed57be8dfee74b8822a"
 dependencies = [
  "accelerate-src",
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
- "cudarc 0.11.1",
+ "cudarc 0.11.2",
  "gemm",
  "half 2.4.1",
  "intel-mkl-src",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "candle-datasets"
 version = "0.5.1"
-source = "git+https://github.com/huggingface/candle?rev=d9bc5ec15164ecb583dbb25653edd89e08e6cbd0#d9bc5ec15164ecb583dbb25653edd89e08e6cbd0"
+source = "git+https://github.com/huggingface/candle?rev=f3fade3b03d8ce9e832c8ed57be8dfee74b8822a#f3fade3b03d8ce9e832c8ed57be8dfee74b8822a"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.5.1"
-source = "git+https://github.com/huggingface/candle?rev=d9bc5ec15164ecb583dbb25653edd89e08e6cbd0#d9bc5ec15164ecb583dbb25653edd89e08e6cbd0"
+source = "git+https://github.com/huggingface/candle?rev=f3fade3b03d8ce9e832c8ed57be8dfee74b8822a#f3fade3b03d8ce9e832c8ed57be8dfee74b8822a"
 dependencies = [
  "anyhow",
  "bindgen_cuda",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.5.1"
-source = "git+https://github.com/huggingface/candle?rev=d9bc5ec15164ecb583dbb25653edd89e08e6cbd0#d9bc5ec15164ecb583dbb25653edd89e08e6cbd0"
+source = "git+https://github.com/huggingface/candle?rev=f3fade3b03d8ce9e832c8ed57be8dfee74b8822a#f3fade3b03d8ce9e832c8ed57be8dfee74b8822a"
 dependencies = [
  "bindgen_cuda",
 ]
@@ -1365,7 +1365,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.5.1"
-source = "git+https://github.com/huggingface/candle?rev=d9bc5ec15164ecb583dbb25653edd89e08e6cbd0#d9bc5ec15164ecb583dbb25653edd89e08e6cbd0"
+source = "git+https://github.com/huggingface/candle?rev=f3fade3b03d8ce9e832c8ed57be8dfee74b8822a#f3fade3b03d8ce9e832c8ed57be8dfee74b8822a"
 dependencies = [
  "metal",
  "once_cell",
@@ -1376,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.5.1"
-source = "git+https://github.com/huggingface/candle?rev=d9bc5ec15164ecb583dbb25653edd89e08e6cbd0#d9bc5ec15164ecb583dbb25653edd89e08e6cbd0"
+source = "git+https://github.com/huggingface/candle?rev=f3fade3b03d8ce9e832c8ed57be8dfee74b8822a#f3fade3b03d8ce9e832c8ed57be8dfee74b8822a"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.5.1"
-source = "git+https://github.com/huggingface/candle?rev=d9bc5ec15164ecb583dbb25653edd89e08e6cbd0#d9bc5ec15164ecb583dbb25653edd89e08e6cbd0"
+source = "git+https://github.com/huggingface/candle?rev=f3fade3b03d8ce9e832c8ed57be8dfee74b8822a#f3fade3b03d8ce9e832c8ed57be8dfee74b8822a"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -2588,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c415f24c56f0bd4e0568e3ceea0bae6e5a1a96bda8ac177d0b6d7fcc7fa8de7a"
+checksum = "37e813aae0d2ce7db2f748094229f5e4c7eac118b78225a17d6bd6d0b5885cec"
 dependencies = [
  "half 2.4.1",
  "libloading",
@@ -7691,7 +7691,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -12512,7 +12512,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ members = [
 ]
 
 [workspace.dependencies]
-candle-core = { git = "https://github.com/huggingface/candle", rev = "d9bc5ec15164ecb583dbb25653edd89e08e6cbd0" }
-candle-nn = { git = "https://github.com/huggingface/candle", rev = "d9bc5ec15164ecb583dbb25653edd89e08e6cbd0" }
-candle-transformers = { git = "https://github.com/huggingface/candle", rev = "d9bc5ec15164ecb583dbb25653edd89e08e6cbd0" }
-candle-datasets = { git = "https://github.com/huggingface/candle", rev = "d9bc5ec15164ecb583dbb25653edd89e08e6cbd0" }
+candle-core = { git = "https://github.com/huggingface/candle", rev = "f3fade3b03d8ce9e832c8ed57be8dfee74b8822a" }
+candle-nn = { git = "https://github.com/huggingface/candle", rev = "f3fade3b03d8ce9e832c8ed57be8dfee74b8822a" }
+candle-transformers = { git = "https://github.com/huggingface/candle", rev = "f3fade3b03d8ce9e832c8ed57be8dfee74b8822a" }
+candle-datasets = { git = "https://github.com/huggingface/candle", rev = "f3fade3b03d8ce9e832c8ed57be8dfee74b8822a" }
 kalosm = { path = "./interfaces/kalosm", version = "0.2.1" }
 kalosm-sample = { path = "./interfaces/kalosm-sample", version = "0.2.1" }
 kalosm-common = { path = "./interfaces/kalosm-common", version = "0.1.0" }

--- a/models/kalosm-llama/examples/bench.rs
+++ b/models/kalosm-llama/examples/bench.rs
@@ -40,7 +40,7 @@ async fn main() {
         )
         .await
         .unwrap();
-        let prompt = "Hello world".repeat(10);
+        let prompt = "Hello world".repeat(600);
 
         let tokens = model.tokenizer().encode(&prompt, true).unwrap().len();
         for _ in 0..100 {
@@ -69,7 +69,7 @@ async fn main() {
         for _ in 0..100 {
             let mut session = model.new_session().unwrap();
             let start_time = std::time::Instant::now();
-            let tokens = 100;
+            let tokens = 200;
             model
                 .stream_text_with_sampler(
                     &mut session,
@@ -90,6 +90,6 @@ async fn main() {
     }
 
     load_small().await;
-    load_large().await;
     generate().await;
+    load_large().await;
 }

--- a/models/kalosm-llama/src/lib.rs
+++ b/models/kalosm-llama/src/lib.rs
@@ -256,7 +256,7 @@ impl LlamaBuilder {
             }
         };
 
-        let cache = LlamaCache::new(model.config.n_layer);
+        let cache = LlamaCache::new(&model.config);
 
         Ok(Llama::from_build(
             model,

--- a/models/kalosm-llama/src/model.rs
+++ b/models/kalosm-llama/src/model.rs
@@ -104,7 +104,7 @@ impl LlamaModel {
             }
         };
 
-        let cache = LlamaCache::new(model.config.n_layer);
+        let cache = LlamaCache::new(&model.config);
         Ok(Self {
             model,
             tokenizer: Arc::new(tokenizer),

--- a/models/kalosm-llama/src/raw/attention_layer.rs
+++ b/models/kalosm-llama/src/raw/attention_layer.rs
@@ -1,4 +1,4 @@
-use super::cache::{AttentionCache, AttentionCacheValue};
+use super::cache::AttentionCache;
 use super::mask::AttentionMask;
 use super::rope::RopeCache;
 use candle_core::Device;
@@ -105,31 +105,7 @@ impl LlamaAttention {
 
         let (key_states, value_states) = match cache {
             None => (key_states, value_states),
-            Some(cache) => match &mut cache.0 {
-                Some(AttentionCacheValue { key, value }) => {
-                    let kv_seq_len = key_states.dim(candle_core::D::Minus2)?;
-                    let (k, v) = if kv_seq_len == 0 {
-                        (key_states, value_states)
-                    } else {
-                        let key_states = Tensor::cat(&[&*key, &key_states], 2)?.contiguous()?;
-                        let value_states =
-                            Tensor::cat(&[&*value, &value_states], 2)?.contiguous()?;
-                        (key_states, value_states)
-                    };
-
-                    *key = k.clone();
-                    *value = v.clone();
-
-                    (k, v)
-                }
-                None => {
-                    cache.0 = Some(AttentionCacheValue {
-                        key: key_states.clone(),
-                        value: value_states.clone(),
-                    });
-                    (key_states, value_states)
-                }
-            },
+            Some(cache) => cache.0.append(&key_states, &value_states)?,
         };
 
         let mut attn_weights = (query_states.matmul(&key_states.t()?)? / (head_dim as f64).sqrt())?;

--- a/models/kalosm-llama/src/raw/cache.rs
+++ b/models/kalosm-llama/src/raw/cache.rs
@@ -1,21 +1,27 @@
 use candle_core::{Device, Tensor};
+use candle_nn::kv_cache::KvCache;
 use std::collections::HashMap;
+
+use super::LlamaConfig;
 
 /// A cache for llama inference. This cache will speed up generation of sequential text significantly.
 #[derive(Debug, Clone)]
 pub struct LlamaCache {
+    max_seq_len: usize,
     pub(crate) tokens: Vec<u32>,
     pub(crate) blocks: Vec<AttentionCache>,
 }
 
 impl LlamaCache {
     /// Create a new cache for a model
-    pub fn new(layers: usize) -> Self {
-        let mut blocks = Vec::with_capacity(layers);
-        for _ in 0..layers {
-            blocks.push(AttentionCache(None))
+    pub fn new(config: &LlamaConfig) -> Self {
+        let max_seq_len = config.context_length;
+        let mut blocks = Vec::with_capacity(config.n_layer);
+        for _ in 0..config.n_layer {
+            blocks.push(AttentionCache(KvCache::new(2, max_seq_len)))
         }
         Self {
+            max_seq_len,
             tokens: Vec::new(),
             blocks,
         }
@@ -24,32 +30,40 @@ impl LlamaCache {
     /// Clear the cache.
     pub fn clear(&mut self) {
         for block in &mut self.blocks {
-            *block = AttentionCache(None)
+            block.0.reset()
         }
     }
 
     /// Get the tensor map for this cache. This can be used to save the cache to disk.
     pub fn get_tensor_map(&self, device: &Device) -> HashMap<String, Tensor> {
         let mut map = HashMap::with_capacity(self.blocks.len());
-        for (i, block) in self.blocks.iter().enumerate() {
-            if let AttentionCache(Some(AttentionCacheValue { key, value })) = block {
-                map.insert(format!("llama.cache.blocks.{}.key", i), key.clone());
-                map.insert(format!("llama.cache.blocks.{}.value", i), value.clone());
+        for (i, kv_cache) in self.blocks.iter().enumerate() {
+            if let (Ok(Some(k)), Ok(Some(v))) = (kv_cache.0.k(), kv_cache.0.v()) {
+                map.insert(format!("llama.cache.blocks.{}.key", i), k);
+                map.insert(format!("llama.cache.blocks.{}.value", i), v);
             }
         }
         map.insert(
             "llama.cache.tokens".to_string(),
             Tensor::from_iter(self.tokens.iter().copied(), device).unwrap(),
         );
+        map.insert(
+            "llama.cache.max_seq_len".to_string(),
+            Tensor::new(self.max_seq_len as u32, device).unwrap(),
+        );
         map
     }
 
     /// Create a cache from a tensor map. This can be used to load a cache from disk.
-    pub fn from_tensor_map(map: HashMap<String, Tensor>) -> Self {
+    pub fn from_tensor_map(map: HashMap<String, Tensor>) -> candle_core::Result<Self> {
         let tokens = map
             .get("llama.cache.tokens")
             .and_then(|tokens| tokens.to_vec1().ok())
             .unwrap_or_default();
+        let max_seq_len = map
+            .get("llama.cache.max_seq_len")
+            .and_then(|max_seq_len| max_seq_len.to_scalar::<u32>().ok())
+            .unwrap_or(2048) as usize;
         let mut blocks = Vec::with_capacity(24);
         for (k, v) in map {
             if let Some(i) = k.strip_prefix("llama.cache.blocks.") {
@@ -58,44 +72,44 @@ impl LlamaCache {
                     .unwrap_or_else(|| i.strip_suffix(".value").unwrap());
                 let i = i.parse::<usize>().unwrap_or(0);
                 if i >= blocks.len() {
-                    blocks.resize(i + 1, AttentionCache(None));
+                    blocks.resize(i + 1, AttentionCache(KvCache::new(2, max_seq_len)));
                 }
                 if k.ends_with(".key") {
                     match blocks.get_mut(i) {
-                        Some(AttentionCache(Some(AttentionCacheValue { key, value: _ }))) => {
-                            *key = v;
+                        Some(AttentionCache(kv_cache)) => {
+                            let key = kv_cache.k_cache_mut();
+                            key.reset();
+                            key.append(&v)?;
                         }
                         _ => {
-                            blocks[i] = AttentionCache(Some(AttentionCacheValue {
-                                key: v.clone(),
-                                value: v,
-                            }));
+                            let mut kv_cache = KvCache::new(2, max_seq_len);
+                            kv_cache.k_cache_mut().append(&v)?;
+                            blocks[i] = AttentionCache(kv_cache);
                         }
                     }
                 } else if k.ends_with(".value") {
                     match blocks.get_mut(i) {
-                        Some(AttentionCache(Some(AttentionCacheValue { key: _, value }))) => {
-                            *value = v;
+                        Some(AttentionCache(kv_cache)) => {
+                            let value = kv_cache.v_cache_mut();
+                            value.reset();
+                            value.append(&v)?;
                         }
                         _ => {
-                            blocks[i] = AttentionCache(Some(AttentionCacheValue {
-                                key: v.clone(),
-                                value: v,
-                            }));
+                            let mut kv_cache = KvCache::new(2, max_seq_len);
+                            kv_cache.k_cache_mut().append(&v)?;
+                            blocks[i] = AttentionCache(kv_cache)
                         }
                     }
                 }
             }
         }
-        Self { tokens, blocks }
+        Ok(Self {
+            tokens,
+            blocks,
+            max_seq_len,
+        })
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct AttentionCache(pub(crate) Option<AttentionCacheValue>);
-
-#[derive(Debug, Clone)]
-pub(crate) struct AttentionCacheValue {
-    pub(crate) key: Tensor,
-    pub(crate) value: Tensor,
-}
+pub(crate) struct AttentionCache(pub(crate) KvCache);

--- a/models/kalosm-llama/src/raw/mod.rs
+++ b/models/kalosm-llama/src/raw/mod.rs
@@ -21,10 +21,11 @@ fn decode_norm(tensor: QTensor, eps: f64) -> candle_core::Result<RmsNorm> {
     RmsNorm::from_qtensor(tensor, eps)
 }
 
+/// The configuration of a Llama model.
 #[allow(unused)]
-pub(crate) struct LlamaConfig {
+pub struct LlamaConfig {
     rope_theta: f32,
-    context_length: usize,
+    pub(crate) context_length: usize,
     head_dimension: usize,
     rope_dimension: usize,
     n_head: usize,

--- a/models/kalosm-llama/src/session.rs
+++ b/models/kalosm-llama/src/session.rs
@@ -24,7 +24,7 @@ impl Session for LlamaSession {
         let device = accelerated_device_if_available()?;
         let tensors = candle_core::safetensors::load(path, &device)?;
 
-        Ok(Self::from_tensor_map(tensors))
+        Ok(Self::from_tensor_map(tensors)?)
     }
 
     fn try_clone(&self) -> anyhow::Result<Self>
@@ -42,14 +42,15 @@ impl LlamaSession {
     }
 
     /// Import a cache tensor map.
-    pub fn set_tensor_map(&mut self, map: HashMap<String, Tensor>) {
-        self.cache = LlamaCache::from_tensor_map(map);
+    pub fn set_tensor_map(&mut self, map: HashMap<String, Tensor>) -> candle_core::Result<()> {
+        self.cache = LlamaCache::from_tensor_map(map)?;
+        Ok(())
     }
 
     /// Create a cache from a tensor map. This can be used to load a cache from disk.
-    pub fn from_tensor_map(map: HashMap<String, Tensor>) -> Self {
-        Self {
-            cache: LlamaCache::from_tensor_map(map),
-        }
+    pub fn from_tensor_map(map: HashMap<String, Tensor>) -> candle_core::Result<Self> {
+        Ok(Self {
+            cache: LlamaCache::from_tensor_map(map)?,
+        })
     }
 }


### PR DESCRIPTION
This PR speeds up longer context sequence generation from `~25t/s` on M2 32gb to `~30t/s` for llama 8b