### PR TITLE
Faster structured generation with sampler aware token decoding

### DIFF
--- a/interfaces/kalosm-language/src/chat.rs
+++ b/interfaces/kalosm-language/src/chat.rs
@@ -186,7 +186,7 @@ impl<Model: SyncModel> ChatSession<Model> {
                     state,
                     self.sampler.clone(),
                     on_token,
-                    Some(32),
+                    Some(64),
                 )?;
             }
             None => {

--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -409,7 +409,7 @@ where
                     state,
                     sampler,
                     on_token,
-                    Some(32),
+                    Some(64),
                 );
                 if parsed_tx.send(result).is_err() {
                     tracing::error!("Failed to send parsed result");

--- a/interfaces/kalosm-language/src/tool/mod.rs
+++ b/interfaces/kalosm-language/src/tool/mod.rs
@@ -297,7 +297,7 @@ Question: {question}
             validator_state,
             Arc::new(Mutex::new(GenerationParameters::default().sampler())),
             &mut add_token,
-            Some(32),
+            Some(64),
         )?;
 
         Ok(match result {

--- a/interfaces/language-model/src/model.rs
+++ b/interfaces/language-model/src/model.rs
@@ -410,7 +410,7 @@ pub trait ModelExt: Model + Send + Sync + 'static {
                     parser_state,
                     sampler,
                     |token| Ok(sender.send(token)?),
-                    Some(32),
+                    Some(64),
                 );
                 match result_sender.send(result) {
                     Ok(()) => {}

--- a/interfaces/language-model/src/token_stream.rs
+++ b/interfaces/language-model/src/token_stream.rs
@@ -188,7 +188,7 @@ impl TokenOutputStream {
     }
 
     /// Peek the next token.
-    pub fn peek_tokens(&self, tokens: Vec<u32>) -> Result<Vec<Option<String>>> {
+    pub fn peek_tokens(&self, tokens: &[u32]) -> Result<Vec<Option<String>>> {
         let prev_text = &self.current_text;
         let prev_text_len = prev_text.len();
         let results = tokens

--- a/models/kalosm-llama/examples/bench.rs
+++ b/models/kalosm-llama/examples/bench.rs
@@ -42,7 +42,11 @@ async fn main() {
         .unwrap();
         let prompt = "Hello world".repeat(600);
 
-        let tokens = model.tokenizer().encode(prompt.clone(), true).unwrap().len();
+        let tokens = model
+            .tokenizer()
+            .encode(prompt.clone(), true)
+            .unwrap()
+            .len();
         for _ in 0..100 {
             let start_time = std::time::Instant::now();
             let mut session = model.new_session().unwrap();

--- a/models/kalosm-llama/src/language_model.rs
+++ b/models/kalosm-llama/src/language_model.rs
@@ -47,7 +47,7 @@ impl Model for Llama {
     ) -> anyhow::Result<()> {
         match self.task_sender.send(Task::RunSync { callback: f }) {
             Ok(_) => Ok(()),
-            Err(_) => Err(anyhow::anyhow!("Failed to send task to Phi thread")),
+            Err(_) => Err(anyhow::anyhow!("Failed to send task to Llama thread")),
         }
     }
 


### PR DESCRIPTION
Instead of decoding every token that could possibly be generated by the LLM, this PR makes decoding the possible next tokens aware of the top-k sampling that will be applied to the tokens. For loose constraints (like `[\w ]+`), this can improve performance significantly. Instead of detokenizing every one of the ~120000 tokens, we can just detokenize the ~64 the llm is actually sampling from