### PR TITLE
Fix classifier training

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "kalosm-learning"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/interfaces/kalosm-learning/Cargo.toml
+++ b/interfaces/kalosm-learning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalosm-learning"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "A simplified machine learning library for building off of pretrained models."
 license = "MIT/Apache-2.0"

--- a/interfaces/kalosm-learning/examples/classify.rs
+++ b/interfaces/kalosm-learning/examples/classify.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     classifier.train(
         &dataset, // The dataset to train on
         &dev,     // The device to train on
-        100,      // The number of epochs to train for
+        10,       // The number of epochs to train for
         0.003,    // The learning rate
         5,        // The batch size
     )?;


### PR DESCRIPTION
This fixes a bug in the classifier reported in the comments of https://www.youtube.com/watch?v=fIFUnYNuYbc

This PR fixes classifier training. The classifier's backwards pass was not being applied because the layers are lazily initialized and we didn't force them to resolve before we copy the varmap into the optimizer