### PR TITLE
Make cloning repeat partial state very cheap with an immutable Arc Linked List

### DIFF
--- a/interfaces/kalosm/docs/vision.md
+++ b/interfaces/kalosm/docs/vision.md
@@ -34,19 +34,17 @@ Kalosm supports image segmentation with the [`SegmentAnything`] model. You can u
 ```rust, no_run
 use kalosm::vision::*;
 
-fn main() {
-    let model = SegmentAnything::builder().build().unwrap();
-    let image = image::open("examples/landscape.jpg").unwrap();
-    let x = image.width() / 2;
-    let y = image.height() / 4;
-    let images = model
-        .segment_from_points(
-            SegmentAnythingInferenceSettings::new(image)
-                .unwrap()
-                .add_goal_point(x, y),
-        )
-        .unwrap();
+let model = SegmentAnything::builder().build().unwrap();
+let image = image::open("examples/landscape.jpg").unwrap();
+let x = image.width() / 2;
+let y = image.height() / 4;
+let images = model
+    .segment_from_points(
+        SegmentAnythingInferenceSettings::new(image)
+            .unwrap()
+            .add_goal_point(x, y),
+    )
+    .unwrap();
 
-    images.save("out.png").unwrap();
-}
+images.save("out.png").unwrap();
 ```

--- a/interfaces/language-model/src/structured.rs
+++ b/interfaces/language-model/src/structured.rs
@@ -96,7 +96,10 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
 
                     // If we eliminated a logit, our partitioning of the logits is no longer valid
                     logits_indexed[i..].select_nth_unstable_by(logits_to_update, |a, b| {
-                        b.logit.partial_cmp(&a.logit).unwrap()
+                        // SAFETY: Logits should never be NaN or Inf
+                        let compare = b.logit.partial_cmp(&a.logit);
+                        debug_assert!(compare.is_some());
+                        unsafe { compare.unwrap_unchecked() }
                     });
                     // Expand the cache to include the new logits
                     partitioned_logits_index = Some(new_partitioned_index);


### PR DESCRIPTION
This PR switches from `Vec<T>` to `ArcLinkedList<T>` to store the results of the repeat parser. This avoids cloning the whole vec when parsing new tokens