### PR TITLE
Slowly expand the llama cache as we need to

### DIFF
--- a/models/kalosm-llama/src/raw/attention_layer.rs
+++ b/models/kalosm-llama/src/raw/attention_layer.rs
@@ -105,7 +105,7 @@ impl LlamaAttention {
 
         let (key_states, value_states) = match cache {
             None => (key_states, value_states),
-            Some(cache) => cache.0.append(&key_states, &value_states)?,
+            Some(cache) => cache.append(&key_states, &value_states)?,
         };
 
         let mut attn_weights = (query_states.matmul(&key_states.t()?)? / (head_dim as f64).sqrt())?;

--- a/models/kalosm-llama/src/raw/cache.rs
+++ b/models/kalosm-llama/src/raw/cache.rs
@@ -1,8 +1,11 @@
 use candle_core::{Device, Tensor};
-use candle_nn::kv_cache::KvCache;
+use candle_nn::kv_cache::{Cache, KvCache};
 use std::collections::HashMap;
 
 use super::LlamaConfig;
+
+/// The dimension along which the attention cache is concatenated with attention for new tokens.
+const CONCAT_DIMENSION: usize = 2;
 
 /// A cache for llama inference. This cache will speed up generation of sequential text significantly.
 #[derive(Debug, Clone)]
@@ -18,7 +21,7 @@ impl LlamaCache {
         let max_seq_len = config.context_length;
         let mut blocks = Vec::with_capacity(config.n_layer);
         for _ in 0..config.n_layer {
-            blocks.push(AttentionCache(KvCache::new(2, max_seq_len)))
+            blocks.push(AttentionCache::new(max_seq_len))
         }
         Self {
             max_seq_len,
@@ -30,7 +33,7 @@ impl LlamaCache {
     /// Clear the cache.
     pub fn clear(&mut self) {
         for block in &mut self.blocks {
-            block.0.reset()
+            block.reset()
         }
     }
 
@@ -38,7 +41,7 @@ impl LlamaCache {
     pub fn get_tensor_map(&self, device: &Device) -> HashMap<String, Tensor> {
         let mut map = HashMap::with_capacity(self.blocks.len());
         for (i, kv_cache) in self.blocks.iter().enumerate() {
-            if let (Ok(Some(k)), Ok(Some(v))) = (kv_cache.0.k(), kv_cache.0.v()) {
+            if let (Ok(Some(k)), Ok(Some(v))) = (kv_cache.cache.k(), kv_cache.cache.v()) {
                 map.insert(format!("llama.cache.blocks.{}.key", i), k);
                 map.insert(format!("llama.cache.blocks.{}.value", i), v);
             }
@@ -72,32 +75,40 @@ impl LlamaCache {
                     .unwrap_or_else(|| i.strip_suffix(".value").unwrap());
                 let i = i.parse::<usize>().unwrap_or(0);
                 if i >= blocks.len() {
-                    blocks.resize(i + 1, AttentionCache(KvCache::new(2, max_seq_len)));
+                    blocks.resize(i + 1, AttentionCache::new(max_seq_len));
                 }
                 if k.ends_with(".key") {
                     match blocks.get_mut(i) {
-                        Some(AttentionCache(kv_cache)) => {
-                            let key = kv_cache.k_cache_mut();
-                            key.reset();
-                            key.append(&v)?;
+                        Some(AttentionCache { cache, .. }) => {
+                            let key_cache = cache.k_cache_mut();
+                            let len = v.dim(CONCAT_DIMENSION)?;
+                            *key_cache = Cache::new(CONCAT_DIMENSION, len);
+                            key_cache.append(&v)?;
                         }
                         _ => {
-                            let mut kv_cache = KvCache::new(2, max_seq_len);
-                            kv_cache.k_cache_mut().append(&v)?;
-                            blocks[i] = AttentionCache(kv_cache);
+                            let mut cache = AttentionCache::new(max_seq_len);
+                            let key_cache = cache.cache.k_cache_mut();
+                            let len = v.dim(CONCAT_DIMENSION)?;
+                            *key_cache = Cache::new(CONCAT_DIMENSION, len);
+                            key_cache.append(&v)?;
+                            blocks[i] = cache;
                         }
                     }
                 } else if k.ends_with(".value") {
                     match blocks.get_mut(i) {
-                        Some(AttentionCache(kv_cache)) => {
-                            let value = kv_cache.v_cache_mut();
-                            value.reset();
-                            value.append(&v)?;
+                        Some(AttentionCache { cache, .. }) => {
+                            let value_cache = cache.v_cache_mut();
+                            let len = v.dim(CONCAT_DIMENSION)?;
+                            *value_cache = Cache::new(CONCAT_DIMENSION, len);
+                            value_cache.append(&v)?;
                         }
                         _ => {
-                            let mut kv_cache = KvCache::new(2, max_seq_len);
-                            kv_cache.k_cache_mut().append(&v)?;
-                            blocks[i] = AttentionCache(kv_cache)
+                            let mut cache = AttentionCache::new(max_seq_len);
+                            let value_cache = cache.cache.v_cache_mut();
+                            let len = v.dim(CONCAT_DIMENSION)?;
+                            *value_cache = Cache::new(CONCAT_DIMENSION, len);
+                            value_cache.append(&v)?;
+                            blocks[i] = cache;
                         }
                     }
                 }
@@ -111,5 +122,54 @@ impl LlamaCache {
     }
 }
 
+/// A cache for the attention layer. This cache wraps candles [`KvCache`] with exponentially larger allocations as the sequence length increases.
 #[derive(Debug, Clone)]
-pub(crate) struct AttentionCache(pub(crate) KvCache);
+pub(crate) struct AttentionCache {
+    cache: KvCache,
+    max_seq_len: usize,
+}
+
+impl AttentionCache {
+    /// Create a new cache with the given max sequence length.
+    pub fn new(max_seq_len: usize) -> Self {
+        Self {
+            cache: KvCache::new(CONCAT_DIMENSION, 8),
+            max_seq_len,
+        }
+    }
+
+    /// Reset the cache.
+    pub fn reset(&mut self) {
+        self.cache.reset()
+    }
+
+    /// Append a new key/value pair to the cache.
+    pub fn append(&mut self, k: &Tensor, v: &Tensor) -> candle_core::Result<(Tensor, Tensor)> {
+        let seq_len = k.dim(CONCAT_DIMENSION)?;
+        // The key and value token length must be the same.
+        debug_assert_eq!(seq_len, v.dim(CONCAT_DIMENSION)?);
+
+        let current_allocated_size = self.cache.k_cache().max_seq_len();
+        let size_required_for_append = self.cache.current_seq_len() + seq_len;
+
+        // If adding the new key/value pair would exceed the max sequence length, we need to allocate a new tensor with double the size or the max sequence length whichever is smaller.
+        if size_required_for_append > current_allocated_size {
+            // The new size of the cache is double the old size or the max sequence length of the model.
+            // We try to keep the new size a power of two to keep memory alignment nice.
+            let next_power_of_two = size_required_for_append.next_power_of_two();
+            let new_cache_max_seq_len = next_power_of_two.min(self.max_seq_len);
+
+            // Create a new cache with the new size.
+            let mut new_cache = KvCache::new(CONCAT_DIMENSION, new_cache_max_seq_len);
+            // Append the old cache to the new cache.
+            if let (Ok(Some(k)), Ok(Some(v))) = (self.cache.k(), self.cache.v()) {
+                new_cache.k_cache_mut().append(&k)?;
+                new_cache.v_cache_mut().append(&v)?;
+            }
+            // Replace the old cache with the new cache.
+            self.cache = new_cache;
+        }
+
+        self.cache.append(k, v)
+    }
+}


### PR DESCRIPTION
#198 switched to the key value cache instead of allocating a new buffer every time. However, it allocated the maximum sequence length at the very beginning of generation which both slows the startup time and results in out of memory errors on less powerful devices even when generating a very short sequence.

This PR doubles the memory limit every time we reach it instead with an initial cache length of 8