### PR TITLE
Save/load classifier heads, add dropout layer and expose the learning rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,16 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli",
+ "gimli 0.28.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli 0.29.0",
 ]
 
 [[package]]
@@ -211,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -456,12 +465,12 @@ dependencies = [
 
 [[package]]
 name = "async-broadcast"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258b52a1aa741b9f09783b2d86cf0aeeb617bbf847f6933340a39644227acbdb"
+checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
 dependencies = [
- "event-listener 5.3.0",
- "event-listener-strategy 0.5.2",
+ "event-listener 5.3.1",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
@@ -484,7 +493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener-strategy 0.5.2",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
@@ -524,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
 dependencies = [
  "async-lock",
  "cfg-if 1.0.0",
@@ -543,12 +552,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener 5.3.1",
+ "event-listener-strategy",
  "pin-project-lite",
 ]
 
@@ -588,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
+checksum = "f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a"
 dependencies = [
  "async-channel 2.3.1",
  "async-io",
@@ -599,7 +608,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if 1.0.0",
- "event-listener 5.3.0",
+ "event-listener 5.3.1",
  "futures-lite 2.3.0",
  "rustix",
  "tracing",
@@ -619,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
+checksum = "329972aa325176e89114919f2a80fdae4f4c040f66a370b1a1159c6c0f94e7aa"
 dependencies = [
  "async-io",
  "async-lock",
@@ -886,16 +895,16 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
 dependencies = [
- "addr2line",
+ "addr2line 0.22.0",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.7.3",
- "object 0.32.2",
+ "object 0.35.0",
  "rustc-demangle",
 ]
 
@@ -1118,19 +1127,19 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a8646f94ab393e43e8b35a2558b1624bed28b97ee09c5d15456e3c9463f46d"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
@@ -1217,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369cfaf2a5bed5d8f8202073b2e093c9f508251de1551a0deb4253e4c7d80909"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1308,7 +1317,7 @@ dependencies = [
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
- "cudarc 0.11.2",
+ "cudarc 0.11.4",
  "gemm",
  "half 2.4.1",
  "intel-mkl-src",
@@ -1728,6 +1737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a483f3cbf7cec2e153d424d0e92329d816becc6421389bd494375c6065921b9b"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -1941,7 +1956,7 @@ checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "crossterm",
  "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum_macros 0.26.3",
  "unicode-width",
 ]
 
@@ -2201,7 +2216,7 @@ dependencies = [
  "cranelift-control 0.106.0",
  "cranelift-entity 0.106.0",
  "cranelift-isle 0.106.0",
- "gimli",
+ "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
@@ -2221,7 +2236,7 @@ dependencies = [
  "cranelift-control 0.107.0",
  "cranelift-entity 0.107.0",
  "cranelift-isle 0.107.0",
- "gimli",
+ "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
@@ -2588,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e813aae0d2ce7db2f748094229f5e4c7eac118b78225a17d6bd6d0b5885cec"
+checksum = "983d9c3634d3ebf37cb1a4a24a15ffe3fad4eaf92ed1e2a4fda571da8d0a3eec"
 dependencies = [
  "half 2.4.1",
  "libloading",
@@ -3042,8 +3057,8 @@ dependencies = [
 
 [[package]]
 name = "dioxus-free-icons"
-version = "0.8.5"
-source = "git+https://github.com/dioxus-community/dioxus-free-icons#9faa544f5cd510068ec4e9848c3470d364d8feb3"
+version = "0.8.6"
+source = "git+https://github.com/dioxus-community/dioxus-free-icons#0cc4ba43a8590a933487e600baf8a4c6e73c7021"
 dependencies = [
  "dioxus",
 ]
@@ -3197,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "dioxus-sdk"
 version = "0.5.0"
-source = "git+https://github.com/DioxusLabs/sdk#ffffa63d75e41ed96a36682893cfede5add92125"
+source = "git+https://github.com/DioxusLabs/sdk#d49812fbc9d4506bd3b1ec994f45ef4447f34c79"
 dependencies = [
  "cfg-if 1.0.0",
  "copypasta",
@@ -3614,33 +3629,12 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -3650,7 +3644,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 5.3.0",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -4276,7 +4270,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "directories",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "octocrab",
  "once_cell",
@@ -4949,6 +4943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5374,9 +5374,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7acb9683d7c7068aa46d47557bfa4e35a277964b350d9504a87b03610163fd"
+checksum = "f60d7cff16094be9627830b399c087a25017e93fb3768b87cd656a68ccb1ebe8"
 dependencies = [
  "bitflags 2.5.0",
  "byteorder",
@@ -5588,9 +5588,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5637,7 +5637,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs",
@@ -5651,7 +5651,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -5664,7 +5664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -5672,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-util",
@@ -6765,9 +6765,9 @@ dependencies = [
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9048db3a58c0732d7236abc4909058f9d2708cfb6d7d047eb895fddec6419a"
+checksum = "a5142795c220effa4c8f4813537bd4c88113a07e45e93100ccb2adc5cec6c7f3"
 dependencies = [
  "cc",
  "doxygen-rs",
@@ -6877,9 +6877,9 @@ checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
 
 [[package]]
 name = "malachite"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b7d9a19f361ff1702218089fe80d8b94ef170d50585e9b62bfd0763a70a3ea"
+checksum = "8daef21442be9219c2b5531ad246332a4e9870efd02143e92c5d05d1d9ba45ce"
 dependencies = [
  "malachite-base",
  "malachite-nz",
@@ -6888,9 +6888,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-base"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1189508294c7720b50c652670cd0fab596873482f57d31dc2737a02a7bbc34"
+checksum = "9a1e2ded837144c32cfd3aafcb3d11f7087a438fcbf4f423c19e8330a39d239f"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.11.0",
@@ -6913,9 +6913,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a3eed175b73b3ee4a4e19f4e7ffcc9d6d5c8c485a067d220670da7ba33c365"
+checksum = "10e203b400efc901d76ad2266fb6a00c4f4c8c44c098f710763e69284d55f708"
 dependencies = [
  "itertools 0.11.0",
  "libm",
@@ -6924,9 +6924,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-q"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0a3652adf704b95a1a8fae715ecf9b001e9e32f015448cec73fe0d84c56943"
+checksum = "ce067038c9196f0730e715a0bd3ea7c8dc9097f02fea8b30232ac656a65a98dc"
 dependencies = [
  "itertools 0.11.0",
  "malachite-base",
@@ -7468,7 +7468,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if 1.0.0",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -7776,6 +7776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "object_store"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7852,7 +7861,7 @@ dependencies = [
  "sha2",
  "tar",
  "thiserror",
- "toml 0.8.13",
+ "toml 0.8.14",
  "ureq",
  "url",
  "uuid",
@@ -7876,7 +7885,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls",
  "hyper-timeout",
  "jsonwebtoken",
@@ -8676,9 +8685,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464db0c665917b13ebb5d453ccdec4add5658ee1adc7affc7677615356a8afaf"
+checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
 dependencies = [
  "atomic-waker",
  "fastrand 2.1.0",
@@ -8778,9 +8787,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
+checksum = "5e6a007746f34ed64099e88783b0ae369eaa3da6392868ba262e2af9b8fbaea1"
 dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
@@ -8903,9 +8912,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -9360,7 +9369,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -10680,9 +10689,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536a5b959673643ee01e59ae41bf01425482c8070dee95d7061ee2d45296b59c"
+checksum = "b06e6e5467a2cd93ce1accfdfd8b859404f0b3b2041131ffd774fabf666b8219"
 dependencies = [
  "bytes",
  "const_format",
@@ -10709,9 +10718,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064dd9b256e78bf2886774f265cc34d2aefdd05b430c58c78a69eceef21b5e60"
+checksum = "09c216bb1c1ac890151397643c663c875a1836adf0b269be4e389cb1b48c173c"
 dependencies = [
  "const_format",
  "convert_case 0.6.0",
@@ -10723,9 +10732,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad11700cbccdbd313703916eb8c97301ee423c4a06e5421b77956fdcb36a9f"
+checksum = "00783df297ec85ea605779f2fef9cbec98981dffe2e01e1a9845c102ee1f1ae6"
 dependencies = [
  "server_fn_macro",
  "syn 2.0.66",
@@ -11080,9 +11089,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ef1a0fa1e39ac22972c8db23ff89aea700ab96aa87114e1fb55937a631a0c9"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
 dependencies = [
  "smallvec",
 ]
@@ -11276,11 +11285,11 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -11347,7 +11356,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "surrealdb-core 1.4.2",
+ "surrealdb-core 1.5.0",
  "surrealdb-core 2.0.0-1.5.1",
  "thiserror",
  "tokio",
@@ -11363,9 +11372,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2f403dba761e0e3404f90334f8ff1454f1f308e88c84dd5dbcee52866ff30e"
+checksum = "d765dbd25b093d89242c4eef253f49d9f026a6acf47b6dee07f86209a78a4080"
 dependencies = [
  "addr",
  "any_ascii",
@@ -11708,7 +11717,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.8.13",
+ "toml 0.8.14",
  "version-compare",
 ]
 
@@ -12073,9 +12082,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -12102,9 +12111,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12187,14 +12196,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.6",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -12261,15 +12270,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.6",
- "winnow 0.6.8",
+ "winnow 0.6.11",
 ]
 
 [[package]]
@@ -12710,9 +12719,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -13031,9 +13040,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.208.1"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6425e84e42f7f558478e40ecc2287912cb319f2ca68e5c0bb93c61d4fc63fa17"
+checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
 dependencies = [
  "leb128",
 ]
@@ -13152,7 +13161,7 @@ name = "wasmtime"
 version = "19.0.0"
 source = "git+https://github.com/bytecodealliance/wasmtime?rev=b736585e2515f253d4507ae32f2e3180f4385192#b736585e2515f253d4507ae32f2e3180f4385192"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "anyhow",
  "async-trait",
  "bincode",
@@ -13160,7 +13169,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "encoding_rs",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.28.1",
  "indexmap 2.2.6",
  "ittapi",
  "libc",
@@ -13195,7 +13204,7 @@ name = "wasmtime"
 version = "20.0.0"
 source = "git+https://github.com/bytecodealliance/wasmtime?rev=c76e1fdc4afaaafb509367f2d09ef50b520efa65#c76e1fdc4afaaafb509367f2d09ef50b520efa65"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "anyhow",
  "async-trait",
  "bincode",
@@ -13203,7 +13212,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "encoding_rs",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.28.1",
  "indexmap 2.2.6",
  "ittapi",
  "libc",
@@ -13265,7 +13274,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.13",
+ "toml 0.8.14",
  "windows-sys 0.52.0",
  "zstd 0.13.0",
 ]
@@ -13284,7 +13293,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.13",
+ "toml 0.8.14",
  "windows-sys 0.52.0",
  "zstd 0.13.0",
 ]
@@ -13340,7 +13349,7 @@ dependencies = [
  "cranelift-frontend 0.106.0",
  "cranelift-native 0.106.0",
  "cranelift-wasm 0.106.0",
- "gimli",
+ "gimli 0.28.1",
  "log",
  "object 0.32.2",
  "target-lexicon",
@@ -13364,7 +13373,7 @@ dependencies = [
  "cranelift-frontend 0.107.0",
  "cranelift-native 0.107.0",
  "cranelift-wasm 0.107.0",
- "gimli",
+ "gimli 0.28.1",
  "log",
  "object 0.33.0",
  "target-lexicon",
@@ -13383,7 +13392,7 @@ dependencies = [
  "cranelift-codegen 0.106.0",
  "cranelift-control 0.106.0",
  "cranelift-native 0.106.0",
- "gimli",
+ "gimli 0.28.1",
  "object 0.32.2",
  "target-lexicon",
  "wasmtime-environ 19.0.0",
@@ -13398,7 +13407,7 @@ dependencies = [
  "bincode",
  "cpp_demangle",
  "cranelift-entity 0.106.0",
- "gimli",
+ "gimli 0.28.1",
  "indexmap 2.2.6",
  "log",
  "object 0.32.2",
@@ -13423,7 +13432,7 @@ dependencies = [
  "bincode",
  "cpp_demangle",
  "cranelift-entity 0.107.0",
- "gimli",
+ "gimli 0.28.1",
  "indexmap 2.2.6",
  "log",
  "object 0.33.0",
@@ -13652,7 +13661,7 @@ source = "git+https://github.com/bytecodealliance/wasmtime?rev=b736585e2515f253d
 dependencies = [
  "anyhow",
  "cranelift-codegen 0.106.0",
- "gimli",
+ "gimli 0.28.1",
  "object 0.32.2",
  "target-lexicon",
  "wasmparser 0.200.0",
@@ -13668,7 +13677,7 @@ source = "git+https://github.com/bytecodealliance/wasmtime?rev=c76e1fdc4afaaafb5
 dependencies = [
  "anyhow",
  "cranelift-codegen 0.107.0",
- "gimli",
+ "gimli 0.28.1",
  "object 0.33.0",
  "target-lexicon",
  "wasmparser 0.202.0",
@@ -13728,24 +13737,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "208.0.1"
+version = "209.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00b3f023b4e2ccd2e054e240294263db52ae962892e6523e550783c83a67f1"
+checksum = "8fffef2ff6147e4d12e972765fd75332c6a11c722571d4ab7a780d81ffc8f0a4"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.208.1",
+ "wasm-encoder 0.209.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.208.1"
+version = "1.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ed38e59176550214c025ea2bd0eeefd8e86b92d0af6698d5ba95020ec2e07b"
+checksum = "42203ec0271d113f8eb1f77ebc624886530cecb35915a7f63a497131f16e4d24"
 dependencies = [
- "wast 208.0.1",
+ "wast 209.0.1",
 ]
 
 [[package]]
@@ -14005,9 +14014,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.21"
+version = "0.7.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8dc749a1b03f3c255a3064a4f5c0ee5ed09b7c6bc6d4525d31f779cd74d7fc"
+checksum = "2c5cb32c74fe55350a3272ba792f050613e692253ae0d89ad5d83eb0dcea15e1"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -14105,7 +14114,7 @@ source = "git+https://github.com/bytecodealliance/wasmtime?rev=b736585e2515f253d
 dependencies = [
  "anyhow",
  "cranelift-codegen 0.106.0",
- "gimli",
+ "gimli 0.28.1",
  "regalloc2",
  "smallvec",
  "target-lexicon",
@@ -14120,7 +14129,7 @@ source = "git+https://github.com/bytecodealliance/wasmtime?rev=c76e1fdc4afaaafb5
 dependencies = [
  "anyhow",
  "cranelift-codegen 0.107.0",
- "gimli",
+ "gimli 0.28.1",
  "regalloc2",
  "smallvec",
  "target-lexicon",
@@ -14450,9 +14459,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
 dependencies = [
  "memchr",
 ]
@@ -14744,7 +14753,7 @@ checksum = "8b717040ba9771fd88eb428c6ea6b555f8e734ff8534f02c13e8f10d97f5935e"
 dependencies = [
  "base64 0.21.7",
  "block",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "cocoa",
  "core-graphics",
  "crossbeam-channel 0.5.13",
@@ -14923,9 +14932,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e71b2e4f287f467794c671e2b8f8a5f3716b3c829079a1c44740148eff07e4"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -14935,9 +14944,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14962,7 +14971,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.3.0",
+ "event-listener 5.3.1",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -15029,18 +15038,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655b0814c5c0b19ade497851070c640773304939a6c0fd5f5fb43da0696d05b7"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/interfaces/kalosm-learning/examples/classify.rs
+++ b/interfaces/kalosm-learning/examples/classify.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &dev,
             ClassifierConfig::new(384).layers_dims(layers.clone()),
         )?);
-        if let Err(error) = classifier.train(&dataset, &dev, 100) {
+        if let Err(error) = classifier.train(&dataset, &dev, 100, 0.0003) {
             println!("Error: {:?}", error);
         } else {
             break;

--- a/interfaces/kalosm-learning/src/classifier/model.rs
+++ b/interfaces/kalosm-learning/src/classifier/model.rs
@@ -1,5 +1,10 @@
-use candle_core::{safetensors::Load, DType, Device, Result, Tensor, Var, D};
-use candle_nn::{loss, ops, Linear, Module, Optimizer, VarBuilder, VarMap};
+use std::collections::HashMap;
+
+use candle_core::{
+    safetensors::{self, Load},
+    DType, Device, Result, Tensor, Var, D,
+};
+use candle_nn::{loss, ops, Dropout, Linear, Module, ModuleT, Optimizer, VarBuilder, VarMap};
 use rand::Rng;
 
 /// A class that a [`Classifier`] can predict.
@@ -20,6 +25,32 @@ pub struct ClassificationDataset {
     train_classes: Tensor,
     test_inputs: Tensor,
     test_classes: Tensor,
+}
+
+impl ClassificationDataset {
+    /// Save the dataset to the given path.
+    pub fn save<P: AsRef<std::path::Path>>(&self, path: P) -> Result<()> {
+        let safetensors = HashMap::from([
+            ("train_inputs".to_string(), self.train_inputs.clone()),
+            ("train_classes".to_string(), self.train_classes.clone()),
+            ("test_inputs".to_string(), self.test_inputs.clone()),
+            ("test_classes".to_string(), self.test_classes.clone()),
+        ]);
+
+        safetensors::save(&safetensors, path)?;
+        Ok(())
+    }
+
+    /// Load the dataset from the given path.
+    pub fn load<P: AsRef<std::path::Path>>(path: P, dev: &Device) -> Result<Self> {
+        let mut safetensors = safetensors::load(path, dev)?;
+        Ok(Self {
+            train_inputs: safetensors.remove("train_inputs").unwrap(),
+            train_classes: safetensors.remove("train_classes").unwrap(),
+            test_inputs: safetensors.remove("test_inputs").unwrap(),
+            test_classes: safetensors.remove("test_classes").unwrap(),
+        })
+    }
 }
 
 /// A builder for [`ClassificationDataset`].
@@ -74,7 +105,7 @@ impl<C: Class> ClassificationDatasetBuilder<C> {
             let index = rng.gen_range(0..self.classes.len());
             let mut input = self.inputs.remove(index);
             let class = self.classes.remove(index);
-            if input_test.len() <= first_quarter {
+            if class_test.len() <= first_quarter {
                 input_test.append(&mut input);
                 class_test.push(class.to_class());
             } else {
@@ -113,6 +144,8 @@ pub struct Classifier<C: Class> {
     device: Device,
     varmap: VarMap,
     layers: Vec<Linear>,
+    dropout: Dropout,
+    dropout_rate: f32,
     phantom: std::marker::PhantomData<C>,
 }
 
@@ -151,6 +184,7 @@ impl<C: Class> Classifier<C> {
                 layers.pop();
                 layers
             },
+            dropout_rate: self.dropout_rate,
         }
     }
 
@@ -163,6 +197,7 @@ impl<C: Class> Classifier<C> {
         let ClassifierConfig {
             input_dim,
             layers_dims,
+            dropout_rate,
         } = config;
         let output_dim = C::CLASSES;
         if layers_dims.is_empty() {
@@ -174,6 +209,8 @@ impl<C: Class> Classifier<C> {
                     output_dim as usize,
                     vs.pp("ln0"),
                 )?],
+                dropout: Dropout::new(dropout_rate),
+                dropout_rate,
                 phantom: std::marker::PhantomData,
             });
         }
@@ -203,15 +240,18 @@ impl<C: Class> Classifier<C> {
             device: dev,
             layers,
             varmap,
+            dropout: Dropout::new(dropout_rate),
+            dropout_rate,
             phantom: std::marker::PhantomData,
         })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let mut xs = xs.clone();
+    fn forward_t(&self, xs: &Tensor, train: bool) -> Result<Tensor> {
+        let xs = xs.clone();
+        let mut xs = self.dropout.forward_t(&xs, train)?;
         for layer in &self.layers {
             xs = layer.forward(&xs)?;
-            xs = xs.relu()?;
+            xs = xs.gelu_erf()?;
         }
         Ok(xs)
     }
@@ -234,40 +274,44 @@ impl<C: Class> Classifier<C> {
     /// dataset.add(vec![1.0, 2.0, 3.0, 4.0], MyClass::Person);
     /// dataset.add(vec![4.0, 3.0, 2.0, 1.0], MyClass::Thing);
     ///
-    /// classifier.train(&dataset.build(&dev).unwrap(), &dev, 20).unwrap();
+    /// classifier.train(&dataset.build(&dev).unwrap(), &dev, 20, 0.05).unwrap();
     /// ```
     pub fn train(
         &mut self,
         m: &ClassificationDataset,
         dev: &Device,
         epochs: usize,
+        learning_rate: f64,
     ) -> anyhow::Result<f32> {
         let train_results = m.train_classes.to_device(dev)?;
         let train_votes = m.train_inputs.to_device(dev)?;
 
-        let mut sgd = candle_nn::AdamW::new_lr(self.varmap.all_vars(), 0.05)?;
+        let mut sgd = candle_nn::AdamW::new_lr(self.varmap.all_vars(), learning_rate)?;
         let test_votes = m.test_inputs.to_device(dev)?;
         let test_results = m.test_classes.to_device(dev)?;
         let mut final_accuracy: f32 = 0.0;
         for epoch in 1..epochs + 1 {
-            let logits = self.forward(&train_votes)?;
+            let logits = self.forward_t(&train_votes, true)?;
             let log_sm = ops::log_softmax(&logits, D::Minus1)?;
             let loss = loss::nll(&log_sm, &train_results)?;
             sgd.backward_step(&loss)?;
 
-            let test_logits = self.forward(&test_votes)?;
-            let sum_ok = test_logits
+            let test_logits = self.forward_t(&test_votes, false)?;
+            let test_cases_passed = test_logits
                 .argmax(D::Minus1)?
                 .eq(&test_results)?
-                .to_dtype(DType::F32)?
+                .to_dtype(DType::U32)?
                 .sum_all()?
-                .to_scalar::<f32>()?;
-            let test_accuracy: f32 = sum_ok / test_results.dims1()? as f32;
+                .to_scalar::<u32>()?;
+            let test_cases = test_results.dims1()?;
+            let test_accuracy: f32 = test_cases_passed as f32 / test_cases as f32;
             final_accuracy = f32::from(100u8) * test_accuracy;
             println!(
-                "Epoch: {epoch:3} Train loss: {:8.5} Test accuracy: {:5.2}%",
+                "Epoch: {epoch:3} Train loss: {:8.5} Test accuracy: {:5.5}% ({}/{})",
                 loss.to_scalar::<f32>()?,
-                final_accuracy
+                final_accuracy,
+                test_cases_passed,
+                test_cases,
             );
         }
         Ok(final_accuracy)
@@ -348,7 +392,7 @@ impl<C: Class> Classifier<C> {
     /// ```
     pub fn run(&mut self, input: &[f32]) -> Result<C> {
         let input = Tensor::from_vec(input.to_vec(), (1, input.len()), &self.device)?;
-        let logits = self.forward(&input)?;
+        let logits = self.forward_t(&input, false)?;
         let class = logits
             .flatten_to(1)?
             .argmax(D::Minus1)?
@@ -364,6 +408,8 @@ pub struct ClassifierConfig {
     input_dim: usize,
     /// The dimensions of the layers.
     layers_dims: Vec<usize>,
+    /// The dropout rate.
+    dropout_rate: f32,
 }
 
 impl ClassifierConfig {
@@ -372,12 +418,19 @@ impl ClassifierConfig {
         Self {
             input_dim,
             layers_dims: vec![4, 8, 4],
+            dropout_rate: 0.1,
         }
     }
 
     /// Set the dimensions of the layers.
     pub fn layers_dims(mut self, layers_dims: Vec<usize>) -> Self {
         self.layers_dims = layers_dims;
+        self
+    }
+
+    /// Set the dropout rate.
+    pub fn dropout_rate(mut self, dropout_rate: f32) -> Self {
+        self.dropout_rate = dropout_rate;
         self
     }
 }


### PR DESCRIPTION
A few improvements to kalosm-learning to make classifier heads on top of bert models more usable:
- Save and load methods for classifier heads
- A dropout layer to reduce overfitting
- Exposing the learning rate for more training flexibility