### PR TITLE
Fix memory usage and add batch sizes to classifier training

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drawille"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e461c3f1e69d99372620640b3fd5f0309eeda2e26e4af69f6760c0e1df845"
+dependencies = [
+ "colored",
+ "fnv",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6305,6 +6315,7 @@ dependencies = [
  "kalosm-learning-macro",
  "rand 0.8.5",
  "rbert",
+ "textplots",
  "tokio",
  "tokio-util",
 ]
@@ -9520,6 +9531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11888,6 +11908,16 @@ dependencies = [
  "regex",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "textplots"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59b64803118dbff62f92842b3154a2c802dfd8e18660132bbcbfb141c637ae3"
+dependencies = [
+ "drawille",
+ "rgb",
 ]
 
 [[package]]

--- a/interfaces/kalosm-learning/Cargo.toml
+++ b/interfaces/kalosm-learning/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.8.5"
 anyhow = "1.0.75"
 tokio = { version = "1.34.0", features = ["full"] }
 kalosm-common.workspace = true
+textplots = "0.8"
 
 [dev-dependencies]
 rbert.workspace = true

--- a/interfaces/kalosm-learning/examples/classify.rs
+++ b/interfaces/kalosm-learning/examples/classify.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &dev,
             ClassifierConfig::new(384).layers_dims(layers.clone()),
         )?);
-        if let Err(error) = classifier.train(&dataset, &dev, 100, 0.0003) {
+        if let Err(error) = classifier.train(&dataset, &dev, 100, 0.0003, 100) {
             println!("Error: {:?}", error);
         } else {
             break;

--- a/interfaces/kalosm-learning/src/classifier/text_classifier.rs
+++ b/interfaces/kalosm-learning/src/classifier/text_classifier.rs
@@ -199,8 +199,10 @@ impl<T: Class, S: VectorSpace + Send + Sync + 'static> TextClassifier<T, S> {
         device: &Device,
         epochs: usize,
         learning_rate: f64,
+        batch_size: usize,
     ) -> anyhow::Result<f32> {
-        self.model.train(dataset, device, epochs, learning_rate)
+        self.model
+            .train(dataset, device, epochs, learning_rate, batch_size)
     }
 
     /// Get the configuration of the classifier.
@@ -311,7 +313,7 @@ async fn simplified() -> anyhow::Result<()> {
             &dev,
             ClassifierConfig::new(384).layers_dims(layers.clone()),
         )?);
-        if let Err(error) = classifier.train(&dataset, &dev, 100, 0.05) {
+        if let Err(error) = classifier.train(&dataset, &dev, 100, 0.05, 100) {
             println!("Error: {:?}", error);
         } else {
             break;


### PR DESCRIPTION
This PR fixes two issues with memory usage in the classifier training code:
1) Candle only releases memory on metal after you exit an autorelease pool. The classifier code was not using any manual autorelease pools which caused a leak
2) The classifier training code puts all examples into a single large batch which performs poorly if you have a lot of data. This PR introduces a batch size which runs backpropagation on a subset of the dataset at once