### PR TITLE
Implement prompt healing

### DIFF
--- a/interfaces/kalosm-sample/src/structured_parser/then.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/then.rs
@@ -215,24 +215,22 @@ pub struct ThenLazy<P1, F> {
     parser_fn: F,
 }
 
-impl<P1: Parser, P2: CreateParserState, F: FnOnce(&P1::Output) -> P2 + Copy> ThenLazy<P1, F> {
+impl<P1: Parser, P2: CreateParserState, F: Fn(&P1::Output) -> P2> ThenLazy<P1, F> {
     /// Create a new parser that is lazily initialized based on the output of the first parser.
     pub fn new(parser1: P1, parser_fn: F) -> Self {
         Self { parser1, parser_fn }
     }
 }
 
-impl<P1: CreateParserState, P2: CreateParserState, F: FnOnce(&P1::Output) -> P2 + Copy>
-    CreateParserState for ThenLazy<P1, F>
+impl<P1: CreateParserState, P2: CreateParserState, F: Fn(&P1::Output) -> P2> CreateParserState
+    for ThenLazy<P1, F>
 {
     fn create_parser_state(&self) -> <Self as Parser>::PartialState {
         ThenLazyParserState::FirstParser(self.parser1.create_parser_state())
     }
 }
 
-impl<P1: Parser, P2: CreateParserState, F: FnOnce(&P1::Output) -> P2 + Copy> Parser
-    for ThenLazy<P1, F>
-{
+impl<P1: Parser, P2: CreateParserState, F: Fn(&P1::Output) -> P2> Parser for ThenLazy<P1, F> {
     type Output = (P1::Output, P2::Output);
     type PartialState = ThenLazyParserState<P1, P2>;
 

--- a/interfaces/kalosm/README.md
+++ b/interfaces/kalosm/README.md
@@ -53,7 +53,7 @@ async fn main() {
     let prompt = "The following is a 300 word essay about Paris:";
     print!("{}", prompt);
 
-    let stream = llm.stream_text(prompt).with_max_length(1000).await.unwrap();
+    let mut stream = llm.stream_text(prompt).with_max_length(1000).await.unwrap();
 
     stream.to_std_out().await.unwrap();
 }
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let prompt = "The following is a 300 word essay about why the capital of France is Paris:";
     print!("{}", prompt);
 
-    let stream = llm.stream_text(prompt).with_max_length(1000).await.unwrap();
+    let mut stream = llm.stream_text(prompt).with_max_length(1000).await.unwrap();
 
     stream.to_std_out().await.unwrap();
 
@@ -143,7 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let prompt = "The following is a 300 word essay about why the capital of France is Paris:";
     print!("{}", prompt);
 
-    let stream = llm.stream_text(prompt).with_max_length(300).await.unwrap();
+    let mut stream = llm.stream_text(prompt).with_max_length(300).await.unwrap();
 
     stream.to_std_out().await.unwrap();
 
@@ -310,7 +310,7 @@ async fn main() -> anyhow::Result<()> {
         println!("{}", prompt);
 
         // And finally, respond to the user
-        let output_stream = chat.add_message(prompt);
+        let mut output_stream = chat.add_message(prompt);
         print!("Bot: ");
         output_stream.to_std_out().await?;
     }
@@ -339,7 +339,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // The audio into chunks based on voice activity and then transcribe those chunks
     // The model will transcribe chunks of speech that are separated by silence
-    let text_stream = stream.transcribe(model);
+    let mut text_stream = stream.transcribe(model);
 
     // Finally, print the text to the console
     text_stream.to_std_out().await.unwrap();

--- a/interfaces/kalosm/src/lib.rs
+++ b/interfaces/kalosm/src/lib.rs
@@ -30,6 +30,7 @@ pub mod language {
 #[cfg(feature = "sound")]
 pub mod sound {
     #![doc = include_str!("../docs/sound.md")]
+    pub use futures_util::StreamExt as _;
     pub use kalosm_sound::*;
     pub use kalosm_streams::text_stream::*;
     pub use kalosm_streams::timed_stream::*;

--- a/interfaces/language-model/src/token_stream.rs
+++ b/interfaces/language-model/src/token_stream.rs
@@ -188,7 +188,7 @@ impl TokenOutputStream {
         }
     }
 
-    /// Peek the next token.
+    /// Peek the next tokens
     pub fn peek_tokens(
         &self,
         tokens: impl IntoParallelIterator<Item = u32>,
@@ -211,6 +211,22 @@ impl TokenOutputStream {
             },
         ));
         Ok(())
+    }
+
+    /// Peek the next token.
+    pub fn peek_token(&self, token: u32) -> Result<Option<String>> {
+        let prev_text = &self.current_text;
+        let prev_text_len = prev_text.len();
+        let mut tokens = self.tokens[self.prev_index..].to_vec();
+        tokens.push(token);
+        let text = self.decode(&tokens)?;
+        tokens.pop();
+        if text.len() > prev_text_len && text.chars().last().unwrap().is_ascii() {
+            let text = text.split_at(prev_text_len);
+            Ok(Some(text.1.to_string()))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Get the tokens


### PR DESCRIPTION
This PR implements prompt healing for the initial prompt. LLMs view text as tokens, not text. Some sequence of tokens never appear in training data, but they may appear if you tokenize two sequences of text independently. Before this PR, kalosm tokenized the whole prompt and then fed those tokens to the LLM. The last token and the next required token may influence the probability of the next token in a negative way because we tokenize before all merges have been finished. This PR instead adds the text for the last token to the constraints which handles token healing automatically 