### PR TITLE
Improve kalosm feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd ./kalosm-hello-world
 3) Add Kalosm as a dependency
 ```sh
 cargo add kalosm --git https://github.com/floneum/floneum --features language
-# You can use `--features language,metal`, `--features language,cublas`, or `--features language,mkl` if your machine supports an accelerator
+# You can use `--features language,metal`, `--features language,cuda`, or `--features language,mkl` if your machine supports an accelerator
 cargo add tokio --features full
 ```
 4) Add this code to your `main.rs` file

--- a/floneum/plugin/Cargo.toml
+++ b/floneum/plugin/Cargo.toml
@@ -32,4 +32,4 @@ kalosm-common.workspace = true
 
 [features]
 metal = ["kalosm/metal"]
-cublas = ["kalosm/cublas"]
+cublas = ["kalosm/cuda"]

--- a/interfaces/kalosm/Cargo.toml
+++ b/interfaces/kalosm/Cargo.toml
@@ -93,7 +93,7 @@ features = ["sound", "language", "vision", "remote"]
 workspace = true
 
 [features]
-cublas = ["kalosm-language/cublas"]
+cublas = ["kalosm-language/cublas", "kalosm-vision/cublas", "kalosm-sound/cuda"]
 mkl = ["kalosm-language/mkl", "kalosm-vision/mkl", "kalosm-sound/mkl"]
 language = ["kalosm-language"]
 metal = ["kalosm-language/metal", "kalosm-vision/metal", "kalosm-sound/metal", "kalosm-common/metal"]

--- a/interfaces/kalosm/Cargo.toml
+++ b/interfaces/kalosm/Cargo.toml
@@ -93,7 +93,7 @@ features = ["sound", "language", "vision", "remote"]
 workspace = true
 
 [features]
-cublas = ["kalosm-language?/cublas", "kalosm-vision?/cublas", "kalosm-sound?/cuda"]
+cuda = ["kalosm-language?/cublas", "kalosm-vision?/cublas", "kalosm-sound?/cuda"]
 mkl = ["kalosm-language?/mkl", "kalosm-vision?/mkl", "kalosm-sound?/mkl"]
 language = ["kalosm-language"]
 metal = ["kalosm-language?/metal", "kalosm-vision?/metal", "kalosm-sound?/metal", "kalosm-common/metal"]

--- a/interfaces/kalosm/Cargo.toml
+++ b/interfaces/kalosm/Cargo.toml
@@ -93,10 +93,10 @@ features = ["sound", "language", "vision", "remote"]
 workspace = true
 
 [features]
-cublas = ["kalosm-language/cublas", "kalosm-vision/cublas", "kalosm-sound/cuda"]
-mkl = ["kalosm-language/mkl", "kalosm-vision/mkl", "kalosm-sound/mkl"]
+cublas = ["kalosm-language?/cublas", "kalosm-vision?/cublas", "kalosm-sound?/cuda"]
+mkl = ["kalosm-language?/mkl", "kalosm-vision?/mkl", "kalosm-sound?/mkl"]
 language = ["kalosm-language"]
-metal = ["kalosm-language/metal", "kalosm-vision/metal", "kalosm-sound/metal", "kalosm-common/metal"]
+metal = ["kalosm-language?/metal", "kalosm-vision?/metal", "kalosm-sound?/metal", "kalosm-common/metal"]
 sound = ["kalosm-sound"]
 surrealdb = ["dep:surrealdb"]
 vision = ["kalosm-vision"]


### PR DESCRIPTION
The PR introduces:

1.  Adds `kalosm-vision/cublas` and `kalosm-sound/cublas` when the root kalosm crate is compiled with cuda support enabled.
2. Respects optional dependency by adding `?` when specifying dependency features: previously compiling a project with  `kalosm = {default_features=false, features="vision, mkl"}` required to compile kalosm-language/sound too.
3. Renamed cublas feature flag to cuda: due to subcrates requiring cudnn I think it's better to rename it to the more generic name