### PR TITLE
Derive a JSON schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6104,6 +6104,7 @@ dependencies = [
  "kalosm",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.68",
  "tokio",
 ]
@@ -10205,12 +10206,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "indexmap 2.2.6",
  "itoa 1.0.11",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,6 +2752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6109,6 +6115,7 @@ dependencies = [
  "anyhow",
  "criterion",
  "kalosm-parse-macro",
+ "pretty_assertions",
  "rand 0.8.5",
  "regex-automata 0.4.7",
  "tracing-subscriber 0.3.18",
@@ -8513,6 +8520,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -12057,7 +12074,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -14105,6 +14122,12 @@ name = "xxhash-rust"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,6 +6102,7 @@ name = "kalosm-parse-macro"
 version = "0.2.1"
 dependencies = [
  "kalosm",
+ "pretty_assertions",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/interfaces/kalosm-parse-macro/Cargo.toml
+++ b/interfaces/kalosm-parse-macro/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro2 = "1.0.86"
 
 [dev-dependencies]
 kalosm = { workspace = true, features = ["language"] }
+serde_json = "1.0.122"
 tokio = { version = "1.28.1", features = ["full"] }
 
 [lib]

--- a/interfaces/kalosm-parse-macro/Cargo.toml
+++ b/interfaces/kalosm-parse-macro/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro2 = "1.0.86"
 kalosm = { workspace = true, features = ["language"] }
 serde_json = "1.0.122"
 tokio = { version = "1.28.1", features = ["full"] }
+pretty_assertions = "1.4.0"
 
 [lib]
 proc-macro = true

--- a/interfaces/kalosm-parse-macro/src/lib.rs
+++ b/interfaces/kalosm-parse-macro/src/lib.rs
@@ -537,8 +537,8 @@ impl EnumParser {
         Ok(quote! {
             impl kalosm_sample::Schema for #ty {
                 fn schema() -> kalosm_sample::SchemaType {
-                    kalosm_sample::SchemaType::AnyOf(
-                        kalosm_sample::AnyOfSchema::new([
+                    kalosm_sample::SchemaType::OneOf(
+                        kalosm_sample::OneOfSchema::new([
                             #(#variants),*
                         ])
                     )
@@ -669,6 +669,7 @@ impl UnitEnumVariantParser {
                             )
                         )
                     )
+                    .with_required(true)
                 ])
             )
         })
@@ -711,30 +712,26 @@ impl StructEnumVariantParser {
     ) -> syn::Result<proc_macro2::TokenStream> {
         let variant_parser = self.fields.quote_schema();
         Ok(quote! {
-            kalosm_sample::SchemaType::IfThen(IfThenSchema::new(
-                kalosm_sample::SchemaType::Object(
-                    kalosm_sample::JsonObjectSchema::new([
-                        kalosm_sample::JsonPropertySchema::new(
-                            #tag,
-                            kalosm_sample::SchemaType::Const(
-                                kalosm_sample::ConstSchema::new(
-                                    kalosm_sample::SchemaLiteral::String(#variant_name.to_string())
-                                )
+            kalosm_sample::SchemaType::Object(
+                kalosm_sample::JsonObjectSchema::new([
+                    kalosm_sample::JsonPropertySchema::new(
+                        #tag,
+                        kalosm_sample::SchemaType::Const(
+                            kalosm_sample::ConstSchema::new(
+                                kalosm_sample::SchemaLiteral::String(#variant_name.to_string())
                             )
                         )
-                    ])
-                ),
-                kalosm_sample::SchemaType::Object(
-                    kalosm_sample::JsonObjectSchema::new([
-                        kalosm_sample::JsonPropertySchema::new(
-                            #content,
-                            kalosm_sample::SchemaType::Object(
-                                #variant_parser
-                            )
+                    )
+                    .with_required(true),
+                    kalosm_sample::JsonPropertySchema::new(
+                        #content,
+                        kalosm_sample::SchemaType::Object(
+                            #variant_parser
                         )
-                    ])
-                )
-            ))
+                    )
+                    .with_required(true)
+                ])
+            )
         })
     }
 }
@@ -774,28 +771,24 @@ impl TupleEnumVariantParser {
     ) -> syn::Result<proc_macro2::TokenStream> {
         let ty = &self.field.ty;
         Ok(quote! {
-            kalosm_sample::SchemaType::IfThen(IfThenSchema::new(
-                kalosm_sample::SchemaType::Object(
-                    kalosm_sample::JsonObjectSchema::new([
-                        kalosm_sample::JsonPropertySchema::new(
-                            #tag,
-                            kalosm_sample::SchemaType::Const(
-                                kalosm_sample::ConstSchema::new(
-                                    kalosm_sample::SchemaLiteral::String(#variant_name.to_string())
-                                )
+            kalosm_sample::SchemaType::Object(
+                kalosm_sample::JsonObjectSchema::new([
+                    kalosm_sample::JsonPropertySchema::new(
+                        #tag,
+                        kalosm_sample::SchemaType::Const(
+                            kalosm_sample::ConstSchema::new(
+                                kalosm_sample::SchemaLiteral::String(#variant_name.to_string())
                             )
                         )
-                    ])
-                ),
-                kalosm_sample::SchemaType::Object(
-                    kalosm_sample::JsonObjectSchema::new([
-                        kalosm_sample::JsonPropertySchema::new(
-                            #content,
-                            <#ty as kalosm_sample::Schema>::schema()
-                        )
-                    ])
-                )
-            ))
+                    )
+                    .with_required(true),
+                    kalosm_sample::JsonPropertySchema::new(
+                        #content,
+                        <#ty as kalosm_sample::Schema>::schema()
+                    )
+                    .with_required(true)
+                ])
+            )
         })
     }
 }

--- a/interfaces/kalosm-parse-macro/src/lib.rs
+++ b/interfaces/kalosm-parse-macro/src/lib.rs
@@ -1194,7 +1194,7 @@ fn doc_comment(attrs: &[syn::Attribute]) -> Option<String> {
         let syn::Meta::NameValue(meta) = &attr.meta else {
             continue;
         };
-        if let Ok(lit_str) = syn::parse2::<syn::LitStr>(meta.value.to_token_stream()) { 
+        if let Ok(lit_str) = syn::parse2::<syn::LitStr>(meta.value.to_token_stream()) {
             if !description.is_empty() {
                 description.push('\n');
             }

--- a/interfaces/kalosm-parse-macro/tests/enum.rs
+++ b/interfaces/kalosm-parse-macro/tests/enum.rs
@@ -56,6 +56,58 @@ enum MixedEnum {
     Turtle(String),
 }
 
+#[test]
+fn mixed_enum_schema() {
+    let schema = MixedEnum::schema();
+    let json = serde_json::from_str::<serde_json::Value>(&schema.to_string()).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "anyOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "type": { "const": "Person" }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "data": {
+                                "properties": {
+                                    "person": {
+                                        "type": "string"
+                                    },
+                                    "age": { "type": "integer" }
+                                },
+                                "required": ["person", "age"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": { "const": "Animal" }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": { "const": "Turtle" }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "data": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            ]
+        })
+    );
+}
+
 #[tokio::test]
 async fn mixed_enum() {
     let model = Llama::builder()
@@ -77,9 +129,23 @@ async fn mixed_enum() {
 
 #[derive(Parse, Schema, Clone)]
 enum UnitEnum {
+    /// The first variant
     First,
+    /// The other variant
     #[parse(rename = "second")]
     Second,
+}
+
+#[test]
+fn unit_enum_schema() {
+    let schema = UnitEnum::schema();
+    let json = serde_json::from_str::<serde_json::Value>(&schema.to_string()).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "enum": ["First", "second"]
+        })
+    )
 }
 
 #[tokio::test]

--- a/interfaces/kalosm-parse-macro/tests/enum.rs
+++ b/interfaces/kalosm-parse-macro/tests/enum.rs
@@ -2,7 +2,7 @@
 
 use kalosm::language::*;
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 #[parse(tag = "ty", content = "contents")]
 enum NamedEnum {
     #[parse(rename = "person")]
@@ -45,7 +45,7 @@ async fn named_enum() {
     assert!(output.contains("\"age\":") || output.contains("\"species\":"));
 }
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 enum MixedEnum {
     Person {
         #[parse(rename = "person")]
@@ -75,7 +75,7 @@ async fn mixed_enum() {
     println!("{output}");
 }
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 enum UnitEnum {
     First,
     #[parse(rename = "second")]
@@ -101,7 +101,7 @@ async fn unit_enum() {
     println!("{output}");
 }
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 enum TupleEnum {
     First(String),
     Second(String),
@@ -130,7 +130,7 @@ async fn tuple_enum() {
 
 #[test]
 fn unit_enum_parses() {
-    #[derive(Parse, Debug, Clone, PartialEq)]
+    #[derive(Parse, Schema, Debug, Clone, PartialEq)]
     enum Color {
         Red,
         Blue,

--- a/interfaces/kalosm-parse-macro/tests/enum.rs
+++ b/interfaces/kalosm-parse-macro/tests/enum.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 
 use kalosm::language::*;
+use pretty_assertions::assert_eq;
 
 #[derive(Parse, Schema, Clone)]
 #[parse(tag = "ty", content = "contents")]
@@ -63,45 +64,42 @@ fn mixed_enum_schema() {
     assert_eq!(
         json,
         serde_json::json!({
-            "anyOf": [
+            "oneOf": [
                 {
-                    "if": {
-                        "properties": {
-                            "type": { "const": "Person" }
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "Person" },
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "person": {
+                                    "type": "string"
+                                },
+                                "age": { "type": "integer" }
+                            },
+                            "required": ["person", "age"],
+                            "additionalProperties": false
                         }
                     },
-                    "then": {
-                        "properties": {
-                            "data": {
-                                "properties": {
-                                    "person": {
-                                        "type": "string"
-                                    },
-                                    "age": { "type": "integer" }
-                                },
-                                "required": ["person", "age"]
-                            }
-                        }
-                    }
+                    "required": ["type", "data"],
+                    "additionalProperties": false
                 },
                 {
+                    "type": "object",
                     "properties": {
                         "type": { "const": "Animal" }
-                    }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
                 },
                 {
-                    "if": {
-                        "properties": {
-                            "type": { "const": "Turtle" }
-                        }
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "Turtle" },
+                        "data": { "type": "string" }
                     },
-                    "then": {
-                        "properties": {
-                            "data": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                    "required": ["type", "data"],
+                    "additionalProperties": false
                 }
             ]
         })

--- a/interfaces/kalosm-parse-macro/tests/enum.rs
+++ b/interfaces/kalosm-parse-macro/tests/enum.rs
@@ -6,9 +6,18 @@ use kalosm::language::*;
 #[parse(tag = "ty", content = "contents")]
 enum NamedEnum {
     #[parse(rename = "person")]
-    Person { name: String, age: u32 },
+    Person {
+        name: String,
+        #[parse(range = 0..=100)]
+        age: u32,
+    },
     #[parse(rename = "animal")]
-    Animal { name: String, species: String },
+    Animal {
+        #[parse(len = 1..=20)]
+        name: String,
+        #[parse(pattern = "cat|dog|bird")]
+        species: String,
+    },
 }
 
 #[tokio::test]

--- a/interfaces/kalosm-parse-macro/tests/struct.rs
+++ b/interfaces/kalosm-parse-macro/tests/struct.rs
@@ -26,11 +26,36 @@ async fn empty_struct() {
     assert_eq!(output, EmptyNamedStruct {});
 }
 
+/// A named struct
 #[derive(Parse, Schema, Clone)]
 struct NamedStruct {
     #[parse(rename = "field name")]
     name: String,
+    /// The age of the person
     age: u32,
+}
+
+#[test]
+fn named_struct_schema()  {
+    let schema = NamedStruct::schema();
+    let json = serde_json::from_str::<serde_json::Value>(&schema.to_string()).unwrap();
+    assert_eq!(json, serde_json::json!({
+        "title": "NamedStruct",
+        "description": "A named struct",
+        "properties": {
+            "field name": {
+                "type": "string"
+            },
+            "age": {
+                "description": "The age of the person",
+                "type": "integer"
+            }
+        },
+        "required": [
+            "field name",
+            "age"
+        ]
+    }));
 }
 
 #[tokio::test]

--- a/interfaces/kalosm-parse-macro/tests/struct.rs
+++ b/interfaces/kalosm-parse-macro/tests/struct.rs
@@ -1,10 +1,23 @@
 #![allow(unused)]
 
 use kalosm::language::*;
+use pretty_assertions::assert_eq;
 
 #[derive(Parse, Schema, Clone, PartialEq, Debug)]
 #[parse(rename = "empty struct")]
 struct EmptyNamedStruct {}
+
+#[test]
+fn empty_struct_schema() {
+    let schema = EmptyNamedStruct::schema();
+    let json = serde_json::from_str::<serde_json::Value>(&schema.to_string()).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "const": "empty struct"
+        })
+    )
+}
 
 #[tokio::test]
 async fn empty_struct() {
@@ -29,6 +42,7 @@ async fn empty_struct() {
 /// A named struct
 #[derive(Parse, Schema, Clone)]
 struct NamedStruct {
+    /// The name of the person
     #[parse(rename = "field name")]
     name: String,
     /// The age of the person
@@ -36,26 +50,30 @@ struct NamedStruct {
 }
 
 #[test]
-fn named_struct_schema()  {
+fn named_struct_schema() {
     let schema = NamedStruct::schema();
     let json = serde_json::from_str::<serde_json::Value>(&schema.to_string()).unwrap();
-    assert_eq!(json, serde_json::json!({
-        "title": "NamedStruct",
-        "description": "A named struct",
-        "properties": {
-            "field name": {
-                "type": "string"
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "title": "NamedStruct",
+            "description": "A named struct",
+            "properties": {
+                "field name": {
+                    "description": "The name of the person",
+                    "type": "string"
+                },
+                "age": {
+                    "description": "The age of the person",
+                    "type": "integer"
+                }
             },
-            "age": {
-                "description": "The age of the person",
-                "type": "integer"
-            }
-        },
-        "required": [
-            "field name",
-            "age"
-        ]
-    }));
+            "required": [
+                "field name",
+                "age"
+            ]
+        })
+    );
 }
 
 #[tokio::test]

--- a/interfaces/kalosm-parse-macro/tests/struct.rs
+++ b/interfaces/kalosm-parse-macro/tests/struct.rs
@@ -58,6 +58,7 @@ fn named_struct_schema() {
         serde_json::json!({
             "title": "NamedStruct",
             "description": "A named struct",
+            "type": "object",
             "properties": {
                 "field name": {
                     "description": "The name of the person",
@@ -71,7 +72,8 @@ fn named_struct_schema() {
             "required": [
                 "field name",
                 "age"
-            ]
+            ],
+            "additionalProperties": false
         })
     );
 }

--- a/interfaces/kalosm-parse-macro/tests/struct.rs
+++ b/interfaces/kalosm-parse-macro/tests/struct.rs
@@ -2,7 +2,7 @@
 
 use kalosm::language::*;
 
-#[derive(Parse, Clone, PartialEq, Debug)]
+#[derive(Parse, Schema, Clone, PartialEq, Debug)]
 #[parse(rename = "empty struct")]
 struct EmptyNamedStruct {}
 
@@ -26,7 +26,7 @@ async fn empty_struct() {
     assert_eq!(output, EmptyNamedStruct {});
 }
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 struct NamedStruct {
     #[parse(rename = "field name")]
     name: String,
@@ -55,7 +55,7 @@ async fn named_struct() {
     assert!(output.contains("\"age\":"));
 }
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 struct WithStruct {
     #[parse(with = StringParser::new(1..=10))]
     name: String,

--- a/interfaces/kalosm-parse-macro/tests/unit.rs
+++ b/interfaces/kalosm-parse-macro/tests/unit.rs
@@ -2,7 +2,7 @@
 
 use kalosm::language::*;
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 struct UnitStruct;
 
 #[tokio::test]
@@ -26,7 +26,7 @@ async fn unit_struct() {
     assert_eq!(output, "\"UnitStruct\"");
 }
 
-#[derive(Parse, Clone)]
+#[derive(Parse, Schema, Clone)]
 #[parse(rename = "unit struct")]
 struct RenamedUnit;
 

--- a/interfaces/kalosm-sample/Cargo.toml
+++ b/interfaces/kalosm-sample/Cargo.toml
@@ -17,6 +17,7 @@ kalosm-parse-macro = { workspace = true }
 tracing-subscriber = "0.3.18"
 criterion = "0.5.1"
 rand = "0.8.5"
+pretty_assertions = "1.4.0"
 
 [[bench]]
 name = "parse"

--- a/interfaces/kalosm-sample/src/structured_parser/mod.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/mod.rs
@@ -40,6 +40,8 @@ mod regex;
 pub use regex::*;
 mod arc_linked_list;
 pub(crate) use arc_linked_list::*;
+mod schema;
+pub use schema::*;
 
 /// An error that occurred while parsing.
 #[derive(Debug, Clone)]

--- a/interfaces/kalosm-sample/src/structured_parser/mod.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-pub use kalosm_parse_macro::Parse;
+pub use kalosm_parse_macro::*;
 mod integer;
 use std::{
     any::Any,

--- a/interfaces/kalosm-sample/src/structured_parser/parse.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/parse.rs
@@ -187,3 +187,12 @@ impl<const N: usize, T: Parse + Clone + Send + Sync> Parse for [T; N] {
         })
     }
 }
+
+impl<T: Parse> Parse for Option<T> {
+    fn new_parser() -> impl SendCreateParserState<Output = Self> {
+        let parser = T::new_parser();
+        parser
+            .map_output(|output| Some(output))
+            .or(LiteralParser::new("null").map_output(|_| None))
+    }
+}

--- a/interfaces/kalosm-sample/src/structured_parser/schema.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/schema.rs
@@ -282,8 +282,8 @@ impl StringSchema {
     }
 
     /// Set a regex pattern the string must match
-    pub fn with_pattern(mut self, pattern: impl Into<Option<String>>) -> Self {
-        self.pattern = pattern.into();
+    pub fn with_pattern(mut self, pattern: impl ToString) -> Self {
+        self.pattern = Some(pattern.to_string());
         self
     }
 }
@@ -562,8 +562,8 @@ impl JsonObjectSchema {
     }
 
     /// Set the title of the object
-    pub fn with_title(mut self, title: impl Into<Option<String>>) -> Self {
-        self.title = title.into();
+    pub fn with_title(mut self, title: impl ToString) -> Self {
+        self.title = Some(title.to_string());
         self
     }
 

--- a/interfaces/kalosm-sample/src/structured_parser/schema.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/schema.rs
@@ -583,10 +583,10 @@ impl Display for JsonObjectSchema {
             if let Some(title) = &self.title {
                 writer.write_str("\"title\": \"")?;
                 writer.write_str(title)?;
-                writer.write_str("\",")?;
+                writer.write_str("\",\n")?;
             }
             if let Some(description) = &self.description {
-                writer.write_fmt(format_args!("\"description\": \"{}\",", description))?;
+                writer.write_fmt(format_args!("\"description\": \"{}\",\n", description))?;
             }
             writer.write_str("\"properties\": {")?;
             if !self.properties.is_empty() {

--- a/interfaces/kalosm-sample/src/structured_parser/schema.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/schema.rs
@@ -1,0 +1,641 @@
+#[cfg(test)]
+use pretty_assertions::assert_eq;
+
+use std::{fmt::Display, fmt::Write};
+
+struct IndentationWriter<'a> {
+    indentation: usize,
+    writer: &'a mut dyn std::fmt::Write,
+}
+
+impl<'a> IndentationWriter<'a> {
+    fn new(indentation: usize, writer: &'a mut dyn std::fmt::Write) -> Self {
+        Self {
+            indentation,
+            writer,
+        }
+    }
+
+    fn with_indent<O>(&mut self, f: impl FnOnce(&mut Self) -> O) -> O {
+        self.indentation += 1;
+        let out = f(self);
+        self.indentation -= 1;
+        out
+    }
+}
+
+impl<'a> std::fmt::Write for IndentationWriter<'a> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        for char in s.chars() {
+            self.writer.write_char(char)?;
+            if char == '\n' {
+                for _ in 0..self.indentation {
+                    self.writer.write_char('\t')?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A literal value in a schema
+#[derive(Debug, Clone)]
+pub enum SchemaLiteral {
+    /// A string
+    String(String),
+    /// A number
+    Number(f64),
+    /// A boolean
+    Boolean(bool),
+    /// The null value
+    Null,
+}
+
+impl Display for SchemaLiteral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaLiteral::String(string) => write!(f, "\"{}\"", string),
+            SchemaLiteral::Number(number) => write!(f, "{}", number),
+            SchemaLiteral::Boolean(boolean) => write!(f, "{}", boolean),
+            SchemaLiteral::Null => write!(f, "null"),
+        }
+    }
+}
+
+/// The type of a schema
+#[derive(Debug, Clone)]
+pub enum SchemaType {
+    /// A string schema
+    String(StringSchema),
+    /// A floating point or integer schema
+    Number(NumberSchema),
+    /// An integer schema
+    Integer(IntegerSchema),
+    /// A boolean schema
+    Boolean(BooleanSchema),
+    /// An array schema
+    Array(ArraySchema),
+    /// An object schema
+    Object(JsonObjectSchema),
+    /// An enum schema
+    Enum(EnumSchema),
+    /// A schema that matches any of the composite schemas
+    AnyOf(AnyOfSchema),
+    /// The null schema
+    Null,
+}
+
+impl Display for SchemaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaType::String(schema) => schema.fmt(f),
+            SchemaType::Number(schema) => schema.fmt(f),
+            SchemaType::Integer(schema) => schema.fmt(f),
+            SchemaType::Boolean(schema) => schema.fmt(f),
+            SchemaType::Array(schema) => schema.fmt(f),
+            SchemaType::Object(schema) => schema.fmt(f),
+            SchemaType::Enum(schema) => schema.fmt(f),
+            SchemaType::AnyOf(schema) => schema.fmt(f),
+            SchemaType::Null => f.write_str("{ \"type\": \"null\" }"),
+        }
+    }
+}
+
+/// A schema that matches any of the composite schemas
+#[derive(Debug, Clone)]
+pub struct AnyOfSchema {
+    any_of: Vec<SchemaType>,
+}
+
+impl AnyOfSchema {
+    /// Create a new any of schema
+    pub fn new(any_of: impl IntoIterator<Item = SchemaType>) -> Self {
+        Self {
+            any_of: any_of.into_iter().collect(),
+        }
+    }
+}
+
+impl Display for AnyOfSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_char('{')?;
+        {
+            let mut writer = IndentationWriter::new(1, f);
+            writer.write_str("\n\"anyOf\": [")?;
+            if !self.any_of.is_empty() {
+                writer.with_indent(|writer| {
+                    for (i, schema) in self.any_of.iter().enumerate() {
+                        if i > 0 {
+                            writer.write_char(',')?;
+                        }
+                        write!(writer, "\n{}", schema)?;
+                    }
+                    Ok(())
+                })?;
+                writer.write_str("\n")?;
+            }
+            writer.write_str("]")?;
+        }
+        f.write_str(" }")
+    }
+}
+
+/// A schema for an enum
+#[derive(Debug, Clone)]
+pub struct EnumSchema {
+    variants: Vec<SchemaLiteral>,
+}
+
+impl EnumSchema {
+    /// Create a new enum schema
+    pub fn new(variants: impl IntoIterator<Item = SchemaLiteral>) -> Self {
+        Self {
+            variants: variants.into_iter().collect(),
+        }
+    }
+}
+
+impl Display for EnumSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_char('{')?;
+        {
+            let mut writer = IndentationWriter::new(1, f);
+            writer.write_str("\n\"enum\": [")?;
+            {
+                for (i, variant) in self.variants.iter().enumerate() {
+                    if i > 0 {
+                        writer.write_str(", ")?;
+                    }
+                    write!(writer, "{}", variant)?;
+                }
+            }
+            writer.write_str("]\n")?;
+        }
+        f.write_str(" }")
+    }
+}
+
+/// A schema for a string
+#[derive(Debug, Clone)]
+pub struct StringSchema {
+    /// The length that is valid for the string
+    length: Option<std::ops::RangeInclusive<usize>>,
+    /// The regex pattern that the string must match
+    pattern: Option<String>,
+}
+
+impl Schema for String {
+    fn schema() -> SchemaType {
+        SchemaType::String(StringSchema::new())
+    }
+}
+
+impl Default for StringSchema {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StringSchema {
+    /// Create a new string schema
+    pub fn new() -> Self {
+        Self {
+            length: None,
+            pattern: None,
+        }
+    }
+
+    /// Set the length range of the string
+    pub fn with_length(
+        mut self,
+        length: impl Into<Option<std::ops::RangeInclusive<usize>>>,
+    ) -> Self {
+        self.length = length.into();
+        self
+    }
+
+    /// Set a regex pattern the string must match
+    pub fn with_pattern(mut self, pattern: impl Into<Option<String>>) -> Self {
+        self.pattern = pattern.into();
+        self
+    }
+}
+
+impl Display for StringSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_char('{')?;
+        {
+            let mut writer = IndentationWriter::new(1, f);
+            writer.write_str("\n\"type\": \"string\"")?;
+            if let Some(length) = &self.length {
+                if *length.start() > 0 {
+                    writer.write_fmt(format_args!(",\n\"minLength\": {}", length.start()))?;
+                }
+                if *length.end() < usize::MAX {
+                    writer.write_fmt(format_args!(",\n\"maxLength\": {}", length.end()))?;
+                }
+            }
+            if let Some(pattern) = &self.pattern {
+                writer.write_fmt(format_args!(",\n\"pattern\": \"{}\"", pattern))?;
+            }
+        }
+        f.write_str("\n}")
+    }
+}
+
+/// A schema for a number (floating point or integer)
+#[derive(Debug, Clone)]
+pub struct NumberSchema {
+    /// The range that the number must be in
+    range: Option<std::ops::RangeInclusive<f64>>,
+}
+
+macro_rules! impl_schema_for_number {
+    ($ty:ty) => {
+        impl Schema for $ty {
+            fn schema() -> SchemaType {
+                SchemaType::Number(NumberSchema::new())
+            }
+        }
+    };
+}
+
+impl_schema_for_number!(f64);
+impl_schema_for_number!(f32);
+
+impl Default for NumberSchema {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NumberSchema {
+    /// Create a new number schema
+    pub fn new() -> Self {
+        Self { range: None }
+    }
+
+    /// Set the range of the number
+    pub fn with_range(mut self, range: impl Into<Option<std::ops::RangeInclusive<f64>>>) -> Self {
+        self.range = range.into();
+        self
+    }
+}
+
+impl Display for NumberSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.range {
+            Some(range) => {
+                f.write_char('{')?;
+                {
+                    let mut writer = IndentationWriter::new(1, f);
+                    writer.write_str("\n\"type\": \"number\",")?;
+                    writer.write_fmt(format_args!("\n\"minimum\": {},", range.start()))?;
+                    writer.write_fmt(format_args!("\n\"maximum\": {}", range.end()))?;
+                }
+                f.write_str("\n}")
+            }
+            None => f.write_str("{ \"type\": \"number\" }"),
+        }
+    }
+}
+
+#[test]
+fn test_number_schema() {
+    let schema = NumberSchema {
+        range: Some(0.0..=100.0),
+    };
+
+    assert_eq!(
+        schema.to_string(),
+        "{\n\t\"type\": \"number\",\n\t\"minimum\": 0,\n\t\"maximum\": 100\n}"
+    );
+
+    let schema = NumberSchema { range: None };
+
+    assert_eq!(schema.to_string(), "{ \"type\": \"number\" }");
+}
+
+/// A schema for an integer
+#[derive(Debug, Clone, Default)]
+
+pub struct IntegerSchema;
+
+macro_rules! impl_schema_for_integer {
+    ($ty:ty) => {
+        impl Schema for $ty {
+            fn schema() -> SchemaType {
+                SchemaType::Number(NumberSchema::new())
+            }
+        }
+    };
+}
+
+impl_schema_for_integer!(i128);
+impl_schema_for_integer!(i64);
+impl_schema_for_integer!(i32);
+impl_schema_for_integer!(i16);
+impl_schema_for_integer!(i8);
+impl_schema_for_integer!(isize);
+
+impl_schema_for_integer!(u128);
+impl_schema_for_integer!(u64);
+impl_schema_for_integer!(u32);
+impl_schema_for_integer!(u16);
+impl_schema_for_integer!(u8);
+impl_schema_for_integer!(usize);
+
+impl Display for IntegerSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("{ \"type\": \"integer\" }")
+    }
+}
+
+#[test]
+fn test_integer_schema() {
+    let schema = IntegerSchema;
+
+    assert_eq!(schema.to_string(), "{ \"type\": \"integer\" }");
+}
+
+/// A schema for a boolean
+#[derive(Debug, Clone, Default)]
+pub struct BooleanSchema;
+
+impl Display for BooleanSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("{ \"type\": \"boolean\" }")
+    }
+}
+
+#[test]
+fn test_boolean_schema() {
+    let schema = BooleanSchema;
+
+    assert_eq!(schema.to_string(), "{ \"type\": \"boolean\" }");
+}
+
+/// A schema for an array
+#[derive(Debug, Clone)]
+pub struct ArraySchema {
+    items: Box<SchemaType>,
+    length: Option<std::ops::RangeInclusive<usize>>,
+}
+
+impl<T: Schema> Schema for Vec<T> {
+    fn schema() -> SchemaType {
+        SchemaType::Array(ArraySchema::new(T::schema()))
+    }
+}
+
+impl<const N: usize, T: Schema> Schema for [T; N] {
+    fn schema() -> SchemaType {
+        SchemaType::Array(ArraySchema::new(T::schema()).with_length(N..=N))
+    }
+}
+
+impl ArraySchema {
+    /// Create a new array schema
+    pub fn new(items: SchemaType) -> Self {
+        Self {
+            items: Box::new(items),
+            length: None,
+        }
+    }
+
+    /// Set the length range of the array
+    pub fn with_length(
+        mut self,
+        length: impl Into<Option<std::ops::RangeInclusive<usize>>>,
+    ) -> Self {
+        self.length = length.into();
+        self
+    }
+}
+
+impl Display for ArraySchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_char('{')?;
+        {
+            let mut writer = IndentationWriter::new(1, f);
+            writer.write_str("\n\"type\": \"array\"")?;
+            writer.write_str(",\n\"items\": ")?;
+            write!(&mut writer, "{}", self.items)?;
+            if let Some(length) = &self.length {
+                if *length.start() > 0 {
+                    writer.write_str(",\n\"minItems\": ")?;
+                    write!(&mut writer, "{}", length.start())?;
+                }
+                if *length.end() < usize::MAX {
+                    writer.write_str(",\n\"maxItems\": ")?;
+                    write!(&mut writer, "{}", length.end())?;
+                }
+            }
+            writer.write_str(",\n\"unevaluatedItems\": false")?;
+        }
+        f.write_str("\n}")
+    }
+}
+
+#[test]
+fn test_array_schema() {
+    let schema = ArraySchema {
+        items: Box::new(SchemaType::String(StringSchema {
+            length: Some(1..=10),
+            pattern: None,
+        })),
+        length: Some(0..=10),
+    };
+
+    assert_eq!(schema.to_string(), "{\n\t\"type\": \"array\",\n\t\"items\": {\n\t\t\"type\": \"string\",\n\t\t\"minLength\": 1,\n\t\t\"maxLength\": 10\n\t},\n\t\"maxItems\": 10,\n\t\"unevaluatedItems\": false\n}");
+
+    let schema = ArraySchema {
+        items: Box::new(SchemaType::String(StringSchema {
+            length: None,
+            pattern: None,
+        })),
+        length: Some(1..=usize::MAX),
+    };
+
+    assert_eq!(schema.to_string(), "{\n\t\"type\": \"array\",\n\t\"items\": {\n\t\t\"type\": \"string\"\n\t},\n\t\"minItems\": 1,\n\t\"unevaluatedItems\": false\n}");
+    let schema = ArraySchema {
+        items: Box::new(SchemaType::String(StringSchema {
+            length: None,
+            pattern: None,
+        })),
+        length: None,
+    };
+
+    assert_eq!(schema.to_string(), "{\n\t\"type\": \"array\",\n\t\"items\": {\n\t\t\"type\": \"string\"\n\t},\n\t\"unevaluatedItems\": false\n}");
+}
+
+/// A schema for an object
+#[derive(Debug, Clone)]
+pub struct JsonObjectSchema {
+    title: String,
+    description: Option<&'static str>,
+    properties: Vec<JsonPropertySchema>,
+}
+
+impl JsonObjectSchema {
+    /// Create a new object schema
+    pub fn new(
+        title: impl ToString,
+        properties: impl IntoIterator<Item = JsonPropertySchema>,
+    ) -> Self {
+        Self {
+            title: title.to_string(),
+            description: None,
+            properties: properties.into_iter().collect(),
+        }
+    }
+
+    /// Set the description of the object
+    pub fn with_description(mut self, description: impl Into<Option<&'static str>>) -> Self {
+        self.description = description.into();
+        self
+    }
+}
+
+impl Display for JsonObjectSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_char('{')?;
+        {
+            let mut writer = IndentationWriter::new(1, f);
+            writer.write_str("\n\"title\": \"")?;
+            writer.write_str(&self.title)?;
+            writer.write_str("\"")?;
+            if let Some(description) = &self.description {
+                writer.write_fmt(format_args!(",\n\"description\": \"{}\"", description))?;
+            }
+            writer.write_str(",\n\"properties\": {")?;
+            if !self.properties.is_empty() {
+                writer.with_indent(|writer| {
+                    for (i, property) in self.properties.iter().enumerate() {
+                        if i > 0 {
+                            writer.write_char(',')?;
+                        }
+                        write!(writer, "\n{}", property)?;
+                    }
+                    Ok(())
+                })?;
+                writer.write_str("\n")?;
+            }
+            writer.write_str("}")?;
+            let required = self
+                .properties
+                .iter()
+                .filter_map(|property| (property.required).then_some(property.name.clone()))
+                .collect::<Vec<_>>();
+            if !required.is_empty() {
+                writer.write_str(",\n\"required\": [")?;
+                {
+                    for (i, required) in required.iter().enumerate() {
+                        if i > 0 {
+                            writer.write_str(", ")?;
+                        }
+                        write!(writer, "\"{}\"", required)?;
+                    }
+                }
+                f.write_str("]")?;
+            }
+        }
+        f.write_str("\n}")
+    }
+}
+
+#[test]
+fn test_object_schema() {
+    let schema = JsonObjectSchema {
+        title: "Person".to_string(),
+        description: Some("A person"),
+        properties: vec![
+            JsonPropertySchema {
+                name: "name".to_string(),
+                description: None,
+                required: true,
+                ty: SchemaType::String(StringSchema {
+                    length: Some(1..=10),
+                    pattern: None,
+                }),
+            },
+            JsonPropertySchema {
+                name: "age".to_string(),
+                description: None,
+                required: true,
+                ty: SchemaType::Number(NumberSchema {
+                    range: Some(0.0..=100.0),
+                }),
+            },
+            JsonPropertySchema {
+                name: "height".to_string(),
+                description: None,
+                required: false,
+                ty: SchemaType::Number(NumberSchema {
+                    range: Some(0.0..=500.0),
+                }),
+            },
+        ],
+    };
+
+    assert_eq!(schema.to_string(), "{\n\t\"title\": \"Person\",\n\t\"description\": \"A person\",\n\t\"properties\": {\n\t\t\"name\": {\n\t\t\t\"type\": \"string\",\n\t\t\t\"minLength\": 1,\n\t\t\t\"maxLength\": 10\n\t\t},\n\t\t\"age\": {\n\t\t\t\"type\": \"number\",\n\t\t\t\"minimum\": 0,\n\t\t\t\"maximum\": 100\n\t\t},\n\t\t\"height\": {\n\t\t\t\"type\": \"number\",\n\t\t\t\"minimum\": 0,\n\t\t\t\"maximum\": 500\n\t\t}\n\t},\n\t\"required\": [\"name\", \"age\"]\n}");
+}
+
+/// A schema for a property of an object
+#[derive(Debug, Clone)]
+pub struct JsonPropertySchema {
+    name: String,
+    description: Option<&'static str>,
+    required: bool,
+    ty: SchemaType,
+}
+
+impl JsonPropertySchema {
+    /// Create a new property schema
+    pub fn new(name: impl Into<String>, ty: SchemaType) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            required: false,
+            ty,
+        }
+    }
+
+    /// Set the description of the property
+    pub fn with_description(mut self, description: impl Into<Option<&'static str>>) -> Self {
+        self.description = description.into();
+        self
+    }
+
+    /// Set whether the property is required
+    pub fn with_required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+}
+
+impl Display for JsonPropertySchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("\"{}\": {}", self.name, self.ty))
+    }
+}
+
+/// A description of the format of a type
+pub trait Schema {
+    /// Get the schema for the type
+    fn schema() -> SchemaType;
+}
+
+impl<T: Schema> Schema for Option<T> {
+    fn schema() -> SchemaType {
+        SchemaType::AnyOf(AnyOfSchema {
+            any_of: vec![SchemaType::Null, T::schema()],
+        })
+    }
+}
+
+impl<T: Schema> Schema for Box<T> {
+    fn schema() -> SchemaType {
+        T::schema()
+    }
+}


### PR DESCRIPTION
Along with a parser, this PR derives a json schema to describe structs. Tool models often expect a json schema in the system prompt. This PR should make it a lot easier to use tool models like groq-llama-tools and generate synthetic data from those tool models