### PR TITLE
Create a compile time state machine for enum parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7393,7 +7393,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -12057,7 +12057,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/interfaces/kalosm-parse-macro/src/lib.rs
+++ b/interfaces/kalosm-parse-macro/src/lib.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use syn::{ext::IdentExt, parse_macro_input, DeriveInput, Field, Ident, LitStr};
-use syn::{DataEnum, Fields};
+use syn::{DataEnum, Fields, LitInt};
 
 /// Derive a default JSON parser for a unit value, struct or enum.
 ///
@@ -12,13 +14,15 @@ use syn::{DataEnum, Fields};
 ///
 /// ```rust
 /// # use kalosm::language::*;
-/// #[derive(Parse)]
+/// #[derive(Parse, Debug, Clone, PartialEq)]
 /// struct Person {
 ///     name: String,
 ///     age: u32,
 /// }
 ///
-/// let person = Person::new_parser().parse("{ \"name\": \"John\", \"age\": 30 }").unwrap().unwrap_finished();
+/// let parser = Person::new_parser();
+/// let state = parser.create_parser_state();
+/// let person = parser.parse(&state, b"{ \"name\": \"John\", \"age\": 30 } ").unwrap().unwrap_finished();
 /// assert_eq!(person.name, "John");
 /// assert_eq!(person.age, 30);
 /// ```
@@ -26,27 +30,31 @@ use syn::{DataEnum, Fields};
 /// Or an enum with unit variants:
 /// ```rust
 /// # use kalosm::language::*;
-/// #[derive(Parse)]
+/// #[derive(Parse, Debug, Clone, PartialEq)]
 /// enum Color {
 ///     Red,
 ///     Blue,
 ///     Green,
 /// }
 ///
-/// let color = Color::new_parser().parse("\"Red\"").unwrap().unwrap_finished();
+/// let parser = Color::new_parser();
+/// let state = parser.create_parser_state();
+/// let color = parser.parse(&state, b"\"Red\" ").unwrap().unwrap_finished();
 /// assert_eq!(color, Color::Red);
 /// ```
 ///
 /// You can even derive Parse for an enum with data variants:
 /// ```rust
 /// # use kalosm::language::*;
-/// #[derive(Parse)]
+/// #[derive(Parse, Debug, Clone, PartialEq)]
 /// enum Action {
 ///     Search { query: String },
 ///     Quit,
 /// }
 ///
-/// let action = Action::new_parser().parse("{ \"type\": \"Search\", \"data\": { \"query\": \"my query\" } }").unwrap().unwrap_finished();
+/// let parser = Action::new_parser();
+/// let state = parser.create_parser_state();
+/// let action = parser.parse(&state, b"{ \"type\": \"Search\", \"data\": { \"query\": \"my query\" } } ").unwrap().unwrap_finished();
 /// assert_eq!(action, Action::Search { query: "my query".to_string() });
 /// ```
 ///
@@ -58,14 +66,14 @@ use syn::{DataEnum, Fields};
 ///
 /// ```rust
 /// # use kalosm::language::*;
-/// #[derive(Parse)]
+/// #[derive(Parse, Clone)]
 /// struct Person {
 ///     #[parse(rename = "full name")]
 ///     name: String,
 ///     age: u32,
 /// }
 ///
-/// #[derive(Parse)]
+/// #[derive(Parse, Clone)]
 /// enum Color {
 ///     #[parse(rename = "red")]
 ///     Red,
@@ -233,12 +241,12 @@ fn impl_unit_parser(attrs: &[syn::Attribute], ty: &Ident, construct: TokenStream
     }
 }
 
-fn unit_parser(attrs: &[syn::Attribute], ty: &Ident) -> TokenStream2 {
+fn unit_parse_literal(attrs: &[syn::Attribute], ty: &Ident) -> syn::Result<String> {
     // Look for #[parse(rename = "name")] attribute
     let mut ty_string = ty.unraw().to_string();
     for attr in attrs.iter() {
         if attr.path().is_ident("parse") {
-            let result = attr.parse_nested_meta(|meta| {
+            attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("rename") {
                     let value = meta
                         .value()
@@ -248,14 +256,19 @@ fn unit_parser(attrs: &[syn::Attribute], ty: &Ident) -> TokenStream2 {
                 } else {
                     Err(meta.error("expected `rename`"))
                 }
-            });
-            if let Err(err) = result {
-                return err.to_compile_error();
-            }
+            })?;
         }
     }
 
-    let ty_string = LitStr::new(&format!("\"{ty_string}\""), ty.span());
+    Ok(format!("\"{ty_string}\""))
+}
+
+fn unit_parser(attrs: &[syn::Attribute], ty: &Ident) -> TokenStream2 {
+    let ty_string = match unit_parse_literal(attrs, ty) {
+        Ok(ty_string) => ty_string,
+        Err(err) => return err.to_compile_error(),
+    };
+    let ty_string = LitStr::new(&ty_string, ty.span());
     quote! {
         kalosm_sample::LiteralParser::new(#ty_string)
     }
@@ -386,35 +399,171 @@ fn full_enum_parser(
 }
 
 fn unit_enum_parser(data: DataEnum, ty: Ident) -> TokenStream2 {
-    let mut parser = None;
+    // We can derive an efficient state machine for unit enums
+    let parser_state = format_ident!("{}ParserState", ty);
+
+    let mut parse_construction_map = HashMap::new();
     for variant in data.variants.iter() {
         let variant_name = &variant.ident;
         let fields = &variant.fields;
         let construct_variant = quote! {
-            Self::#variant_name #fields
+            #ty::#variant_name #fields
         };
-        let unit_parser = unit_parser(&variant.attrs, variant_name);
-        let parse_variant = quote! {
-            #unit_parser.map_output(|_| #construct_variant)
+        let literal_string = match unit_parse_literal(&variant.attrs, variant_name) {
+            Ok(literal_string) => literal_string,
+            Err(err) => return err.to_compile_error(),
         };
-        match &mut parser {
-            Some(current) => {
-                *current = quote! {
-                    #current
-                        .or(
-                            #parse_variant
-                        )
-                };
+        parse_construction_map.insert(literal_string.as_bytes().to_vec(), construct_variant);
+    }
+
+    let mut prefix_state_map = HashMap::new();
+    let mut max_state = 0usize;
+    for bytes in parse_construction_map.keys() {
+        for i in 0..bytes.len() + 1 {
+            let prefix = &bytes[..i];
+            if prefix_state_map.contains_key(prefix) {
+                continue;
             }
-            None => {
-                parser = Some(parse_variant);
-            }
+            prefix_state_map.insert(prefix, max_state);
+            max_state += 1;
         }
     }
+
+    let mut parse_states = Vec::new();
+    for (state_prefix, state) in &prefix_state_map {
+        let state = LitInt::new(&state.to_string(), ty.span());
+
+        let mut next_bytes = Vec::new();
+        for (next_state_prefix, next_state) in &prefix_state_map {
+            if let Some(&[byte]) = next_state_prefix.strip_prefix(*state_prefix) {
+                let next_state = LitInt::new(&next_state.to_string(), ty.span());
+
+                next_bytes.push(quote! {
+                    #byte => state = #parser_state(#next_state),
+                });
+            }
+        }
+
+        let unrecognized_byte = if let Some(constructor) = parse_construction_map.get(*state_prefix)
+        {
+            quote! {
+                return kalosm_sample::ParseResult::Ok(kalosm_sample::ParseStatus::Finished {
+                    result: #constructor,
+                    remaining: &input[i..],
+                })
+            }
+        } else {
+            quote! {
+                return kalosm_sample::ParseResult::Err(kalosm_sample::ParserError::msg("Unrecognized byte"))
+            }
+        };
+
+        if !next_bytes.is_empty() {
+            parse_states.push(quote! {
+                #state => match byte {
+                    #(#next_bytes)*
+                    _ => #unrecognized_byte,
+                },
+            });
+        } else if parse_construction_map.contains_key(*state_prefix) {
+            parse_states.push(quote! {
+                #state => #unrecognized_byte,
+            });
+        }
+    }
+
+    let mut match_required_next = Vec::new();
+    for (state_prefix, state) in &prefix_state_map {
+        let state = LitInt::new(&state.to_string(), ty.span());
+        let mut required_next = Vec::new();
+        let mut current_prefix = state_prefix.to_vec();
+        loop {
+            let mut valid_next_bytes = Vec::new();
+            for prefix in prefix_state_map.keys() {
+                if let Some(&[byte]) = prefix.strip_prefix(current_prefix.as_slice()) {
+                    valid_next_bytes.push(byte);
+                }
+            }
+            if let [byte] = *valid_next_bytes {
+                current_prefix.push(byte);
+                required_next.push(byte);
+            } else {
+                break;
+            }
+        }
+        if !required_next.is_empty() {
+            let required_next_str = String::from_utf8_lossy(&required_next);
+            match_required_next.push(quote! {
+                #state => std::borrow::Cow::Borrowed(#required_next_str),
+            });
+        }
+    }
+
+    let state_type = if max_state <= u8::MAX as usize {
+        quote! { u8 }
+    } else if max_state <= u16::MAX as usize {
+        quote! { u16 }
+    } else if max_state <= u32::MAX as usize {
+        quote! { u32 }
+    } else if max_state <= u64::MAX as usize {
+        quote! { u64 }
+    } else {
+        quote! { u128 }
+    };
+
+    let impl_parser_state = quote! {
+        #[derive(Debug, Clone, Copy)]
+        struct #parser_state(#state_type);
+
+        impl #parser_state {
+            const fn new() -> Self {
+                Self(0)
+            }
+        }
+    };
+
+    let parser = format_ident!("{}Parser", ty);
+    let impl_parser = quote! {
+        struct #parser;
+
+        impl kalosm_sample::CreateParserState for #parser {
+            fn create_parser_state(&self) -> <Self as kalosm_sample::Parser>::PartialState {
+                #parser_state::new()
+            }
+        }
+        impl kalosm_sample::Parser for #parser {
+            type Output = #ty;
+            type PartialState = #parser_state;
+
+            fn parse<'a>(
+                &self,
+                state: &Self::PartialState,
+                input: &'a [u8],
+            ) -> kalosm_sample::ParseResult<kalosm_sample::ParseStatus<'a, Self::PartialState, Self::Output>> {
+                let mut state = *state;
+                for (i, byte) in input.iter().enumerate() {
+                    match state.0 {
+                        #(#parse_states)*
+                        _ => return kalosm_sample::ParseResult::Err(kalosm_sample::ParserError::msg("Invalid state")),
+                    }
+                }
+                kalosm_sample::ParseResult::Ok(kalosm_sample::ParseStatus::Incomplete {
+                    new_state: state,
+                    required_next: match state.0 {
+                        #(#match_required_next)*
+                        _ => std::borrow::Cow::Borrowed("")
+                    },
+                })
+            }
+        }
+    };
 
     quote! {
         impl kalosm_sample::Parse for #ty {
             fn new_parser() -> impl kalosm_sample::SendCreateParserState<Output = Self> {
+                #impl_parser_state
+                #impl_parser
+
                 #parser
             }
         }

--- a/interfaces/kalosm-parse-macro/tests/enum.rs
+++ b/interfaces/kalosm-parse-macro/tests/enum.rs
@@ -118,3 +118,18 @@ async fn tuple_enum() {
 
     assert!(output.contains("\"type\": \"First\"") || output.contains("\"type\": \"Second\""));
 }
+
+#[test]
+fn unit_enum_parses() {
+    #[derive(Parse, Debug, Clone, PartialEq)]
+    enum Color {
+        Red,
+        Blue,
+        Green,
+    }
+
+    let parser = Color::new_parser();
+    let state = parser.create_parser_state();
+    let color = parser.parse(&state, b"\"Red\" ").unwrap().unwrap_finished();
+    assert_eq!(color, Color::Red);
+}


### PR DESCRIPTION
This PR switches to a state machine with pre computed values for simple literal enum parsers. This is 10 times faster with 3 small literal strings, 25 times faster with 7 small literal strings, and 160 times faster with 62 slightly larger literal enums. It is also much more memory efficient. For the 62 variant enum, the parser was previously `1976` bytes and the partial state was `992` bytes. The parser is now `0` bytes and the partial state is `2` bytes