### PR TITLE
Add a separate method for embedding queries

### DIFF
--- a/interfaces/kalosm-language/src/context/io/mod.rs
+++ b/interfaces/kalosm-language/src/context/io/mod.rs
@@ -85,7 +85,7 @@ impl IntoDocument for FsDocument {
 ///     let documents = DocumentFolder::try_from(PathBuf::from("./documents")).unwrap();
 ///
 ///     let mut database = DocumentDatabase::new(
-///         Bert::builder().build().unwrap(),
+///         Bert::new_for_search().unwrap(),
 ///         ChunkStrategy::Sentence {
 ///             sentence_count: 1,
 ///             overlap: 0,

--- a/interfaces/kalosm-language/src/vector_db.rs
+++ b/interfaces/kalosm-language/src/vector_db.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// #[tokio::main]
 /// async fn main() -> anyhow::Result<()> {
-///     let mut bert = Bert::builder().build()?;
+///     let mut bert = Bert::new_for_search()?;
 ///     let sentences = [
 ///         "Cats are cool",
 ///         "The geopolitical situation is dire",
@@ -42,8 +42,7 @@ use serde::{Deserialize, Serialize};
 ///     let mut db = VectorDB::new()?;
 ///     println!("added {:?}", db.add_embeddings(embeddings)?);
 ///     // Find the closest sentence to "Cats are good"
-///     let embedding = bert.embed("Cats are good").await?;
-///     let closest = db.get_closest(embedding, 1)?;
+///     let closest = db.get_closest("Cats are good", 1)?;
 ///     println!("closest: {:?}", closest);
 ///
 ///     Ok(())

--- a/interfaces/kalosm/README.md
+++ b/interfaces/kalosm/README.md
@@ -181,7 +181,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let documents = DocumentFolder::try_from(PathBuf::from("./documents")).unwrap();
 
     let mut database = DocumentDatabase::new(
-        Bert::builder().build().unwrap(),
+        Bert::new_for_search().unwrap(),
         ChunkStrategy::Sentence {
             sentence_count: 1,
             overlap: 0,

--- a/interfaces/kalosm/examples/live-qa.rs
+++ b/interfaces/kalosm/examples/live-qa.rs
@@ -65,11 +65,6 @@ async fn main() -> Result<(), anyhow::Error> {
         // Ask the user for a question
         let user_question = prompt_input("\n> ").unwrap();
 
-        let user_question = format!(
-            "Represent this sentence for searching relevant passages: {}",
-            user_question
-        );
-
         // Search for relevant context in the document engine
         let context = document_table
             .select_nearest(&user_question, 5)

--- a/interfaces/kalosm/examples/semantic-chunk.rs
+++ b/interfaces/kalosm/examples/semantic-chunk.rs
@@ -15,10 +15,7 @@ async fn main() -> anyhow::Result<()> {
         .parse()?;
 
     let start_loading_time = Instant::now();
-    let bert = Bert::builder()
-        .with_source(BertSource::snowflake_arctic_embed_extra_small())
-        .build()
-        .await?;
+    let bert = Bert::new_for_search().await?;
     println!("Loaded in {:?}", start_loading_time.elapsed());
 
     let semantic_chunker = SemanticChunker::new().with_target_score(target_score);

--- a/interfaces/kalosm/examples/semantic-search.rs
+++ b/interfaces/kalosm/examples/semantic-search.rs
@@ -15,8 +15,10 @@ async fn main() {
     // Select a specific namespace / database
     db.use_ns("test").use_db("test").await.unwrap();
 
+    // Create a chunker splits the document into chunks to be embedded
     let chunker = SemanticChunker::new();
 
+    // Create a table in the surreal database to store the embeddings
     let document_table = db
         .document_table_builder("documents")
         .with_embedding_model(
@@ -33,6 +35,7 @@ async fn main() {
         .unwrap();
 
     if !exists {
+        // If the database is new, add documents to it
         let start_time = std::time::Instant::now();
         std::fs::create_dir_all("documents").unwrap();
         let context = [
@@ -49,28 +52,20 @@ async fn main() {
         .iter()
         .map(|url| Url::parse(url).unwrap());
 
-        // Create a new document database table
         document_table.add_context(context).await.unwrap();
         println!("Added context in {:?}", start_time.elapsed());
     }
 
     loop {
+        // Get the user's question
         let user_question = prompt_input("Query: ").unwrap();
-        let user_question = format!(
-            "Represent this sentence for searching relevant passages: {}",
-            user_question
-        );
-        let user_question_embedding = document_table
-            .embedding_model()
-            .embed(user_question)
-            .await
-            .unwrap();
 
         let nearest_5 = document_table
-            .select_nearest_embedding(user_question_embedding, 5)
+            .select_nearest(user_question, 5)
             .await
             .unwrap();
 
+        // Display the results in a pretty table
         let mut table = Table::new();
         table.set_content_arrangement(comfy_table::ContentArrangement::DynamicFullWidth);
         table.load_preset(comfy_table::presets::UTF8_FULL);

--- a/interfaces/kalosm/src/lib.rs
+++ b/interfaces/kalosm/src/lib.rs
@@ -10,7 +10,9 @@ pub mod language {
     pub use kalosm_common::FileSource;
     pub use kalosm_language::chat::*;
     pub use kalosm_language::context::*;
-    pub use kalosm_language::kalosm_language_model::{Model as _, ModelExt as _, *};
+    pub use kalosm_language::kalosm_language_model::{
+        Embedder as _, EmbedderExt as _, Model as _, ModelExt as _, *,
+    };
     pub use kalosm_language::kalosm_llama::{Llama, LlamaBuilder, LlamaSession, LlamaSource};
     pub use kalosm_language::kalosm_sample::*;
     pub use kalosm_language::prelude::Html;

--- a/interfaces/kalosm/src/prompt_annealing.rs
+++ b/interfaces/kalosm/src/prompt_annealing.rs
@@ -123,7 +123,7 @@ where
             (self.train, self.test)
         };
 
-        let bert = Bert::builder().build().await?;
+        let bert = Bert::new().await?;
 
         // Calculate embeddings for all examples
         let mut embedded_train_set = Vec::new();

--- a/interfaces/kalosm/src/surrealdb_integration/document_table.rs
+++ b/interfaces/kalosm/src/surrealdb_integration/document_table.rs
@@ -124,31 +124,18 @@ impl<C: Connection, R, M: Embedder, K: Chunker> DocumentTable<C, R, M, K> {
         self.table.select_all().await
     }
 
-    /// Select the top k records nearest records to the given record.
+    /// Select the top k records nearest records to the given item.
+    ///
+    /// NOTE: If your embedding model has a different query embedding and you pass in a raw embedding, that embedding will perform best if it was created with [`EmbedderExt::embed_query`].
     pub async fn select_nearest(
         &self,
-        record: impl IntoDocument,
+        embedding: impl IntoEmbedding<M::VectorSpace>,
         k: usize,
     ) -> anyhow::Result<Vec<EmbeddingIndexedTableSearchResult<R>>>
     where
         R: DeserializeOwned,
     {
-        let embedding = self
-            .embedding_model
-            .embed(record.into_document().await?.body())
-            .await?;
-        self.select_nearest_embedding(embedding, k).await
-    }
-
-    /// Select the top k records nearest records to the given embedding.
-    pub async fn select_nearest_embedding(
-        &self,
-        embedding: Embedding<M::VectorSpace>,
-        k: usize,
-    ) -> anyhow::Result<Vec<EmbeddingIndexedTableSearchResult<R>>>
-    where
-        R: DeserializeOwned,
-    {
+        let embedding = embedding.into_embedding(&self.embedding_model).await?;
         self.table.select_nearest(embedding, k).await
     }
 }
@@ -237,7 +224,7 @@ impl<C: Connection, E, K: Chunker> DocumentTableBuilder<C, E, K> {
             Some(embedding_model) => embedding_model,
             None => {
                 if TypeId::of::<E>() == TypeId::of::<Bert>() {
-                    let embedding_model = Bert::new().await?;
+                    let embedding_model = Bert::new_for_search().await?;
                     *(Box::new(embedding_model) as Box<dyn Any>)
                         .downcast::<E>()
                         .unwrap()

--- a/interfaces/language-model/src/embedding/into_embedding.rs
+++ b/interfaces/language-model/src/embedding/into_embedding.rs
@@ -1,0 +1,52 @@
+use futures_util::Future;
+
+use crate::{Embedder, EmbedderExt, Embedding, VectorSpace};
+
+/// Convert a type into an embedding with an embedding model.
+pub trait IntoEmbedding<S: VectorSpace> {
+    /// Convert the type into an embedding with the given embedding model.
+    fn into_embedding<E: Embedder<VectorSpace = S>>(
+        self,
+        embedder: &E,
+    ) -> impl Future<Output = anyhow::Result<Embedding<S>>>;
+
+    /// Convert the type into a query embedding with the given embedding model.
+    fn into_query_embedding<E: Embedder<VectorSpace = S>>(
+        self,
+        embedder: &E,
+    ) -> impl Future<Output = anyhow::Result<Embedding<S>>>;
+}
+
+/// Convert any type that implements [`ToString`] into an embedding with an embedding model.
+impl<S: ToString, V: VectorSpace> IntoEmbedding<V> for S {
+    async fn into_embedding<E: Embedder<VectorSpace = V>>(
+        self,
+        embedder: &E,
+    ) -> anyhow::Result<Embedding<V>> {
+        embedder.embed(self).await
+    }
+
+    async fn into_query_embedding<E: Embedder<VectorSpace = V>>(
+        self,
+        embedder: &E,
+    ) -> anyhow::Result<Embedding<V>> {
+        embedder.embed_query(self).await
+    }
+}
+
+/// Convert an embedding of the same vector space into an embedding with an embedding model.
+impl<S: VectorSpace> IntoEmbedding<S> for Embedding<S> {
+    async fn into_embedding<E: Embedder<VectorSpace = S>>(
+        self,
+        _: &E,
+    ) -> anyhow::Result<Embedding<S>> {
+        Ok(self)
+    }
+
+    async fn into_query_embedding<E: Embedder<VectorSpace = S>>(
+        self,
+        _: &E,
+    ) -> anyhow::Result<Embedding<S>> {
+        Ok(self)
+    }
+}

--- a/interfaces/language-model/src/embedding/mod.rs
+++ b/interfaces/language-model/src/embedding/mod.rs
@@ -13,6 +13,8 @@ mod cache;
 pub use cache::*;
 mod model;
 pub use model::*;
+mod into_embedding;
+pub use into_embedding::*;
 
 /// An untyped vector space that is not associated with a model. This can be used to erase the vector type from an embedding.
 pub struct UnknownVectorSpace;

--- a/interfaces/language-model/src/remote/open_ai.rs
+++ b/interfaces/language-model/src/remote/open_ai.rs
@@ -240,6 +240,24 @@ impl AdaEmbedder {
 impl Embedder for AdaEmbedder {
     type VectorSpace = AdaEmbedding;
 
+    fn embed_for(
+        &self,
+        input: crate::EmbeddingInput,
+    ) -> BoxedFuture<'_, anyhow::Result<Embedding<Self::VectorSpace>>> {
+        self.embed_string(input.text)
+    }
+
+    fn embed_vec_for(
+        &self,
+        inputs: Vec<crate::EmbeddingInput>,
+    ) -> BoxedFuture<'_, anyhow::Result<Vec<Embedding<Self::VectorSpace>>>> {
+        let inputs = inputs
+            .into_iter()
+            .map(|input| input.text)
+            .collect::<Vec<_>>();
+        self.embed_vec(inputs)
+    }
+
     /// Embed a single string.
     fn embed_string(
         &self,

--- a/models/rbert/src/language_model.rs
+++ b/models/rbert/src/language_model.rs
@@ -3,7 +3,8 @@ use crate::BertBuilder;
 use crate::Pooling;
 use kalosm_common::*;
 pub use kalosm_language_model::{
-    Embedder, EmbedderCacheExt, EmbedderExt, Embedding, ModelBuilder, VectorSpace,
+    Embedder, EmbedderCacheExt, EmbedderExt, Embedding, EmbeddingInput, EmbeddingVariant,
+    ModelBuilder, VectorSpace,
 };
 use serde::Deserialize;
 use serde::Serialize;
@@ -31,7 +32,7 @@ impl Bert {
         input: &str,
         pooling: Pooling,
     ) -> anyhow::Result<Embedding<BertSpace>> {
-        let mut tensors = self.embed_batch_raw(std::iter::once(input), pooling)?;
+        let mut tensors = self.embed_batch_raw(vec![input], pooling)?;
 
         Ok(Embedding::new(tensors.pop().unwrap()))
     }
@@ -39,10 +40,10 @@ impl Bert {
     /// Embed a batch of sentences with a specific pooling strategy.
     pub fn embed_batch_with_pooling(
         &self,
-        inputs: &[&str],
+        inputs: Vec<&str>,
         pooling: Pooling,
     ) -> anyhow::Result<Vec<Embedding<BertSpace>>> {
-        let tensors = self.embed_batch_raw(inputs.iter().copied(), pooling)?;
+        let tensors = self.embed_batch_raw(inputs, pooling)?;
 
         let mut embeddings = Vec::with_capacity(tensors.len());
         for tensor in tensors {
@@ -55,6 +56,40 @@ impl Bert {
 
 impl Embedder for Bert {
     type VectorSpace = BertSpace;
+
+    fn embed_for(
+        &self,
+        input: EmbeddingInput,
+    ) -> BoxedFuture<'_, anyhow::Result<Embedding<Self::VectorSpace>>> {
+        match (&*self.embedding_search_prefix, input.variant) {
+            (Some(prefix), EmbeddingVariant::Query) => {
+                let mut new_input = prefix.clone();
+                new_input.push_str(&input.text);
+                self.embed_string(new_input)
+            }
+            _ => self.embed_string(input.text),
+        }
+    }
+
+    fn embed_vec_for(
+        &self,
+        inputs: Vec<EmbeddingInput>,
+    ) -> BoxedFuture<'_, anyhow::Result<Vec<Embedding<Self::VectorSpace>>>> {
+        let inputs = inputs
+            .into_iter()
+            .map(
+                |input| match (&*self.embedding_search_prefix, input.variant) {
+                    (Some(prefix), EmbeddingVariant::Query) => {
+                        let mut new_input = prefix.clone();
+                        new_input.push_str(&input.text);
+                        new_input
+                    }
+                    _ => input.text,
+                },
+            )
+            .collect::<Vec<_>>();
+        self.embed_vec(inputs)
+    }
 
     fn embed_string(&self, input: String) -> BoxedFuture<'_, anyhow::Result<Embedding<BertSpace>>> {
         Box::pin(async move {
@@ -72,7 +107,7 @@ impl Embedder for Bert {
             let self_clone = self.clone();
             tokio::task::spawn_blocking(move || {
                 let inputs_borrowed = inputs.iter().map(|s| s.as_str()).collect::<Vec<_>>();
-                self_clone.embed_batch_with_pooling(&inputs_borrowed, Pooling::CLS)
+                self_clone.embed_batch_with_pooling(inputs_borrowed, Pooling::CLS)
             })
             .await?
         })

--- a/models/rbert/src/source.rs
+++ b/models/rbert/src/source.rs
@@ -1,13 +1,27 @@
 use kalosm_common::FileSource;
 
+const SNOWFLAKE_EMBEDDING_PREFIX: &str =
+    "Represent this sentence for searching relevant passages: ";
+
 /// A the source of a [`Bert`] model
 pub struct BertSource {
+    pub(crate) search_embedding_prefix: Option<String>,
     pub(crate) config: FileSource,
     pub(crate) tokenizer: FileSource,
     pub(crate) model: FileSource,
 }
 
 impl BertSource {
+    /// Create a new [`BertSource`] for embedding plain text
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new [`BertSource`] for embedding text for search
+    pub fn new_for_search() -> Self {
+        Self::snowflake_arctic_embed_extra_small()
+    }
+
     /// Set the model to use, check out available models: <https://huggingface.co/models?library=sentence-transformers&sort=trending>
     pub fn with_model(mut self, model: FileSource) -> Self {
         self.model = model;
@@ -23,6 +37,15 @@ impl BertSource {
     /// Set the config to use
     pub fn with_config(mut self, config: FileSource) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Set the prefix to use when embedding search queries
+    pub(crate) fn with_search_embedding_prefix(
+        mut self,
+        prefix: impl Into<Option<String>>,
+    ) -> Self {
+        self.search_embedding_prefix = prefix.into();
         self
     }
 
@@ -68,22 +91,24 @@ impl BertSource {
 
     /// Create a new [`BertSource`] with the BGE small english preset
     pub fn bge_small_en() -> Self {
-        Self::default()
-            .with_model(FileSource::huggingface(
-                "BAAI/bge-small-en-v1.5".to_string(),
-                "refs/pr/3".to_string(),
-                "model.safetensors".to_string(),
-            ))
-            .with_tokenizer(FileSource::huggingface(
-                "BAAI/bge-small-en-v1.5".to_string(),
-                "refs/pr/3".to_string(),
-                "tokenizer.json".to_string(),
-            ))
-            .with_config(FileSource::huggingface(
+        Self {
+            config: FileSource::huggingface(
                 "BAAI/bge-small-en-v1.5".to_string(),
                 "refs/pr/3".to_string(),
                 "config.json".to_string(),
-            ))
+            ),
+            tokenizer: FileSource::huggingface(
+                "BAAI/bge-small-en-v1.5".to_string(),
+                "refs/pr/3".to_string(),
+                "tokenizer.json".to_string(),
+            ),
+            model: FileSource::huggingface(
+                "BAAI/bge-small-en-v1.5".to_string(),
+                "refs/pr/3".to_string(),
+                "model.safetensors".to_string(),
+            ),
+            search_embedding_prefix: None,
+        }
     }
 
     /// Create a new [`BertSource`] with the MiniLM-L6-v2 preset
@@ -108,23 +133,23 @@ impl BertSource {
 
     /// Create a new [`BertSource`] with the [snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs) model
     pub fn snowflake_arctic_embed_extra_small() -> Self {
-        Self {
-            config: FileSource::huggingface(
+        Self::default()
+            .with_config(FileSource::huggingface(
                 "Snowflake/snowflake-arctic-embed-xs".to_string(),
                 "main".to_string(),
                 "config.json".to_string(),
-            ),
-            tokenizer: FileSource::huggingface(
+            ))
+            .with_tokenizer(FileSource::huggingface(
                 "Snowflake/snowflake-arctic-embed-xs".to_string(),
                 "main".to_string(),
                 "tokenizer.json".to_string(),
-            ),
-            model: FileSource::huggingface(
+            ))
+            .with_model(FileSource::huggingface(
                 "Snowflake/snowflake-arctic-embed-xs".to_string(),
                 "main".to_string(),
                 "model.safetensors".to_string(),
-            ),
-        }
+            ))
+            .with_search_embedding_prefix(SNOWFLAKE_EMBEDDING_PREFIX.to_string())
     }
 
     /// Create a new [`BertSource`] with the [snowflake-arctic-embed-s](https://huggingface.co/Snowflake/snowflake-arctic-embed-s) model
@@ -145,6 +170,7 @@ impl BertSource {
                 "main".to_string(),
                 "config.json".to_string(),
             ))
+            .with_search_embedding_prefix(SNOWFLAKE_EMBEDDING_PREFIX.to_string())
     }
 
     /// Create a new [`BertSource`] with the [snowflake-arctic-embed-m](https://huggingface.co/Snowflake/snowflake-arctic-embed-m) model
@@ -165,6 +191,7 @@ impl BertSource {
                 "main".to_string(),
                 "model.safetensors".to_string(),
             ))
+            .with_search_embedding_prefix(SNOWFLAKE_EMBEDDING_PREFIX.to_string())
     }
 
     /// Create a new [`BertSource`] with the [snowflake-arctic-embed-m-long](https://huggingface.co/Snowflake/snowflake-arctic-embed-m-long) model
@@ -187,6 +214,7 @@ impl BertSource {
                 "main".to_string(),
                 "config.json".to_string(),
             ))
+            .with_search_embedding_prefix(SNOWFLAKE_EMBEDDING_PREFIX.to_string())
     }
 
     /// Create a new [`BertSource`] with the [snowflake-arctic-embed-l](https://huggingface.co/Snowflake/snowflake-arctic-embed-l) model
@@ -207,11 +235,12 @@ impl BertSource {
                 "main".to_string(),
                 "config.json".to_string(),
             ))
+            .with_search_embedding_prefix(SNOWFLAKE_EMBEDDING_PREFIX.to_string())
     }
 }
 
 impl Default for BertSource {
     fn default() -> Self {
-        Self::snowflake_arctic_embed_extra_small()
+        Self::bge_small_en()
     }
 }


### PR DESCRIPTION
Many embedding models including the snowflake family of bert models embed queries in a different way then content. This PR adds a method to embed queries with the `Embedder` trait instead of manually adding the search prefix