### PR TITLE
Serialize session to and from bytes instead of a path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4113,6 +4113,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "rayon",
+ "safetensors",
  "thiserror 2.0.9",
  "tokenizers",
  "tokio",

--- a/interfaces/kalosm/examples/resume-chat.rs
+++ b/interfaces/kalosm/examples/resume-chat.rs
@@ -16,5 +16,6 @@ async fn main() {
         output_stream.to_std_out().await.unwrap();
     }
 
-    chat.save_session(save_path).await.unwrap();
+    let bytes = chat.save_session().await.unwrap();
+    std::fs::write(save_path, bytes).unwrap();
 }

--- a/interfaces/language-model/src/builder.rs
+++ b/interfaces/language-model/src/builder.rs
@@ -1,0 +1,43 @@
+use kalosm_common::ModelLoadingProgress;
+
+/// A builder that can create a model asynchronously.
+///
+/// # Example
+/// ```rust, no_run
+/// use kalosm::language::*;
+/// use kalosm_language_model::ModelBuilder;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let model = AdaEmbedderBuilder::default().start().await.unwrap();
+/// }
+/// ```
+#[async_trait::async_trait]
+pub trait ModelBuilder {
+    /// The model that this trait creates.
+    type Model;
+
+    /// An error that can occur when creating the model.
+    type Error: Send + Sync + 'static;
+
+    /// Start the model.
+    async fn start(self) -> Result<Self::Model, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.start_with_loading_handler(|_| {}).await
+    }
+
+    /// Start the model with a loading handler.
+    async fn start_with_loading_handler(
+        self,
+        handler: impl FnMut(ModelLoadingProgress) + Send + Sync + 'static,
+    ) -> Result<Self::Model, Self::Error>
+    where
+        Self: Sized;
+
+    /// Check if the model will need to be downloaded before use (default: false)
+    fn requires_download(&self) -> bool {
+        false
+    }
+}

--- a/interfaces/language-model/src/lib.rs
+++ b/interfaces/language-model/src/lib.rs
@@ -38,3 +38,5 @@ mod embedding;
 pub use embedding::*;
 mod model;
 pub use model::*;
+mod builder;
+pub use builder::*;

--- a/models/kalosm-llama/Cargo.toml
+++ b/models/kalosm-llama/Cargo.toml
@@ -31,6 +31,7 @@ kalosm-language-model.workspace = true
 kalosm-streams.workspace = true
 kalosm-common = { workspace = true }
 thiserror.workspace = true
+safetensors = "0.4.5"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
This PR makes the session trait for models more flexible by serializing the session to and from bytes instead of a path. This is useful if you need to serialize the session into a larger file, store it in memory, etc