### PR TITLE
Fix the message in the default loading indicator

### DIFF
--- a/interfaces/kalosm-common/src/cache.rs
+++ b/interfaces/kalosm-common/src/cache.rs
@@ -10,18 +10,14 @@ use tokio::io::AsyncWriteExt;
 
 use crate::FileSource;
 
-#[derive(Debug)]
 /// The progress starting a model
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ModelLoadingProgress {
     /// The model is downloading
     Downloading {
         /// The source of the download. This is not a path or URL, but a description of the source
         source: String,
-        /// The time stamp the download started
-        start_time: std::time::Instant,
-        /// The progress of the download, from 0 to 1
-        progress: f32,
+        progress: FileLoadingProgress,
     },
     /// The model is loading
     Loading {
@@ -30,20 +26,33 @@ pub enum ModelLoadingProgress {
     },
 }
 
+/// The progress of a file download
+#[derive(Clone, Debug)]
+pub struct FileLoadingProgress {
+    /// The time stamp the download started
+    start_time: std::time::Instant,
+    /// The size of the cached part of the download in bytes
+    cached_size: u64,
+    /// The size of the download in bytes
+    size: u64,
+    /// The progress of the download in bytes, from 0 to size
+    progress: u64,
+}
+
 impl ModelLoadingProgress {
     /// Create a new downloading progress
-    pub fn downloading(source: String, progress: f32, start_time: std::time::Instant) -> Self {
+    pub fn downloading(source: String, file_loading_progress: FileLoadingProgress) -> Self {
         Self::Downloading {
             source,
-            progress,
-            start_time,
+            progress: file_loading_progress,
         }
     }
 
     /// Create a new downloading progress
-    pub fn downloading_progress(source: String) -> impl FnMut(f32) -> Self + Send + Sync {
-        let start = std::time::Instant::now();
-        move |progress| ModelLoadingProgress::downloading(source.clone(), progress, start)
+    pub fn downloading_progress(
+        source: String,
+    ) -> impl FnMut(FileLoadingProgress) -> Self + Send + Sync {
+        move |progress| ModelLoadingProgress::downloading(source.clone(), progress)
     }
 
     /// Create a new loading progress
@@ -51,15 +60,32 @@ impl ModelLoadingProgress {
         Self::Loading { progress }
     }
 
+    /// Return the percent complete
+    pub fn progress(&self) -> f32 {
+        match self {
+            Self::Downloading {
+                progress:
+                    FileLoadingProgress {
+                        progress,
+                        size,
+                        cached_size,
+                        ..
+                    },
+                ..
+            } => (*progress - *cached_size) as f32 / *size as f32,
+            Self::Loading { progress } => *progress,
+        }
+    }
+
     /// Try to estimate the time remaining for a download
     pub fn estimate_time_remaining(&self) -> Option<std::time::Duration> {
         match self {
             Self::Downloading {
-                start_time,
-                progress,
+                progress: FileLoadingProgress { start_time, .. },
                 ..
             } => {
                 let elapsed = start_time.elapsed();
+                let progress = self.progress();
                 let remaining = (1. - progress) * elapsed.as_secs_f32();
                 Some(std::time::Duration::from_secs_f32(remaining))
             }
@@ -74,26 +100,32 @@ impl ModelLoadingProgress {
         use std::collections::HashMap;
         let m = MultiProgress::new();
         let sty = ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] ({pos}/{len}, ETA {eta})",
+            "{spinner:.green} {msg} [{elapsed_precise}] [{bar:40.cyan/blue}] ({decimal_bytes_per_sec}, ETA {eta})",
         )
         .unwrap();
         let mut progress_bars = HashMap::new();
 
         move |progress| match progress {
-            ModelLoadingProgress::Downloading {
-                source, progress, ..
+            Self::Downloading {
+                source,
+                progress:
+                    FileLoadingProgress {
+                        progress,
+                        size,
+                        cached_size,
+                        ..
+                    },
+                ..
             } => {
-                let n = 100;
-                let progress = progress * n as f32;
-
                 let progress_bar = progress_bars.entry(source.clone()).or_insert_with(|| {
-                    let pb = m.add(ProgressBar::new(n));
+                    let pb = m.add(ProgressBar::new(size));
                     pb.set_message(format!("Downloading {source}"));
                     pb.set_style(sty.clone());
+                    pb.set_position(cached_size);
                     pb
                 });
 
-                progress_bar.set_position(progress as u64);
+                progress_bar.set_position(progress);
             }
             ModelLoadingProgress::Loading { progress } => {
                 for pb in progress_bars.values_mut() {
@@ -149,7 +181,7 @@ impl Cache {
     pub async fn get(
         &self,
         source: &FileSource,
-        progress: impl FnMut(f32),
+        progress: impl FnMut(FileLoadingProgress),
     ) -> anyhow::Result<PathBuf> {
         match source {
             FileSource::HuggingFace {
@@ -232,7 +264,10 @@ impl Default for Cache {
 
 impl FileSource {
     /// Check if the file exists locally (if it is a local file or if it has been downloaded)
-    pub async fn download(&self, progress: impl FnMut(f32)) -> anyhow::Result<PathBuf> {
+    pub async fn download(
+        &self,
+        progress: impl FnMut(FileLoadingProgress),
+    ) -> anyhow::Result<PathBuf> {
         let cache = Cache::default();
         cache.get(self, progress).await
     }
@@ -244,7 +279,7 @@ async fn download_into(
     head: Response,
     client: reqwest::Client,
     token: Option<String>,
-    mut progress: impl FnMut(f32),
+    mut progress: impl FnMut(FileLoadingProgress),
 ) -> anyhow::Result<()> {
     let length = head
         .headers()
@@ -263,12 +298,22 @@ async fn download_into(
     };
 
     if let Some(length) = length {
-        progress(start as f32 / length as f32);
+        progress(FileLoadingProgress {
+            progress: start,
+            cached_size: start,
+            size: length,
+            start_time: std::time::Instant::now(),
+        });
     }
 
     if Some(start) == length {
         tracing::trace!("File {} already downloaded", file.display());
-        progress(1.0);
+        progress(FileLoadingProgress {
+            progress: start,
+            cached_size: start,
+            size: length.unwrap_or(0),
+            start_time: std::time::Instant::now(),
+        });
         return Ok(());
     }
 
@@ -294,12 +339,16 @@ async fn download_into(
         tracing::trace!("wrote chunk of size {}", chunk.len());
         current_progress += chunk.len() as u64;
         if let Some(length) = length {
-            progress(current_progress as f32 / length as f32);
+            progress(FileLoadingProgress {
+                progress: current_progress,
+                cached_size: start,
+                size: length,
+                start_time: std::time::Instant::now(),
+            });
         }
     }
 
     tracing::trace!("Download of {} complete", file.display());
-    progress(1.0);
 
     Ok(())
 }
@@ -323,7 +372,7 @@ async fn downloads_work() {
     let url = "https://httpbin.org/range/102400?duration=2";
     let file = PathBuf::from("download.bin");
     let progress = |p| {
-        println!("Progress: {}", p);
+        println!("Progress: {:?}", p);
     };
     let client = reqwest::Client::new();
     let response = client.head(url).send().await.unwrap();

--- a/models/kalosm-llama/src/source.rs
+++ b/models/kalosm-llama/src/source.rs
@@ -1,4 +1,4 @@
-use kalosm_common::FileSource;
+use kalosm_common::{FileLoadingProgress, FileSource};
 use kalosm_language_model::ChatMarkers;
 use tokenizers::Tokenizer;
 
@@ -90,14 +90,17 @@ impl LlamaSource {
         self
     }
 
-    pub(crate) async fn tokenizer(&self, progress: impl FnMut(f32)) -> anyhow::Result<Tokenizer> {
+    pub(crate) async fn tokenizer(
+        &self,
+        progress: impl FnMut(FileLoadingProgress),
+    ) -> anyhow::Result<Tokenizer> {
         let tokenizer_path = self.cache.get(&self.tokenizer, progress).await?;
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
     }
 
     pub(crate) async fn model(
         &self,
-        progress: impl FnMut(f32),
+        progress: impl FnMut(FileLoadingProgress),
     ) -> anyhow::Result<std::path::PathBuf> {
         self.cache.get(&self.model, progress).await
     }


### PR DESCRIPTION
Kalosm was setting the message but not displaying it because the template the default loading indicator was missing the message. This PR fixes that issue and makes the eta more accurate for resumed downloads

Fixes #287 