### PR TITLE
Add attributes to modify unit, enum and struct parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6533,10 +6533,12 @@ dependencies = [
 name = "kalosm-parse-macro"
 version = "0.2.1"
 dependencies = [
+ "kalosm",
  "proc-macro2",
  "quote",
  "regex-automata 0.4.7",
  "syn 2.0.68",
+ "tokio",
 ]
 
 [[package]]

--- a/interfaces/kalosm-parse-macro/Cargo.toml
+++ b/interfaces/kalosm-parse-macro/Cargo.toml
@@ -14,5 +14,9 @@ quote = "1.0"
 proc-macro2 = "1.0.86"
 regex-automata = "0.4.5"
 
+[dev-dependencies]
+kalosm = { workspace = true, features = ["language"] }
+tokio = { version = "1.28.1", features = ["full"] }
+
 [lib]
 proc-macro = true

--- a/interfaces/kalosm-parse-macro/src/lib.rs
+++ b/interfaces/kalosm-parse-macro/src/lib.rs
@@ -14,7 +14,11 @@ pub fn derive_parse(input: TokenStream) -> TokenStream {
             syn::Fields::Named(fields) => {
                 let ty = input.ident;
                 if fields.named.is_empty() {
-                    return TokenStream::from(impl_unit_parser(&ty, quote! { Self {} }));
+                    return TokenStream::from(impl_unit_parser(
+                        &input.attrs,
+                        &ty,
+                        quote! { Self {} },
+                    ));
                 }
 
                 let field_names = fields.named.iter().map(|f| f.ident.as_ref().unwrap());
@@ -26,7 +30,11 @@ pub fn derive_parse(input: TokenStream) -> TokenStream {
                     }
                 };
 
-                let parser = field_parser(&fields.named.iter().collect::<Vec<_>>(), construct);
+                let parser = match field_parser(&fields.named.iter().collect::<Vec<_>>(), construct)
+                {
+                    Ok(parser) => parser,
+                    Err(err) => return err.to_compile_error().into(),
+                };
                 let expanded = quote! {
                     impl kalosm_sample::Parse for #ty {
                         fn new_parser() -> impl kalosm_sample::SendCreateParserState<Output = Self> {
@@ -39,7 +47,7 @@ pub fn derive_parse(input: TokenStream) -> TokenStream {
             }
             syn::Fields::Unit => {
                 let ty = input.ident;
-                TokenStream::from(impl_unit_parser(&ty, quote! { Self }))
+                TokenStream::from(impl_unit_parser(&input.attrs, &ty, quote! { Self }))
             }
             _ => syn::Error::new(
                 input.ident.span(),
@@ -62,7 +70,10 @@ pub fn derive_parse(input: TokenStream) -> TokenStream {
                 .any(|variant| !matches!(&variant.fields, syn::Fields::Unit));
 
             if has_fields {
-                full_enum_parser(data, ty)
+                match full_enum_parser(input.attrs, data, ty) {
+                    Ok(parser) => parser,
+                    Err(err) => err.to_compile_error(),
+                }
             } else {
                 unit_enum_parser(data, ty)
             }
@@ -105,8 +116,8 @@ fn quote_fields(fields: Fields) -> TokenStream2 {
     }
 }
 
-fn impl_unit_parser(ty: &Ident, construct: TokenStream2) -> TokenStream2 {
-    let unit_parser = unit_parser(ty);
+fn impl_unit_parser(attrs: &[syn::Attribute], ty: &Ident, construct: TokenStream2) -> TokenStream2 {
+    let unit_parser = unit_parser(attrs, ty);
     quote! {
         impl kalosm_sample::Parse for #ty {
             fn new_parser() -> impl kalosm_sample::SendCreateParserState<Output = Self> {
@@ -117,32 +128,99 @@ fn impl_unit_parser(ty: &Ident, construct: TokenStream2) -> TokenStream2 {
     }
 }
 
-fn unit_parser(ty: &Ident) -> TokenStream2 {
-    let ty_string = LitStr::new(&format!("\"{}\"", ty.unraw()), ty.span());
+fn unit_parser(attrs: &[syn::Attribute], ty: &Ident) -> TokenStream2 {
+    // Look for #[parse(rename = "name")] attribute
+    let mut ty_string = ty.unraw().to_string();
+    for attr in attrs.iter() {
+        if attr.path().is_ident("parse") {
+            let result = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("rename") {
+                    let value = meta
+                        .value()
+                        .and_then(|value| value.parse::<syn::LitStr>())?;
+                    ty_string = value.value();
+                    Ok(())
+                } else {
+                    Err(meta.error("expected `rename`"))
+                }
+            });
+            if let Err(err) = result {
+                return err.to_compile_error();
+            }
+        }
+    }
+
+    let ty_string = LitStr::new(&format!("\"{ty_string}\""), ty.span());
     quote! {
         kalosm_sample::LiteralParser::new(#ty_string)
     }
 }
 
-fn full_enum_parser(data: DataEnum, ty: Ident) -> TokenStream2 {
+fn full_enum_parser(
+    attrs: Vec<syn::Attribute>,
+    data: DataEnum,
+    ty: Ident,
+) -> syn::Result<TokenStream2> {
+    // Look for the tag and content attributes within the #[parse] attribute
+    let mut tag = "type".to_string();
+    let mut content = "data".to_string();
+    for attr in attrs.iter() {
+        if attr.path().is_ident("parse") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("tag") {
+                    let value = meta
+                        .value()
+                        .and_then(|value| value.parse::<syn::LitStr>())?;
+                    tag = value.value();
+                    Ok(())
+                } else if meta.path.is_ident("content") {
+                    let value = meta
+                        .value()
+                        .and_then(|value| value.parse::<syn::LitStr>())?;
+                    content = value.value();
+                    Ok(())
+                } else {
+                    Err(meta.error("expected `tag` or `content`"))
+                }
+            })?;
+        }
+    }
+
     let mut parser = None;
     for variant in data.variants.iter() {
-        let variant_name = &variant.ident;
+        let variant_ident = &variant.ident;
+        let mut variant_name = variant_ident.unraw().to_string();
+        // Look for #[parse(rename = "name")] attribute
+        for attr in variant.attrs.iter() {
+            if attr.path().is_ident("parse") {
+                attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("rename") {
+                        let value = meta
+                            .value()
+                            .and_then(|value| value.parse::<syn::LitStr>())?;
+                        variant_name = value.value();
+                        Ok(())
+                    } else {
+                        Err(meta.error("expected `rename`"))
+                    }
+                })?;
+            }
+        }
 
         let construct_variant = {
             let fields = quote_fields(variant.fields.clone());
             quote! {
-                Self::#variant_name #fields
+                Self::#variant_ident #fields
             }
         };
         let parse_variant = match &variant.fields {
             syn::Fields::Named(fields) => {
                 let parse_name_and_data = LitStr::new(
-                    &format!("{}\",\"data\":", variant_name.unraw()),
+                    &format!("{}\",\"{content}\":", variant_name),
                     variant.ident.span(),
                 );
                 let fields = fields.named.iter().collect::<Vec<_>>();
-                let field_parser = field_parser(&fields, construct_variant);
+                let field_parser = field_parser(&fields, construct_variant)?;
                 quote! {
                     kalosm_sample::LiteralParser::from(#parse_name_and_data).ignore_output_then(#field_parser)
                 }
@@ -150,15 +228,14 @@ fn full_enum_parser(data: DataEnum, ty: Ident) -> TokenStream2 {
             syn::Fields::Unnamed(fields) => {
                 let field_vec = fields.unnamed.iter().collect::<Vec<_>>();
                 let [inner] = *field_vec else {
-                    return syn::Error::new(
+                    return Err(syn::Error::new(
                         variant.ident.span(),
                         "Unnamed enum variants with more or less than one field are not supported",
-                    )
-                    .to_compile_error();
+                    ));
                 };
 
                 let parse_name_and_data = LitStr::new(
-                    &format!("{}\",\"data\":", variant_name.unraw()),
+                    &format!("{}\",\"{content}\":", variant_name),
                     variant.ident.span(),
                 );
                 let ty = &inner.ty;
@@ -169,7 +246,7 @@ fn full_enum_parser(data: DataEnum, ty: Ident) -> TokenStream2 {
             // If this is a unit variant, we can just parse the type
             syn::Fields::Unit => {
                 let lit_str_name =
-                    LitStr::new(&format!("{}\"", variant_name.unraw()), variant.ident.span());
+                    LitStr::new(&format!("{}\"", variant_name), variant.ident.span());
                 quote! {
                     kalosm_sample::LiteralParser::from(#lit_str_name).map_output(|_| #construct_variant)
                 }
@@ -190,15 +267,17 @@ fn full_enum_parser(data: DataEnum, ty: Ident) -> TokenStream2 {
         }
     }
 
-    quote! {
+    let struct_start = format!("{{\"{tag}\":\"");
+
+    Ok(quote! {
         impl kalosm_sample::Parse for #ty {
             fn new_parser() -> impl kalosm_sample::SendCreateParserState<Output = Self> {
-                kalosm_sample::LiteralParser::from(r#"{"type":""#)
+                kalosm_sample::LiteralParser::from(#struct_start)
                     .ignore_output_then(#parser)
                     .then_literal(r#"}"#)
             }
         }
-    }
+    })
 }
 
 fn unit_enum_parser(data: DataEnum, ty: Ident) -> TokenStream2 {
@@ -206,15 +285,12 @@ fn unit_enum_parser(data: DataEnum, ty: Ident) -> TokenStream2 {
     for variant in data.variants.iter() {
         let variant_name = &variant.ident;
         let fields = &variant.fields;
-        let lit_str_name = LitStr::new(
-            &format!("\"{}\"", variant_name.unraw()),
-            variant.ident.span(),
-        );
         let construct_variant = quote! {
             Self::#variant_name #fields
         };
+        let unit_parser = unit_parser(&variant.attrs, &ty);
         let parse_variant = quote! {
-            kalosm_sample::LiteralParser::from(#lit_str_name).map_output(|_| #construct_variant)
+            #unit_parser.map_output(|_| #construct_variant)
         };
         match &mut parser {
             Some(current) => {
@@ -246,7 +322,7 @@ fn wrap_tuple(ident: &Ident, current: TokenStream2) -> TokenStream2 {
     }
 }
 
-fn field_parser(fields: &[&Field], construct: TokenStream2) -> TokenStream2 {
+fn field_parser(fields: &[&Field], construct: TokenStream2) -> syn::Result<TokenStream2> {
     let mut parsers = Vec::new();
     let idents: Vec<_> = fields
         .iter()
@@ -254,38 +330,41 @@ fn field_parser(fields: &[&Field], construct: TokenStream2) -> TokenStream2 {
         .collect();
     for (i, (field, parser_ident)) in fields.iter().zip(idents.iter()).enumerate() {
         let ident = field.ident.as_ref().unwrap().unraw();
+
+        let mut field_name = field.ident.as_ref().unwrap().unraw().to_string();
+        let mut field_parser = {
+            let ty = &field.ty;
+            quote! {<#ty as kalosm_sample::Parse>::new_parser()}
+        };
+        // Look for #[parse(rename = "name")] or #[parse(with = expr)] attributes
+        for attr in field.attrs.iter() {
+            if attr.path().is_ident("parse") {
+                attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("rename") {
+                        let value = meta
+                            .value()
+                            .and_then(|value| value.parse::<syn::LitStr>())?;
+                        field_name = value.value();
+                        Ok(())
+                    } else if meta.path.is_ident("with") {
+                        let value = meta.value().and_then(|value| value.parse::<syn::Expr>())?;
+                        field_parser = value.into_token_stream();
+                        Ok(())
+                    } else {
+                        Err(meta.error("expected `rename` or `with`"))
+                    }
+                })?;
+            }
+        }
+
         let mut literal_text = String::new();
         if i == 0 {
             literal_text.push('{');
         } else {
             literal_text.push(',');
         }
-        literal_text.push_str(&format!("\"{}\":", field.ident.as_ref().unwrap().unraw()));
+        literal_text.push_str(&format!("\"{field_name}\":"));
         let literal_text = LitStr::new(&literal_text, ident.span());
-        // Try to grab the parser from the `#[parse(with = expr)]` attribute, otherwise use the default parser
-        let field_parser = if let Some(attr) = field
-            .attrs
-            .iter()
-            .find(|attr| attr.path().is_ident("parse"))
-        {
-            let mut parser = None;
-            let result = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("with") {
-                    let value = meta.value().and_then(|value| value.parse::<syn::Expr>())?;
-                    parser = Some(value.into_token_stream());
-                    Ok(())
-                } else {
-                    Err(meta.error("expected `with`"))
-                }
-            });
-            if let Err(err) = result {
-                return err.to_compile_error();
-            }
-            parser.to_token_stream()
-        } else {
-            let ty = &field.ty;
-            quote! {<#ty as kalosm_sample::Parse>::new_parser()}
-        };
 
         parsers.push(quote! {
             let #parser_ident = kalosm_sample::LiteralParser::from(#literal_text)
@@ -321,7 +400,7 @@ fn field_parser(fields: &[&Field], construct: TokenStream2) -> TokenStream2 {
         }
     }
 
-    quote! {
+    Ok(quote! {
         {
             #(
                 #parsers
@@ -331,5 +410,5 @@ fn field_parser(fields: &[&Field], construct: TokenStream2) -> TokenStream2 {
                 .then_literal(r#"}"#)
                 .map_output(|#output_tuple| #construct)
         }
-    }
+    })
 }

--- a/interfaces/kalosm-parse-macro/tests/enum.rs
+++ b/interfaces/kalosm-parse-macro/tests/enum.rs
@@ -1,0 +1,120 @@
+#![allow(unused)]
+
+use kalosm::language::*;
+
+#[derive(Parse, Clone)]
+#[parse(tag = "ty", content = "contents")]
+enum NamedEnum {
+    #[parse(rename = "person")]
+    Person { name: String, age: u32 },
+    #[parse(rename = "animal")]
+    Animal { name: String, species: String },
+}
+
+#[tokio::test]
+async fn named_enum() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(NamedEnum::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+
+    assert!(output.contains("\"ty\":"));
+    assert!(output.contains("\"contents\":"));
+    assert!(output.contains("\"ty\":\"person\"") || output.contains("\"ty\":\"animal\""));
+    assert!(output.contains("\"name\":"));
+    assert!(output.contains("\"age\":") || output.contains("\"species\":"));
+}
+
+#[derive(Parse, Clone)]
+enum MixedEnum {
+    Person {
+        #[parse(rename = "person")]
+        name: String,
+        age: u32,
+    },
+    Animal,
+    Turtle(String),
+}
+
+#[tokio::test]
+async fn mixed_enum() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(MixedEnum::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+}
+
+#[derive(Parse, Clone)]
+enum UnitEnum {
+    First,
+    #[parse(rename = "second")]
+    Second,
+}
+
+#[tokio::test]
+async fn unit_enum() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(UnitEnum::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+}
+
+#[derive(Parse, Clone)]
+enum TupleEnum {
+    First(String),
+    Second(String),
+}
+
+#[tokio::test]
+async fn tuple_enum() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(TupleEnum::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+
+    assert!(output.contains("\"type\":\"First\"") || output.contains("\"type\":\"Second\""));
+}

--- a/interfaces/kalosm-parse-macro/tests/struct.rs
+++ b/interfaces/kalosm-parse-macro/tests/struct.rs
@@ -1,0 +1,86 @@
+#![allow(unused)]
+
+use kalosm::language::*;
+
+#[derive(Parse, Clone, PartialEq, Debug)]
+#[parse(rename = "empty struct")]
+struct EmptyNamedStruct {}
+
+#[tokio::test]
+async fn empty_struct() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(EmptyNamedStruct::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .await
+        .unwrap();
+
+    assert_eq!(output, EmptyNamedStruct {});
+}
+
+#[derive(Parse, Clone)]
+struct NamedStruct {
+    #[parse(rename = "field name")]
+    name: String,
+    age: u32,
+}
+
+#[tokio::test]
+async fn named_struct() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(NamedStruct::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+
+    assert!(output.contains("\"field name\":"));
+    assert!(output.contains("\"age\":"));
+}
+
+#[derive(Parse, Clone)]
+struct WithStruct {
+    #[parse(with = StringParser::new(1..=10))]
+    name: String,
+    #[parse(rename = "field name")]
+    age: u32,
+}
+
+#[tokio::test]
+async fn with_struct() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(WithStruct::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+
+    assert!(output.contains("\"name\":"));
+    assert!(output.contains("\"field name\":"));
+}

--- a/interfaces/kalosm-parse-macro/tests/unit.rs
+++ b/interfaces/kalosm-parse-macro/tests/unit.rs
@@ -1,0 +1,52 @@
+#![allow(unused)]
+
+use kalosm::language::*;
+
+#[derive(Parse, Clone)]
+struct UnitStruct;
+
+#[tokio::test]
+async fn unit_struct() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(UnitStruct::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+
+    assert_eq!(output, "\"UnitStruct\"");
+}
+
+#[derive(Parse, Clone)]
+#[parse(rename = "unit struct")]
+struct RenamedUnit;
+
+#[tokio::test]
+async fn renamed_unit_struct() {
+    let model = Llama::builder()
+        .with_source(LlamaSource::tiny_llama_1_1b_chat())
+        .build()
+        .await
+        .unwrap();
+
+    let task = Task::builder("You generate json")
+        .with_constraints(RenamedUnit::new_parser())
+        .build();
+
+    let output = task
+        .run("What is the capital of France?", &model)
+        .all_text()
+        .await;
+    println!("{output}");
+
+    assert_eq!(output, "\"unit struct\"");
+}


### PR DESCRIPTION
This PR adds attributes with the same format as serde to modify how fields, variants, and unit types are parsed. It also adds a bunch of tests for structured generation