### PR TITLE
Fix chunked sorting logits structured

### DIFF
--- a/interfaces/kalosm-language/src/chat.rs
+++ b/interfaces/kalosm-language/src/chat.rs
@@ -188,7 +188,7 @@ impl<Model: SyncModel> ChatSession<Model> {
                     state,
                     self.sampler.clone(),
                     on_token,
-                    Some(16),
+                    Some(4),
                 )?;
                 let end_assistant_token = model
                     .tokenizer()

--- a/interfaces/kalosm-language/src/chat.rs
+++ b/interfaces/kalosm-language/src/chat.rs
@@ -188,7 +188,7 @@ impl<Model: SyncModel> ChatSession<Model> {
                     state,
                     self.sampler.clone(),
                     on_token,
-                    Some(64),
+                    Some(16),
                 )?;
                 let end_assistant_token = model
                     .tokenizer()

--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -411,7 +411,7 @@ where
                     state,
                     sampler,
                     on_token,
-                    Some(16),
+                    Some(4),
                 );
                 if parsed_tx.send(result).is_err() {
                     tracing::error!("Failed to send parsed result");

--- a/interfaces/kalosm-language/src/task.rs
+++ b/interfaces/kalosm-language/src/task.rs
@@ -411,7 +411,7 @@ where
                     state,
                     sampler,
                     on_token,
-                    Some(64),
+                    Some(16),
                 );
                 if parsed_tx.send(result).is_err() {
                     tracing::error!("Failed to send parsed result");

--- a/interfaces/kalosm-language/src/tool/mod.rs
+++ b/interfaces/kalosm-language/src/tool/mod.rs
@@ -297,7 +297,7 @@ Question: {question}
             validator_state,
             Arc::new(Mutex::new(GenerationParameters::default().sampler())),
             &mut add_token,
-            Some(16),
+            Some(4),
         )?;
 
         Ok(match result {

--- a/interfaces/kalosm-language/src/tool/mod.rs
+++ b/interfaces/kalosm-language/src/tool/mod.rs
@@ -297,7 +297,7 @@ Question: {question}
             validator_state,
             Arc::new(Mutex::new(GenerationParameters::default().sampler())),
             &mut add_token,
-            Some(64),
+            Some(16),
         )?;
 
         Ok(match result {

--- a/interfaces/language-model/src/structured.rs
+++ b/interfaces/language-model/src/structured.rs
@@ -123,6 +123,7 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
 
                     // If we eliminated a logit, our partitioning of the logits is no longer valid
                     logits_indexed[i..].select_nth_unstable_by(logits_to_update, cmp_logits);
+                    logits_indexed[i..=logits_to_update].sort_unstable_by(cmp_logits);
                     // Expand the cache to include the new logits
                     partitioned_logits_index = Some(new_partitioned_index);
                     token_cache.expand_with_logits(

--- a/interfaces/language-model/src/structured.rs
+++ b/interfaces/language-model/src/structured.rs
@@ -116,14 +116,14 @@ pub(crate) fn generate_structured<M: ?Sized + SyncModel, P: Parser>(
                 let remaining_needed = top_k - logits.len();
                 let remaining_possible = partitioned_index - i;
                 if remaining_possible <= remaining_needed {
-                    // We batch together updates to the cache by DETOKENIZATION_BATCH_SIZE
+                    // We batch together updates to the cache by detokenization_batch_size
                     let logits_to_update = (remaining_needed.max(detokenization_batch_size))
                         .min(logits_indexed.len() - 1 - i);
                     let new_partitioned_index = i + logits_to_update;
 
                     // If we eliminated a logit, our partitioning of the logits is no longer valid
                     logits_indexed[i..].select_nth_unstable_by(logits_to_update, cmp_logits);
-                    logits_indexed[i..=logits_to_update].sort_unstable_by(cmp_logits);
+                    logits_indexed[i..=new_partitioned_index].sort_unstable_by(cmp_logits);
                     // Expand the cache to include the new logits
                     partitioned_logits_index = Some(new_partitioned_index);
                     token_cache.expand_with_logits(


### PR DESCRIPTION
This PR fixes structured generation quality issues when the top_k argument is set to less than 64 (the chunked sorting size)