### PR TITLE
Improve kalosm-learning docs and lazily find the input size

### DIFF
--- a/interfaces/kalosm-language/src/vector_db.rs
+++ b/interfaces/kalosm-language/src/vector_db.rs
@@ -37,13 +37,13 @@ use serde::{Deserialize, Serialize};
 /// // Embed sentences into the vector space
 /// let embeddings = bert.embed_batch(sentences).await.unwrap();
 /// println!("embeddings {:?}", embeddings);
-/// 
+///
 /// // Create a vector database from the embeddings along with a map between the embedding ids and the sentences
 /// let db = VectorDB::new().unwrap();
 /// let embeddings = db.add_embeddings(embeddings).unwrap();
 /// let embedding_id_to_sentence: HashMap<EmbeddingId, &str> =
 ///     HashMap::from_iter(embeddings.into_iter().zip(sentences));
-/// 
+///
 /// // Find the closest sentence to "What is Kalosm?"
 /// let query = "What is Kalosm?";
 /// // Embed the query into the vector space. We use `embed_query` instead of `embed` because some models embed queries differently than normal text.

--- a/interfaces/kalosm-learning/examples/classify.rs
+++ b/interfaces/kalosm-learning/examples/classify.rs
@@ -11,89 +11,83 @@ enum MyClass {
     Thing,
 }
 
+const PEOPLE_QUESTIONS: &[&str] = &[
+    "What is the author's name?",
+    "What is the author's age?",
+    "Who is the queen of England?",
+    "Who is the president of the United States?",
+    "Who is the president of France?",
+    "Tell me about the CEO of Apple.",
+    "Who is the CEO of Google?",
+    "Who is the CEO of Microsoft?",
+    "What person invented the light bulb?",
+    "What person invented the telephone?",
+    "What is the name of the person who invented the light bulb?",
+    "Who wrote the book 'The Lord of the Rings'?",
+    "Who wrote the book 'The Hobbit'?",
+    "How old is the author of the book 'The Lord of the Rings'?",
+    "How old is the author of the book 'The Hobbit'?",
+    "Who is the best soccer player in the world?",
+    "Who is the best basketball player in the world?",
+    "Who is the best tennis player in the world?",
+    "Who is the best soccer player in the world right now?",
+    "Who is the leader of the United States?",
+    "Who is the leader of France?",
+    "What is the name of the leader of the United States?",
+    "What is the name of the leader of France?",
+];
+const THING_QUESTIONS: &[&str] = &[
+    "What is the capital of France?",
+    "What is the capital of England?",
+    "What is the name of the biggest city in the world?",
+    "What tool do you use to cut a tree?",
+    "What tool do you use to cut a piece of paper?",
+    "What is a good book to read?",
+    "What is a good movie to watch?",
+    "What is a good song to listen to?",
+    "What is the best tool to use to create a website?",
+    "What is the best tool to use to create a mobile app?",
+    "How long does it take to fly from Paris to New York?",
+    "How do you make a cake?",
+    "How do you make a pizza?",
+    "How can you make a website?",
+    "What is the best way to learn a new language?",
+    "What is the best way to learn a new programming language?",
+    "What is a framework?",
+    "What is a library?",
+    "What is a good way to learn a new language?",
+    "What is a good way to learn a new programming language?",
+    "What is the city with the most people in the world?",
+    "What is the most spoken language in the world?",
+    "What is the most spoken language in the United States?",
+];
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut bert = Bert::builder().build().await?;
+    // Create a new Bert model
+    let mut bert = Bert::new().await?;
 
+    // Create a dataset for the classifier
     let dev = accelerated_device_if_available()?;
-    let person_questions = vec![
-        "What is the author's name?",
-        "What is the author's age?",
-        "Who is the queen of England?",
-        "Who is the president of the United States?",
-        "Who is the president of France?",
-        "Tell me about the CEO of Apple.",
-        "Who is the CEO of Google?",
-        "Who is the CEO of Microsoft?",
-        "What person invented the light bulb?",
-        "What person invented the telephone?",
-        "What is the name of the person who invented the light bulb?",
-        "Who wrote the book 'The Lord of the Rings'?",
-        "Who wrote the book 'The Hobbit'?",
-        "How old is the author of the book 'The Lord of the Rings'?",
-        "How old is the author of the book 'The Hobbit'?",
-        "Who is the best soccer player in the world?",
-        "Who is the best basketball player in the world?",
-        "Who is the best tennis player in the world?",
-        "Who is the best soccer player in the world right now?",
-        "Who is the leader of the United States?",
-        "Who is the leader of France?",
-        "What is the name of the leader of the United States?",
-        "What is the name of the leader of France?",
-    ];
-    let thing_sentences = vec![
-        "What is the capital of France?",
-        "What is the capital of England?",
-        "What is the name of the biggest city in the world?",
-        "What tool do you use to cut a tree?",
-        "What tool do you use to cut a piece of paper?",
-        "What is a good book to read?",
-        "What is a good movie to watch?",
-        "What is a good song to listen to?",
-        "What is the best tool to use to create a website?",
-        "What is the best tool to use to create a mobile app?",
-        "How long does it take to fly from Paris to New York?",
-        "How do you make a cake?",
-        "How do you make a pizza?",
-        "How can you make a website?",
-        "What is the best way to learn a new language?",
-        "What is the best way to learn a new programming language?",
-        "What is a framework?",
-        "What is a library?",
-        "What is a good way to learn a new language?",
-        "What is a good way to learn a new programming language?",
-        "What is the city with the most people in the world?",
-        "What is the most spoken language in the world?",
-        "What is the most spoken language in the United States?",
-    ];
-
     let mut dataset = TextClassifierDatasetBuilder::<MyClass, _>::new(&mut bert);
-
-    for question in &person_questions {
+    for question in PEOPLE_QUESTIONS {
         dataset.add(question, MyClass::Person).await?;
     }
-
-    for sentence in &thing_sentences {
+    for sentence in THING_QUESTIONS {
         dataset.add(sentence, MyClass::Thing).await?;
     }
-
     let dataset = dataset.build(&dev)?;
 
-    let mut classifier;
-    let layers = vec![3, 3, 3];
+    let mut classifier =
+        TextClassifier::<MyClass, BertSpace>::new(Classifier::new(&dev, ClassifierConfig::new())?);
 
-    loop {
-        classifier = TextClassifier::<MyClass, BertSpace>::new(Classifier::new(
-            &dev,
-            ClassifierConfig::new(384).layers_dims(layers.clone()),
-        )?);
-        if let Err(error) = classifier.train(&dataset, &dev, 100, 0.0003, 100) {
-            println!("Error: {:?}", error);
-        } else {
-            break;
-        }
-        println!("Retrying...");
-    }
+    classifier.train(
+        &dataset, // The dataset to train on
+        &dev,     // The device to train on
+        100,      // The number of epochs to train for
+        0.003,    // The learning rate
+        5,        // The batch size
+    )?;
 
     let config = classifier.config();
     classifier.save("classifier.safetensors")?;

--- a/interfaces/kalosm-learning/src/classifier/model.rs
+++ b/interfaces/kalosm-learning/src/classifier/model.rs
@@ -1,5 +1,5 @@
 use rand::prelude::SliceRandom;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::OnceLock};
 
 use candle_core::{
     safetensors::{self, Load},
@@ -9,7 +9,17 @@ use candle_nn::{loss, ops, Dropout, Linear, Module, ModuleT, Optimizer, VarBuild
 use kalosm_common::maybe_autoreleasepool;
 use rand::Rng;
 
-/// A class that a [`Classifier`] can predict.
+/// A class that a [`Classifier`] can predict. You can derive this trait for any enum with only unit values.
+///
+/// # Example
+/// ```rust
+/// # use kalosm_learning::*;
+/// #[derive(Debug, Clone, Copy, Class)]
+/// enum MyClass {
+///     Person,
+///     Thing,
+/// }
+///```
 pub trait Class {
     /// The number of classes.
     const CLASSES: u32;
@@ -36,6 +46,14 @@ impl ClassificationDataset {
     }
 
     /// Save the dataset to the given path.
+    /// 
+    /// # Example
+    /// ```rust
+    /// # use kalosm_learning::*;
+    /// let dev = candle_core::Device::Cpu;
+    /// let dataset = ClassificationDataset::load("dataset.safetensors", &dev).unwrap();
+    /// dataset.save("dataset_copy.safetensors").unwrap();
+    /// ```
     pub fn save<P: AsRef<std::path::Path>>(&self, path: P) -> Result<()> {
         let safetensors = HashMap::from([
             ("train_inputs".to_string(), self.train_inputs.clone()),
@@ -49,6 +67,13 @@ impl ClassificationDataset {
     }
 
     /// Load the dataset from the given path.
+    /// 
+    /// # Example
+    /// ```rust
+    /// # use kalosm_learning::*;
+    /// let dev = candle_core::Device::Cpu;
+    /// let dataset = ClassificationDataset::load("dataset.safetensors", &dev).unwrap();
+    /// ```
     pub fn load<P: AsRef<std::path::Path>>(path: P, dev: &Device) -> Result<Self> {
         let mut safetensors = safetensors::load(path, dev)?;
         Ok(Self {
@@ -84,6 +109,14 @@ impl<C: Class> ClassificationDatasetBuilder<C> {
     }
 
     /// Adds a pair of input and class to the dataset.
+    /// 
+    /// # Example
+    /// ```rust
+    /// # use kalosm_learning::*;
+    /// let mut dataset = ClassificationDatasetBuilder::new();
+    /// dataset.add(vec![1.0, 2.0, 3.0, 4.0], MyClass::Person);
+    /// dataset.add(vec![4.0, 3.0, 2.0, 1.0], MyClass::Thing);
+    /// ```
     pub fn add(&mut self, input: Vec<f32>, class: C) {
         if let Some(input_size) = self.input_size {
             debug_assert_eq!(input.len(), input_size, "input size mismatch");
@@ -94,7 +127,17 @@ impl<C: Class> ClassificationDatasetBuilder<C> {
         self.classes.push(class);
     }
 
-    /// Builds the dataset.
+    /// Builds the dataset and copies the data to the device passed in.
+    /// 
+    /// # Example
+    /// ```rust
+    /// # use kalosm_learning::*;
+    /// let dev = candle_core::Device::Cpu;
+    /// let mut dataset = ClassificationDatasetBuilder::new();
+    /// dataset.add(vec![1.0, 2.0, 3.0, 4.0], MyClass::Person);
+    /// dataset.add(vec![4.0, 3.0, 2.0, 1.0], MyClass::Thing);
+    /// let dataset = dataset.build(&dev).unwrap();
+    /// ```
     pub fn build(mut self, dev: &Device) -> Result<ClassificationDataset> {
         // split into train and test
         let mut rng = rand::thread_rng();
@@ -150,7 +193,8 @@ impl<C: Class> ClassificationDatasetBuilder<C> {
 pub struct Classifier<C: Class> {
     device: Device,
     varmap: VarMap,
-    layers: Vec<Linear>,
+    layers_dims: Vec<usize>,
+    layers: OnceLock<Vec<Linear>>,
     dropout: Dropout,
     dropout_rate: f32,
     phantom: std::marker::PhantomData<C>,
@@ -174,78 +218,26 @@ impl<C: Class> Classifier<C> {
     /// ```
     pub fn new(dev: &Device, config: ClassifierConfig) -> Result<Self> {
         let varmap = VarMap::new();
-        let vs = VarBuilder::from_varmap(&varmap, DType::F32, dev);
-        Self::new_inner(dev.clone(), varmap, vs, config)
+        Self::new_inner(dev.clone(), varmap, config)
     }
 
     /// Get the config of the classifier.
     pub fn config(&self) -> ClassifierConfig {
         ClassifierConfig {
-            input_dim: self.layers.first().unwrap().weight().dims2().unwrap().1,
-            layers_dims: {
-                let mut layers = self
-                    .layers
-                    .iter()
-                    .map(|l| l.weight().dims2().unwrap().0)
-                    .collect::<Vec<_>>();
-                layers.pop();
-                layers
-            },
+            layers_dims: self.layers_dims.clone(),
             dropout_rate: self.dropout_rate,
         }
     }
 
-    fn new_inner(
-        dev: Device,
-        varmap: VarMap,
-        vs: VarBuilder,
-        config: ClassifierConfig,
-    ) -> Result<Self> {
+    fn new_inner(dev: Device, varmap: VarMap, config: ClassifierConfig) -> Result<Self> {
         let ClassifierConfig {
-            input_dim,
             layers_dims,
             dropout_rate,
         } = config;
-        let output_dim = C::CLASSES;
-        if layers_dims.is_empty() {
-            return Ok(Self {
-                device: dev,
-                varmap,
-                layers: vec![candle_nn::linear(
-                    input_dim,
-                    output_dim as usize,
-                    vs.pp("ln0"),
-                )?],
-                dropout: Dropout::new(dropout_rate),
-                dropout_rate,
-                phantom: std::marker::PhantomData,
-            });
-        }
-        let mut layers = Vec::with_capacity(layers_dims.len() + 1);
-        layers.push(candle_nn::linear(
-            input_dim,
-            *layers_dims.first().unwrap(),
-            vs.pp("ln0"),
-        )?);
-        for (i, (in_dim, out_dim)) in layers_dims
-            .iter()
-            .zip(layers_dims.iter().skip(1))
-            .enumerate()
-        {
-            layers.push(candle_nn::linear(
-                *in_dim,
-                *out_dim,
-                vs.pp(&format!("ln{}", i + 1)),
-            )?);
-        }
-        layers.push(candle_nn::linear(
-            *layers_dims.last().unwrap(),
-            output_dim as usize,
-            vs.pp(format!("ln{}", layers_dims.len() + 1)),
-        )?);
         Ok(Self {
             device: dev,
-            layers,
+            layers: OnceLock::new(),
+            layers_dims,
             varmap,
             dropout: Dropout::new(dropout_rate),
             dropout_rate,
@@ -253,10 +245,49 @@ impl<C: Class> Classifier<C> {
         })
     }
 
+    fn layers(&self, input_dim: usize) -> candle_core::Result<&Vec<Linear>> {
+        if let Some(layers) = self.layers.get() {
+            return Ok(layers);
+        }
+        let vs = VarBuilder::from_varmap(&self.varmap, DType::F32, &self.device);
+        let output_dim = C::CLASSES;
+        let mut layers = Vec::with_capacity(self.layers_dims.len() + 1);
+        if self.layers_dims.is_empty() {
+            let layer = candle_nn::linear(input_dim, output_dim as usize, vs.pp("ln0"))?;
+            layers.push(layer);
+        } else {
+            layers.push(candle_nn::linear(
+                input_dim,
+                *self.layers_dims.first().unwrap(),
+                vs.pp("ln0"),
+            )?);
+            for (i, (in_dim, out_dim)) in self
+                .layers_dims
+                .iter()
+                .zip(self.layers_dims.iter().skip(1))
+                .enumerate()
+            {
+                layers.push(candle_nn::linear(
+                    *in_dim,
+                    *out_dim,
+                    vs.pp(&format!("ln{}", i + 1)),
+                )?);
+            }
+            layers.push(candle_nn::linear(
+                *self.layers_dims.last().unwrap(),
+                output_dim as usize,
+                vs.pp(format!("ln{}", self.layers_dims.len() + 1)),
+            )?);
+        }
+
+        Ok(self.layers.get_or_init(|| layers))
+    }
+
     fn forward_t(&self, xs: &Tensor, train: bool) -> Result<Tensor> {
         let xs = xs.clone();
         let mut xs = self.dropout.forward_t(&xs, train)?;
-        for layer in &self.layers {
+        let input_dim = *xs.dims().last().unwrap();
+        for layer in self.layers(input_dim)? {
             xs = layer.forward(&xs)?;
             xs = xs.gelu_erf()?;
         }
@@ -397,7 +428,6 @@ impl<C: Class> Classifier<C> {
         config: ClassifierConfig,
     ) -> Result<Self> {
         let varmap = VarMap::new();
-        let vs = VarBuilder::from_varmap(&varmap, DType::F32, dev);
         {
             let safetensors = unsafe { candle_core::safetensors::MmapedSafetensors::new(path) }?;
             let tensors = safetensors.tensors();
@@ -407,7 +437,7 @@ impl<C: Class> Classifier<C> {
                 tensor_data.insert(name.to_string(), Var::from_tensor(&tensor)?);
             }
         }
-        Self::new_inner(dev.clone(), varmap, vs, config)
+        Self::new_inner(dev.clone(), varmap, config)
     }
 
     /// Run the model on the given input.
@@ -472,27 +502,30 @@ impl<C: Class> ClassifierOutput<C> {
 #[derive(Debug, Clone)]
 /// A config for a [`Classifier`].
 pub struct ClassifierConfig {
-    /// The input dimension.
-    input_dim: usize,
     /// The dimensions of the layers.
     layers_dims: Vec<usize>,
     /// The dropout rate.
     dropout_rate: f32,
 }
 
+impl Default for ClassifierConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ClassifierConfig {
     /// Create a new config.
-    pub fn new(input_dim: usize) -> Self {
+    pub fn new() -> Self {
         Self {
-            input_dim,
             layers_dims: vec![4, 8, 4],
             dropout_rate: 0.1,
         }
     }
 
     /// Set the dimensions of the layers.
-    pub fn layers_dims(mut self, layers_dims: Vec<usize>) -> Self {
-        self.layers_dims = layers_dims;
+    pub fn layers_dims(mut self, layers_dims: impl IntoIterator<Item = usize>) -> Self {
+        self.layers_dims = layers_dims.into_iter().collect();
         self
     }
 

--- a/interfaces/kalosm-learning/src/classifier/model.rs
+++ b/interfaces/kalosm-learning/src/classifier/model.rs
@@ -46,7 +46,7 @@ impl ClassificationDataset {
     }
 
     /// Save the dataset to the given path.
-    /// 
+    ///
     /// # Example
     /// ```rust
     /// # use kalosm_learning::*;
@@ -67,7 +67,7 @@ impl ClassificationDataset {
     }
 
     /// Load the dataset from the given path.
-    /// 
+    ///
     /// # Example
     /// ```rust
     /// # use kalosm_learning::*;
@@ -109,7 +109,7 @@ impl<C: Class> ClassificationDatasetBuilder<C> {
     }
 
     /// Adds a pair of input and class to the dataset.
-    /// 
+    ///
     /// # Example
     /// ```rust
     /// # use kalosm_learning::*;
@@ -128,7 +128,7 @@ impl<C: Class> ClassificationDatasetBuilder<C> {
     }
 
     /// Builds the dataset and copies the data to the device passed in.
-    /// 
+    ///
     /// # Example
     /// ```rust
     /// # use kalosm_learning::*;


### PR DESCRIPTION
A few different improvements:
- More and more clear examples in kalosm-learning documentation
- Instead of manually passing in the input size of embeddings or other input to classification models, this PR lazily determines the input size based on training data