### PR TITLE
Upgrade rodio version

### DIFF
--- a/interfaces/kalosm-sound/Cargo.toml
+++ b/interfaces/kalosm-sound/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.4.3"
 tokenizers = "0.19.1"
 serde_json = "1.0.107"
 hound = "3.5"
-rodio = "0.17.1"
+rodio = "0.20.1"
 dasp = { version = "0.11.0", features = ["all"] }
 tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.37"

--- a/models/rwhisper/Cargo.toml
+++ b/models/rwhisper/Cargo.toml
@@ -20,7 +20,7 @@ hf-hub = "0.3.1"
 tokenizers = "0.19.1"
 serde_json = "1.0.107"
 hound = "3.5"
-rodio = "0.17.1"
+rodio = "0.20.1"
 tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.37"
 futures-util = "0.3.28"


### PR DESCRIPTION
I wanted to pass an mp4 file to a Whisper model. This requires upgrades rodio from 0.17.1 to 0.20.1 (latest version) and adding the [symphonia](https://docs.rs/rodio/latest/rodio/#alternative-decoder-backends) backend to rodio. 

I've also added a `symphonia_mp4` feature which enables all the mp4 related features of symphonia. 

I think the other way to do this would simply to be bump rodio in the library and then I could import the same version in my project with the symphonia features enabled (it doesn't work with 0.17.1 for some reason. So if you prefer not to have a feature for this and just bump rodio please let me know and I can change the PR.

p.s. This is a really cool crate!!! Enjoying using it.