### PR TITLE
Fix the required next tokens for repeat parsers

### DIFF
--- a/interfaces/kalosm-sample/src/structured_parser/map.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/map.rs
@@ -1,3 +1,5 @@
+use std::{fmt::Debug, marker::PhantomData};
+
 use crate::{CreateParserState, ParseStatus, Parser};
 
 /// A parser that maps the output of another parser.
@@ -5,6 +7,28 @@ pub struct MapOutputParser<P: Parser, O, F = fn(<P as Parser>::Output) -> O> {
     pub(crate) parser: P,
     pub(crate) map: F,
     pub(crate) _output: std::marker::PhantomData<O>,
+}
+
+impl<P: Parser + Debug, O, F> Debug for MapOutputParser<P, O, F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.parser.fmt(f)
+    }
+}
+
+impl<P: Parser + PartialEq, O, F: PartialEq> PartialEq for MapOutputParser<P, O, F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.parser == other.parser && self.map == other.map
+    }
+}
+
+impl<P: Parser + Clone, O, F: Clone> Clone for MapOutputParser<P, O, F> {
+    fn clone(&self) -> Self {
+        Self {
+            parser: self.parser.clone(),
+            map: self.map.clone(),
+            _output: PhantomData,
+        }
+    }
 }
 
 impl<P: CreateParserState, O: Clone, F: Fn(P::Output) -> O> CreateParserState

--- a/interfaces/kalosm-sample/src/structured_parser/parse.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/parse.rs
@@ -9,17 +9,17 @@ use crate::{
 ///
 /// # Example
 /// ```rust
-/// use kalosm_sample::{Parse, SendCreateParserState, StringParser, IntegerParser};
+/// use kalosm_sample::*;
 ///
 /// // You can derive parse for structs with named fields that implement Parse
-/// #[derive(Parse)]
+/// #[derive(Parse, Clone)]
 /// struct Person {
 ///     name: String,
 ///     favorite_color: Color,
 /// }
 ///
 /// // You can derive parse for enums with only unit variants
-/// #[derive(Parse)]
+/// #[derive(Parse, Clone)]
 /// enum Color {
 ///     Red,
 ///     Blue,
@@ -32,6 +32,7 @@ use crate::{
 /// }
 ///
 /// // Or you can implement parse manually for custom types
+/// #[derive(Clone)]
 /// struct MyStruct(i64, String);
 ///
 /// impl Parse for MyStruct {


### PR DESCRIPTION
Repeat parsers were forwarding the required_next string even when it was valid to stop the sequence which causes repeat to generate the maximum of the range more often then it should