### PR TITLE
Support boxed variants of chat and completion models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynosaur"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fac44672fabad44990176319b9e94393f3a38b960b5ca2af6cd90f5ecd1497"
+dependencies = [
+ "dynosaur_derive",
+ "trait-variant",
+]
+
+[[package]]
+name = "dynosaur_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c187d1e575ef546d24f0fcd7701cc04abfe6b5e7e2758aabc450b99e835ac3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,6 +4081,7 @@ dependencies = [
  "anyhow",
  "async-lock",
  "candle-core",
+ "dynosaur",
  "futures-channel",
  "futures-util",
  "kalosm",
@@ -8574,6 +8596,17 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log 0.2.0",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]

--- a/interfaces/kalosm-parse-macro/src/lib.rs
+++ b/interfaces/kalosm-parse-macro/src/lib.rs
@@ -403,7 +403,9 @@ fn unit_schema(attrs: &[syn::Attribute], ty: &Ident) -> TokenStream2 {
     quote! {
         impl kalosm_sample::Schema for #ty {
             fn schema() -> kalosm_sample::SchemaType {
-                kalosm_sample::SchemaType::Const(kalosm_sample::ConstSchema::new(kalosm_sample::SchemaLiteral::String(#name.to_string())))
+                kalosm_sample::SchemaType::Enum(kalosm_sample::EnumSchema::new([
+                    kalosm_sample::SchemaLiteral::String(#name.to_string())
+                ]))
             }
         }
     }
@@ -557,8 +559,8 @@ impl EnumParser {
         Ok(quote! {
             impl kalosm_sample::Schema for #ty {
                 fn schema() -> kalosm_sample::SchemaType {
-                    kalosm_sample::SchemaType::OneOf(
-                        kalosm_sample::OneOfSchema::new([
+                    kalosm_sample::SchemaType::AnyOf(
+                        kalosm_sample::AnyOfSchema::new([
                             #(#variants),*
                         ])
                     )
@@ -686,10 +688,10 @@ impl UnitEnumVariantParser {
                 kalosm_sample::JsonObjectSchema::new([
                     kalosm_sample::JsonPropertySchema::new(
                         #tag,
-                        kalosm_sample::SchemaType::Const(
-                            kalosm_sample::ConstSchema::new(
+                        kalosm_sample::SchemaType::Enum(
+                            kalosm_sample::EnumSchema::new([
                                 kalosm_sample::SchemaLiteral::String(#variant_name.to_string())
-                            )
+                            ])
                         )
                     )
                     .with_required(true)
@@ -742,10 +744,10 @@ impl StructEnumVariantParser {
                 kalosm_sample::JsonObjectSchema::new([
                     kalosm_sample::JsonPropertySchema::new(
                         #tag,
-                        kalosm_sample::SchemaType::Const(
-                            kalosm_sample::ConstSchema::new(
+                        kalosm_sample::SchemaType::Enum(
+                            kalosm_sample::EnumSchema::new([
                                 kalosm_sample::SchemaLiteral::String(#variant_name.to_string())
-                            )
+                            ])
                         )
                     )
                     .with_required(true),
@@ -807,10 +809,10 @@ impl TupleEnumVariantParser {
                 kalosm_sample::JsonObjectSchema::new([
                     kalosm_sample::JsonPropertySchema::new(
                         #tag,
-                        kalosm_sample::SchemaType::Const(
-                            kalosm_sample::ConstSchema::new(
+                        kalosm_sample::SchemaType::Enum(
+                            kalosm_sample::EnumSchema::new([
                                 kalosm_sample::SchemaLiteral::String(#variant_name.to_string())
-                            )
+                            ])
                         )
                     )
                     .with_required(true),

--- a/interfaces/kalosm-parse-macro/tests/enum.rs
+++ b/interfaces/kalosm-parse-macro/tests/enum.rs
@@ -64,11 +64,11 @@ fn mixed_enum_schema() {
     assert_eq!(
         json,
         serde_json::json!({
-            "oneOf": [
+            "anyOf": [
                 {
                     "type": "object",
                     "properties": {
-                        "type": { "const": "Person" },
+                        "type": { "enum": ["Person"] },
                         "data": {
                             "type": "object",
                             "properties": {
@@ -87,7 +87,7 @@ fn mixed_enum_schema() {
                 {
                     "type": "object",
                     "properties": {
-                        "type": { "const": "Animal" }
+                        "type": { "enum": ["Animal"] }
                     },
                     "required": ["type"],
                     "additionalProperties": false
@@ -95,7 +95,7 @@ fn mixed_enum_schema() {
                 {
                     "type": "object",
                     "properties": {
-                        "type": { "const": "Turtle" },
+                        "type": { "enum": ["Turtle"] },
                         "data": { "type": "string" }
                     },
                     "required": ["type", "data"],

--- a/interfaces/kalosm-parse-macro/tests/struct.rs
+++ b/interfaces/kalosm-parse-macro/tests/struct.rs
@@ -14,7 +14,7 @@ fn empty_struct_schema() {
     assert_eq!(
         json,
         serde_json::json!({
-            "const": "empty struct"
+            "enum": ["empty struct"]
         })
     )
 }

--- a/interfaces/kalosm/examples/chat-boxed.rs
+++ b/interfaces/kalosm/examples/chat-boxed.rs
@@ -1,0 +1,52 @@
+#![allow(unused)]
+use kalosm::language::*;
+
+#[tokio::main]
+async fn main() {
+    let model = loop {
+        let input = prompt_input("Choose Model (gpt, claude, llama, or phi): ").unwrap();
+        match input.to_lowercase().as_str() {
+            "gpt" => {
+                break OpenAICompatibleChatModel::builder()
+                    .with_gpt_4o_mini()
+                    .build()
+                    .boxed_chat_model()
+            }
+            "claude" => {
+                break AnthropicCompatibleChatModel::builder()
+                    .with_claude_3_5_haiku()
+                    .build()
+                    .boxed_chat_model()
+            }
+            "llama" => {
+                break Llama::builder()
+                    .with_source(LlamaSource::llama_3_1_8b_chat())
+                    .build()
+                    .await
+                    .unwrap()
+                    .boxed_chat_model()
+            }
+            "phi" => {
+                break Llama::builder()
+                    .with_source(LlamaSource::phi_3_5_mini_4k_instruct())
+                    .build()
+                    .await
+                    .unwrap()
+                    .boxed_chat_model()
+            }
+            _ => {}
+        }
+    };
+
+    let mut chat = model
+        .chat()
+        .with_system_prompt("The assistant will act like a pirate");
+
+    // Then chat with the session
+    loop {
+        chat(&prompt_input("\n> ").unwrap())
+            .to_std_out()
+            .await
+            .unwrap();
+    }
+}

--- a/interfaces/kalosm/examples/chat-constrained-boxed.rs
+++ b/interfaces/kalosm/examples/chat-constrained-boxed.rs
@@ -1,0 +1,61 @@
+#![allow(unused)]
+use kalosm::language::*;
+use serde::Deserialize;
+
+#[tokio::main]
+async fn main() {
+    // You can derive an efficient parser for your struct with the `Parse` trait
+    // OpenAI doesn't support root anyof schemas, so we need to wrap the constraints in a struct
+    #[derive(Parse, Clone, Schema, Deserialize, Debug)]
+    struct Response {
+        action: Action,
+    }
+
+    #[derive(Parse, Clone, Schema, Deserialize, Debug)]
+    #[serde(tag = "type")]
+    #[serde(content = "data")]
+    pub enum Action {
+        Do(String),
+        Say(String),
+    }
+
+    let model: BoxedStructuredChatModel<Response> = loop {
+        let input = prompt_input("Choose Model (gpt, llama, or phi): ").unwrap();
+        match input.to_lowercase().as_str() {
+            "gpt" => {
+                break OpenAICompatibleChatModel::builder()
+                    .with_gpt_4o_mini()
+                    .build()
+                    .boxed_typed_chat_model()
+            }
+            "llama" => {
+                break Llama::builder()
+                    .with_source(LlamaSource::llama_3_1_8b_chat())
+                    .build()
+                    .await
+                    .unwrap()
+                    .boxed_typed_chat_model()
+            }
+            "phi" => {
+                break Llama::builder()
+                    .with_source(LlamaSource::phi_3_5_mini_4k_instruct())
+                    .build()
+                    .await
+                    .unwrap()
+                    .boxed_typed_chat_model()
+            }
+            _ => {}
+        }
+    };
+
+    let mut chat = model
+        .chat()
+        .with_system_prompt("The assistant will act like a pirate. You will respond with either something you do or something you say. Respond with JSON in the format { \"type\": \"Say\", \"data\": \"hello\" } or { \"type\": \"Do\", \"data\": \"run away\" }");
+
+    // Then chat with the session
+    loop {
+        let mut response = chat(&prompt_input("\n> ").unwrap()).typed::<Response>();
+        response.to_std_out().await.unwrap();
+        println!("{:?}", response.await);
+    }
+}

--- a/interfaces/language-model/Cargo.toml
+++ b/interfaces/language-model/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { version = "1.0.134", optional = true }
 reqwest-eventsource = { version = "0.6.0", optional = true }
 anyhow = { workspace = true }
 async-lock = "3.4.0"
+dynosaur = "0.1.2"
 
 [dev-dependencies]
 tokio = { version = "1.28.1", features = ["full"] }

--- a/interfaces/language-model/src/chat/boxed.rs
+++ b/interfaces/language-model/src/chat/boxed.rs
@@ -1,0 +1,458 @@
+use crate::ModelConstraints;
+
+use super::{
+    ChatMessage, ChatModel, ChatSession, CreateChatSession, CreateDefaultChatConstraintsForType,
+    StructuredChatModel,
+};
+use std::{error::Error, future::Future, pin::Pin, sync::Arc};
+
+/// A boxed [`ChatModel`].
+#[derive(Clone)]
+pub struct BoxedChatModel {
+    model: Arc<dyn DynChatModel + Send + Sync>,
+}
+
+impl BoxedChatModel {
+    pub(crate) fn new(
+        model: impl ChatModel<
+                Error: Send + Sync + Error + 'static,
+                ChatSession: ChatSession<Error: Error + Send + Sync + 'static>
+                                 + Clone
+                                 + Send
+                                 + Sync
+                                 + 'static,
+            > + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        Self {
+            model: Arc::new(model),
+        }
+    }
+}
+
+impl CreateChatSession for BoxedChatModel {
+    type ChatSession = BoxedChatSession;
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn new_chat_session(&self) -> Result<Self::ChatSession, Self::Error> {
+        self.model.new_chat_session_boxed()
+    }
+}
+
+impl ChatModel for BoxedChatModel {
+    fn add_messages_with_callback<'a>(
+        &'a self,
+        session: &'a mut Self::ChatSession,
+        messages: &[ChatMessage],
+        sampler: crate::GenerationParameters,
+        on_token: impl FnMut(String) -> Result<(), Self::Error> + Send + Sync + 'static,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
+        self.model
+            .add_messages_with_callback_boxed(session, messages, sampler, Box::new(on_token))
+    }
+}
+
+/// A boxed [`StructuredChatModel`].
+#[derive(Clone)]
+pub struct BoxedStructuredChatModel<T> {
+    model: Arc<dyn DynStructuredChatModel<T> + Send + Sync>,
+}
+
+impl<T> BoxedStructuredChatModel<T> {
+    pub(crate) fn new<S>(model: S) -> Self
+    where
+        S: StructuredChatModel<
+                S::DefaultConstraints,
+                Error: Send + Sync + Error + 'static,
+                ChatSession: ChatSession<Error: Error + Send + Sync + 'static>
+                                 + Clone
+                                 + Send
+                                 + Sync
+                                 + 'static,
+            > + CreateDefaultChatConstraintsForType<T>
+            + Send
+            + Sync
+            + 'static,
+        T: 'static,
+    {
+        Self {
+            model: Arc::new(model),
+        }
+    }
+}
+
+impl<T> CreateChatSession for BoxedStructuredChatModel<T> {
+    type ChatSession = BoxedChatSession;
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn new_chat_session(&self) -> Result<Self::ChatSession, Self::Error> {
+        self.model.new_chat_session_boxed()
+    }
+}
+
+impl<T> ChatModel for BoxedStructuredChatModel<T> {
+    fn add_messages_with_callback<'a>(
+        &'a self,
+        session: &'a mut Self::ChatSession,
+        messages: &[ChatMessage],
+        sampler: crate::GenerationParameters,
+        on_token: impl FnMut(String) -> Result<(), Self::Error> + Send + Sync + 'static,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
+        self.model
+            .add_messages_with_callback_boxed(session, messages, sampler, Box::new(on_token))
+    }
+}
+
+impl<T: 'static> StructuredChatModel<BoxedChatConstraintsForType<T>>
+    for BoxedStructuredChatModel<T>
+{
+    fn add_message_with_callback_and_constraints<'a>(
+        &'a self,
+        session: &'a mut Self::ChatSession,
+        messages: &[ChatMessage],
+        sampler: crate::GenerationParameters,
+        constraints: BoxedChatConstraintsForType<T>,
+        on_token: impl FnMut(String) -> Result<(), Self::Error> + Send + Sync + 'static,
+    ) -> impl Future<Output = Result<T, Self::Error>> + Send + 'a {
+        self.model.add_message_with_callback_and_constraints_boxed(
+            session,
+            messages,
+            sampler,
+            constraints,
+            Box::new(on_token),
+        )
+    }
+}
+
+impl<T> CreateDefaultChatConstraintsForType<T> for BoxedStructuredChatModel<T>
+where
+    T: 'static,
+{
+    type DefaultConstraints = BoxedChatConstraintsForType<T>;
+
+    fn create_default_constraints() -> Self::DefaultConstraints {
+        BoxedChatConstraintsForType {
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+/// A boxed [`ChatSession`].
+pub struct BoxedChatSession {
+    session: Box<dyn DynChatSession + Send + Sync>,
+}
+
+impl Clone for BoxedChatSession {
+    fn clone(&self) -> Self {
+        DynChatSession::clone_(&*self.session)
+    }
+}
+
+impl ChatSession for BoxedChatSession {
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn write_to(&self, into: &mut Vec<u8>) -> Result<(), Self::Error> {
+        self.session.write_to_boxed(into)
+    }
+
+    fn from_bytes(_: &[u8]) -> Result<Self, Self::Error>
+    where
+        Self: std::marker::Sized,
+    {
+        #[derive(Debug)]
+        struct FromBytesNotSupported;
+
+        impl std::error::Error for FromBytesNotSupported {}
+
+        impl std::fmt::Display for FromBytesNotSupported {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "FromBytesNotSupported")
+            }
+        }
+
+        Err(Box::new(FromBytesNotSupported))
+    }
+
+    fn history(&self) -> Vec<super::ChatMessage> {
+        self.session.history_boxed()
+    }
+
+    fn try_clone(&self) -> Result<Self, Self::Error>
+    where
+        Self: std::marker::Sized,
+    {
+        self.session.try_clone_boxed()
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error> {
+        self.session.to_bytes_boxed()
+    }
+}
+
+#[derive(Debug)]
+struct MismatchedSessionType;
+
+impl std::error::Error for MismatchedSessionType {}
+
+impl std::fmt::Display for MismatchedSessionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MismatchedSessionType")
+    }
+}
+
+trait DynCreateChatSession {
+    fn new_chat_session_boxed(
+        &self,
+    ) -> Result<BoxedChatSession, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+impl<S> DynCreateChatSession for S
+where
+    S: CreateChatSession<
+        Error: Send + Sync + Error,
+        ChatSession: ChatSession<Error: Error> + Clone + Send + Sync + 'static,
+    >,
+{
+    fn new_chat_session_boxed(
+        &self,
+    ) -> Result<BoxedChatSession, Box<dyn std::error::Error + Send + Sync>> {
+        let session = self
+            .new_chat_session()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+        let session = Box::new(session) as Box<dyn DynChatSession + Send + Sync>;
+        Ok(BoxedChatSession { session })
+    }
+}
+
+trait DynChatSession {
+    fn write_to_boxed(
+        &self,
+        into: &mut Vec<u8>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    fn history_boxed(&self) -> Vec<super::ChatMessage>;
+
+    fn try_clone_boxed(
+        &self,
+    ) -> Result<BoxedChatSession, Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    fn to_bytes_boxed(&self)
+        -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+
+    fn clone_(&self) -> BoxedChatSession;
+}
+
+impl<S: ChatSession<Error: Error> + Send + Sync + Clone + 'static> DynChatSession for S {
+    fn write_to_boxed(
+        &self,
+        into: &mut Vec<u8>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.write_to(into)
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    }
+
+    fn history_boxed(&self) -> Vec<super::ChatMessage> {
+        self.history()
+    }
+
+    fn try_clone_boxed(
+        &self,
+    ) -> Result<BoxedChatSession, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        let session = self
+            .try_clone()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+        let session = Box::new(session) as Box<dyn DynChatSession + Send + Sync>;
+        Ok(BoxedChatSession { session })
+    }
+
+    fn to_bytes_boxed(
+        &self,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.to_bytes()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn clone_(&self) -> BoxedChatSession {
+        BoxedChatSession {
+            session: Box::new(Clone::clone(self)),
+        }
+    }
+}
+
+trait DynChatModel: DynCreateChatSession {
+    fn add_messages_with_callback_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedChatSession,
+        messages: &[super::ChatMessage],
+        sampler: crate::GenerationParameters,
+        on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    >;
+}
+
+impl<S> DynChatModel for S
+where
+    S: ChatModel<
+        Error: Send + Sync + Error + 'static,
+        ChatSession: ChatSession<Error: Error + Send + Sync + 'static>
+                         + Clone
+                         + Send
+                         + Sync
+                         + 'static,
+    >,
+{
+    fn add_messages_with_callback_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedChatSession,
+        messages: &[super::ChatMessage],
+        sampler: crate::GenerationParameters,
+        mut on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    > {
+        let session = session.session.as_any_mut();
+
+        let Some(session) = session.downcast_mut::<S::ChatSession>() else {
+            return Box::pin(async move {
+                Err(Box::new(MismatchedSessionType) as Box<dyn Error + Send + Sync>)
+            });
+        };
+        let on_token = move |token: String| {
+            if let Err(err) = on_token(token) {
+                tracing::error!("Error running on_token callback: {}", err);
+            }
+            Ok(())
+        };
+        let future = self.add_messages_with_callback(session, messages, sampler, on_token);
+        // Double box prevents a rust compiler error with lifetimes. See https://github.com/rust-lang/rust/issues/102211
+        let future: Pin<Box<dyn Future<Output = Result<(), _>> + Send>> = Box::pin(future);
+        Box::pin(async move {
+            future
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync + 'static>)
+        })
+    }
+}
+
+/// A constraints for [`CreateDefaultChatConstraintsForType`] that work with boxed [`StructuredChatModel`]s.
+pub struct BoxedChatConstraintsForType<T> {
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> ModelConstraints for BoxedChatConstraintsForType<T> {
+    type Output = T;
+}
+
+trait DynStructuredChatModel<T>: DynChatModel {
+    fn add_message_with_callback_and_constraints_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedChatSession,
+        messages: &[ChatMessage],
+        sampler: crate::GenerationParameters,
+        constraints: BoxedChatConstraintsForType<T>,
+        on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    >;
+}
+
+impl<S, T> DynStructuredChatModel<T> for S
+where
+    S: StructuredChatModel<
+            S::DefaultConstraints,
+            Error: Send + Sync + Error + 'static,
+            ChatSession: ChatSession<Error: Error + Send + Sync + 'static>
+                             + Clone
+                             + Send
+                             + Sync
+                             + 'static,
+        > + CreateDefaultChatConstraintsForType<T>,
+    T: 'static,
+{
+    fn add_message_with_callback_and_constraints_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedChatSession,
+        messages: &[ChatMessage],
+        sampler: crate::GenerationParameters,
+        _: BoxedChatConstraintsForType<T>,
+        mut on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    > {
+        let constraints =
+            <S as CreateDefaultChatConstraintsForType<T>>::create_default_constraints();
+        let session = session.session.as_any_mut();
+
+        let Some(session) = session.downcast_mut::<S::ChatSession>() else {
+            return Box::pin(async move {
+                Err(Box::new(MismatchedSessionType) as Box<dyn Error + Send + Sync>)
+            });
+        };
+
+        let on_token = move |token: String| {
+            if let Err(err) = on_token(token) {
+                tracing::error!("Error running on_token callback: {}", err);
+            }
+            Ok(())
+        };
+
+        let future = self.add_message_with_callback_and_constraints(
+            session,
+            messages,
+            sampler,
+            constraints,
+            on_token,
+        );
+        // Double box prevents a rust compiler error with lifetimes. See https://github.com/rust-lang/rust/issues/102211
+        let future: Pin<Box<dyn Future<Output = Result<T, _>> + Send>> = Box::pin(future);
+        Box::pin(async move {
+            future
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync + 'static>)
+        })
+    }
+}

--- a/interfaces/language-model/src/chat/ext.rs
+++ b/interfaces/language-model/src/chat/ext.rs
@@ -30,6 +30,65 @@ pub trait ChatModelExt: CreateChatSession {
         Task::new(self.clone(), description)
     }
 
+    /// Erase the type of the chat model. This can be used to make multiple implementations of
+    /// [`ChatModel`] compatible with the same type.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # #![allow(unused)]
+    /// # use kalosm::language::*;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let model = loop {
+    ///     let input = prompt_input("Choose Model (gpt, claude, llama, or phi): ").unwrap();
+    ///     match input.to_lowercase().as_str() {
+    ///         "gpt" => {
+    ///             break OpenAICompatibleChatModel::builder()
+    ///                 .with_gpt_4o_mini()
+    ///                 .build()
+    ///                 .boxed_chat_model()
+    ///         }
+    ///         "claude" => {
+    ///             break AnthropicCompatibleChatModel::builder()
+    ///                 .with_claude_3_5_haiku()
+    ///                 .build()
+    ///                 .boxed_chat_model()
+    ///         }
+    ///         "llama" => {
+    ///             break Llama::builder()
+    ///                 .with_source(LlamaSource::llama_3_1_8b_chat())
+    ///                 .build()
+    ///                 .await
+    ///                 .unwrap()
+    ///                 .boxed_chat_model()
+    ///         }
+    ///         "phi" => {
+    ///             break Llama::builder()
+    ///                 .with_source(LlamaSource::phi_3_5_mini_4k_instruct())
+    ///                 .build()
+    ///                 .await
+    ///                 .unwrap()
+    ///                 .boxed_chat_model()
+    ///         }
+    ///         _ => {}
+    ///     }
+    /// };
+    ///
+    /// let mut chat = model
+    ///     .chat()
+    ///     .with_system_prompt("The assistant will act like a pirate");
+    ///
+    /// // Then chat with the session
+    /// loop {
+    ///     chat(&prompt_input("\n> ").unwrap())
+    ///         .to_std_out()
+    ///         .await
+    ///         .unwrap();
+    /// }
+    /// # }
+    /// ```
     fn boxed_chat_model(self) -> BoxedChatModel
     where
         Self: ChatModel<
@@ -47,6 +106,73 @@ pub trait ChatModelExt: CreateChatSession {
         BoxedChatModel::new(self)
     }
 
+    /// Erase the type of the structured chat model. This can be used to make multiple implementations of
+    /// [`StructuredChatModel`] compatible with the same type.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # #![allow(unused)]
+    /// # use kalosm::language::*;
+    /// # use serde::Deserialize;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// // You can derive an efficient parser for your struct with the `Parse` trait
+    /// // OpenAI doesn't support root anyof schemas, so we need to wrap the constraints in a struct
+    /// #[derive(Parse, Clone, Schema, Deserialize, Debug)]
+    /// struct Response {
+    ///     action: Action,
+    /// }
+    ///
+    /// #[derive(Parse, Clone, Schema, Deserialize, Debug)]
+    /// #[serde(tag = "type")]
+    /// #[serde(content = "data")]
+    /// pub enum Action {
+    ///     Do(String),
+    ///     Say(String),
+    /// }
+    ///
+    /// let model: BoxedStructuredChatModel<Response> = loop {
+    ///     let input = prompt_input("Choose Model (gpt, llama, or phi): ").unwrap();
+    ///     match input.to_lowercase().as_str() {
+    ///         "gpt" => {
+    ///             break OpenAICompatibleChatModel::builder()
+    ///                 .with_gpt_4o_mini()
+    ///                 .build()
+    ///                 .boxed_typed_chat_model()
+    ///         }
+    ///         "llama" => {
+    ///             break Llama::builder()
+    ///                 .with_source(LlamaSource::llama_3_1_8b_chat())
+    ///                 .build()
+    ///                 .await
+    ///                 .unwrap()
+    ///                 .boxed_typed_chat_model()
+    ///         }
+    ///         "phi" => {
+    ///             break Llama::builder()
+    ///                 .with_source(LlamaSource::phi_3_5_mini_4k_instruct())
+    ///                 .build()
+    ///                 .await
+    ///                 .unwrap()
+    ///                 .boxed_typed_chat_model()
+    ///         }
+    ///         _ => {}
+    ///     }
+    /// };
+    ///
+    /// let mut chat = model
+    ///     .chat()
+    ///     .with_system_prompt("The assistant will act like a pirate. You will respond with either something you do or something you say. Respond with JSON in the format { \"type\": \"Say\", \"data\": \"hello\" } or { \"type\": \"Do\", \"data\": \"run away\" }");
+    ///
+    /// // Then chat with the session
+    /// loop {
+    ///     let mut response = chat(&prompt_input("\n> ").unwrap()).typed::<Response>();
+    ///     response.to_std_out().await.unwrap();
+    ///     println!("{:?}", response.await);
+    /// }
+    /// # }
+    /// ```
     fn boxed_typed_chat_model<T>(self) -> BoxedStructuredChatModel<T>
     where
         Self: StructuredChatModel<

--- a/interfaces/language-model/src/chat/ext.rs
+++ b/interfaces/language-model/src/chat/ext.rs
@@ -1,5 +1,13 @@
+use std::error::Error;
+
+use super::BoxedChatModel;
+use super::BoxedStructuredChatModel;
 use super::Chat;
+use super::ChatModel;
+use super::ChatSession;
 use super::CreateChatSession;
+use super::CreateDefaultChatConstraintsForType;
+use super::StructuredChatModel;
 use super::Task;
 
 /// An extension trait for chat models with helpers for handling chat sessions. This trait is implemented automatically for all [`crate::ChatModel`]s.
@@ -20,6 +28,43 @@ pub trait ChatModelExt: CreateChatSession {
         Self: Clone,
     {
         Task::new(self.clone(), description)
+    }
+
+    fn boxed_chat_model(self) -> BoxedChatModel
+    where
+        Self: ChatModel<
+                Error: Send + Sync + std::error::Error + 'static,
+                ChatSession: ChatSession<Error: std::error::Error + Send + Sync + 'static>
+                                 + Clone
+                                 + Send
+                                 + Sync
+                                 + 'static,
+            > + Sized
+            + Send
+            + Sync
+            + 'static,
+    {
+        BoxedChatModel::new(self)
+    }
+
+    fn boxed_typed_chat_model<T>(self) -> BoxedStructuredChatModel<T>
+    where
+        Self: StructuredChatModel<
+                Self::DefaultConstraints,
+                Error: Send + Sync + Error + 'static,
+                ChatSession: ChatSession<Error: Error + Send + Sync + 'static>
+                                 + Clone
+                                 + Send
+                                 + Sync
+                                 + 'static,
+            > + CreateDefaultChatConstraintsForType<T>
+            + Sized
+            + Send
+            + Sync
+            + 'static,
+        T: 'static,
+    {
+        BoxedStructuredChatModel::new(self)
     }
 }
 

--- a/interfaces/language-model/src/model/boxed.rs
+++ b/interfaces/language-model/src/model/boxed.rs
@@ -1,0 +1,434 @@
+use super::{
+    CreateDefaultCompletionConstraintsForType, CreateTextCompletionSession, ModelConstraints,
+    StructuredTextCompletionModel, TextCompletionModel, TextCompletionSession,
+};
+use std::{error::Error, future::Future, pin::Pin, sync::Arc};
+
+/// A boxed [`TextCompletionModel`].
+#[derive(Clone)]
+pub struct BoxedTextCompletionModel {
+    model: Arc<dyn DynTextCompletionModel + Send + Sync>,
+}
+
+impl BoxedTextCompletionModel {
+    pub(crate) fn new(
+        model: impl TextCompletionModel<
+                Error: Send + Sync + Error + 'static,
+                Session: TextCompletionSession<Error: Error + Send + Sync + 'static>
+                             + Clone
+                             + Send
+                             + Sync
+                             + 'static,
+            > + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        Self {
+            model: Arc::new(model),
+        }
+    }
+}
+
+impl CreateTextCompletionSession for BoxedTextCompletionModel {
+    type Session = BoxedTextCompletionSession;
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn new_session(&self) -> Result<Self::Session, Self::Error> {
+        self.model.new_session_boxed()
+    }
+}
+
+impl TextCompletionModel for BoxedTextCompletionModel {
+    fn stream_text_with_callback<'a>(
+        &'a self,
+        session: &'a mut Self::Session,
+        text: &str,
+        sampler: super::GenerationParameters,
+        on_token: impl FnMut(String) -> Result<(), Self::Error> + Send + Sync + 'static,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
+        self.model
+            .add_messages_with_callback_boxed(session, text, sampler, Box::new(on_token))
+    }
+}
+
+/// A boxed [`BoxedStructuredTextCompletionModel`].
+#[derive(Clone)]
+pub struct BoxedStructuredTextCompletionModel<T> {
+    model: Arc<dyn DynStructuredTextCompletionModel<T> + Send + Sync>,
+}
+
+impl<T> BoxedStructuredTextCompletionModel<T> {
+    pub(crate) fn new<S>(model: S) -> Self
+    where
+        S: StructuredTextCompletionModel<
+                S::DefaultConstraints,
+                Error: Send + Sync + Error + 'static,
+                Session: TextCompletionSession<Error: Error + Send + Sync + 'static>
+                             + Clone
+                             + Send
+                             + Sync
+                             + 'static,
+            > + CreateDefaultCompletionConstraintsForType<T>
+            + Send
+            + Sync
+            + 'static,
+        T: 'static,
+    {
+        Self {
+            model: Arc::new(model),
+        }
+    }
+}
+
+impl<T> CreateTextCompletionSession for BoxedStructuredTextCompletionModel<T> {
+    type Session = BoxedTextCompletionSession;
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn new_session(&self) -> Result<Self::Session, Self::Error> {
+        self.model.new_session_boxed()
+    }
+}
+
+impl<T> TextCompletionModel for BoxedStructuredTextCompletionModel<T> {
+    fn stream_text_with_callback<'a>(
+        &'a self,
+        session: &'a mut Self::Session,
+        text: &str,
+        sampler: super::GenerationParameters,
+        on_token: impl FnMut(String) -> Result<(), Self::Error> + Send + Sync + 'static,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
+        self.model
+            .add_messages_with_callback_boxed(session, text, sampler, Box::new(on_token))
+    }
+}
+
+impl<T> StructuredTextCompletionModel<BoxedCompletionConstraintsForType<T>>
+    for BoxedStructuredTextCompletionModel<T>
+{
+    fn stream_text_with_callback_and_parser<'a>(
+        &'a self,
+        session: &'a mut Self::Session,
+        text: &str,
+        sampler: super::GenerationParameters,
+        parser: BoxedCompletionConstraintsForType<T>,
+        on_token: impl FnMut(String) -> Result<(), Self::Error> + Send + Sync + 'static,
+    ) -> impl Future<Output = Result<T, Self::Error>> + Send + 'a {
+        self.model.add_messages_with_callback_and_parser_boxed(
+            session,
+            text,
+            sampler,
+            parser,
+            Box::new(on_token),
+        )
+    }
+}
+
+/// A boxed [`TextCompletionSession`].
+pub struct BoxedTextCompletionSession {
+    session: Box<dyn DynTextCompletionSession + Send + Sync>,
+}
+
+impl Clone for BoxedTextCompletionSession {
+    fn clone(&self) -> Self {
+        DynTextCompletionSession::clone_(&*self.session)
+    }
+}
+
+impl TextCompletionSession for BoxedTextCompletionSession {
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn write_to(&self, into: &mut Vec<u8>) -> Result<(), Self::Error> {
+        self.session.write_to_boxed(into)
+    }
+
+    fn from_bytes(_: &[u8]) -> Result<Self, Self::Error>
+    where
+        Self: std::marker::Sized,
+    {
+        #[derive(Debug)]
+        struct FromBytesNotSupported;
+
+        impl std::error::Error for FromBytesNotSupported {}
+
+        impl std::fmt::Display for FromBytesNotSupported {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "FromBytesNotSupported")
+            }
+        }
+
+        Err(Box::new(FromBytesNotSupported))
+    }
+
+    fn try_clone(&self) -> Result<Self, Self::Error>
+    where
+        Self: std::marker::Sized,
+    {
+        self.session.try_clone_boxed()
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error> {
+        self.session.to_bytes_boxed()
+    }
+}
+
+#[derive(Debug)]
+struct MismatchedSessionType;
+
+impl std::error::Error for MismatchedSessionType {}
+
+impl std::fmt::Display for MismatchedSessionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MismatchedSessionType")
+    }
+}
+
+trait DynCreateTextCompletionSession {
+    fn new_session_boxed(
+        &self,
+    ) -> Result<BoxedTextCompletionSession, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+impl<S> DynCreateTextCompletionSession for S
+where
+    S: CreateTextCompletionSession<
+        Error: Send + Sync + Error,
+        Session: TextCompletionSession<Error: Error> + Clone + Send + Sync + 'static,
+    >,
+{
+    fn new_session_boxed(
+        &self,
+    ) -> Result<BoxedTextCompletionSession, Box<dyn std::error::Error + Send + Sync>> {
+        let session = self
+            .new_session()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+        let session = Box::new(session) as Box<dyn DynTextCompletionSession + Send + Sync>;
+        Ok(BoxedTextCompletionSession { session })
+    }
+}
+
+trait DynTextCompletionSession {
+    fn write_to_boxed(
+        &self,
+        into: &mut Vec<u8>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    fn try_clone_boxed(
+        &self,
+    ) -> Result<BoxedTextCompletionSession, Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    fn to_bytes_boxed(&self)
+        -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+
+    fn clone_(&self) -> BoxedTextCompletionSession;
+}
+
+impl<S: TextCompletionSession<Error: Error> + Clone + Send + Sync + 'static>
+    DynTextCompletionSession for S
+{
+    fn write_to_boxed(
+        &self,
+        into: &mut Vec<u8>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.write_to(into)
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    }
+
+    fn try_clone_boxed(
+        &self,
+    ) -> Result<BoxedTextCompletionSession, Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
+        let session = self
+            .try_clone()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+        let session = Box::new(session) as Box<dyn DynTextCompletionSession + Send + Sync>;
+        Ok(BoxedTextCompletionSession { session })
+    }
+
+    fn to_bytes_boxed(
+        &self,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.to_bytes()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn clone_(&self) -> BoxedTextCompletionSession {
+        BoxedTextCompletionSession {
+            session: Box::new(Clone::clone(self)),
+        }
+    }
+}
+
+trait DynTextCompletionModel: DynCreateTextCompletionSession {
+    fn add_messages_with_callback_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedTextCompletionSession,
+        text: &str,
+        sampler: crate::GenerationParameters,
+        on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    >;
+}
+
+impl<S> DynTextCompletionModel for S
+where
+    S: TextCompletionModel<
+        Error: Send + Sync + Error + 'static,
+        Session: TextCompletionSession<Error: Error + Send + Sync + 'static>
+                     + Clone
+                     + Send
+                     + Sync
+                     + 'static,
+    >,
+{
+    fn add_messages_with_callback_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedTextCompletionSession,
+        text: &str,
+        sampler: crate::GenerationParameters,
+        mut on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    > {
+        let session = session.session.as_any_mut();
+
+        let Some(session) = session.downcast_mut::<S::Session>() else {
+            return Box::pin(async move {
+                Err(Box::new(MismatchedSessionType) as Box<dyn Error + Send + Sync>)
+            });
+        };
+        let on_token = move |token: String| {
+            if let Err(err) = on_token(token) {
+                tracing::error!("Error running on_token callback: {}", err);
+            }
+            Ok(())
+        };
+        let future = self.stream_text_with_callback(session, text, sampler, on_token);
+        // Double box prevents a rust compiler error with lifetimes. See https://github.com/rust-lang/rust/issues/102211
+        let boxed: Pin<Box<dyn Future<Output = Result<(), _>> + Send>> = Box::pin(future);
+        Box::pin(async move {
+            boxed
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync + 'static>)
+        })
+    }
+}
+
+/// A constraints for [`CreateDefaultCompletionConstraintsForType`] that work with boxed [`TextCompletionModel`]s.
+pub struct BoxedCompletionConstraintsForType<T> {
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> ModelConstraints for BoxedCompletionConstraintsForType<T> {
+    type Output = T;
+}
+
+trait DynStructuredTextCompletionModel<T>: DynTextCompletionModel {
+    fn add_messages_with_callback_and_parser_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedTextCompletionSession,
+        text: &str,
+        sampler: crate::GenerationParameters,
+        constraints: BoxedCompletionConstraintsForType<T>,
+        on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    >;
+}
+
+impl<S, T> DynStructuredTextCompletionModel<T> for S
+where
+    S: StructuredTextCompletionModel<
+            S::DefaultConstraints,
+            Error: Send + Sync + Error + 'static,
+            Session: TextCompletionSession<Error: Error + Send + Sync + 'static>
+                         + Clone
+                         + Send
+                         + Sync
+                         + 'static,
+        > + CreateDefaultCompletionConstraintsForType<T>,
+    T: 'static,
+{
+    fn add_messages_with_callback_and_parser_boxed<'a>(
+        &'a self,
+        session: &'a mut BoxedTextCompletionSession,
+        text: &str,
+        sampler: crate::GenerationParameters,
+        _: BoxedCompletionConstraintsForType<T>,
+        mut on_token: Box<
+            dyn FnMut(String) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>>
+                + Send
+                + 'a,
+        >,
+    > {
+        let constraints =
+            <S as CreateDefaultCompletionConstraintsForType<T>>::create_default_constraints();
+        let session = session.session.as_any_mut();
+
+        let Some(session) = session.downcast_mut::<S::Session>() else {
+            return Box::pin(async move {
+                Err(Box::new(MismatchedSessionType) as Box<dyn Error + Send + Sync>)
+            });
+        };
+        let on_token = move |token: String| {
+            if let Err(err) = on_token(token) {
+                tracing::error!("Error running on_token callback: {}", err);
+            }
+            Ok(())
+        };
+        let future = self.stream_text_with_callback_and_parser(
+            session,
+            text,
+            sampler,
+            constraints,
+            on_token,
+        );
+        // Double box prevents a rust compiler error with lifetimes. See https://github.com/rust-lang/rust/issues/102211
+        let boxed: Pin<Box<dyn Future<Output = Result<T, _>> + Send>> = Box::pin(future);
+        Box::pin(async move {
+            boxed
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync + 'static>)
+        })
+    }
+}

--- a/interfaces/language-model/src/model/ext.rs
+++ b/interfaces/language-model/src/model/ext.rs
@@ -45,6 +45,8 @@ pub trait TextCompletionModelExt: CreateTextCompletionSession {
         }
     }
 
+    /// Erase the type of the text completion model. This can be used to make multiple implementations of
+    /// [`TextCompletionModel`] compatible with the same type.
     fn boxed_completion_model(self) -> BoxedTextCompletionModel
     where
         Self: TextCompletionModel<
@@ -62,6 +64,8 @@ pub trait TextCompletionModelExt: CreateTextCompletionSession {
         BoxedTextCompletionModel::new(self)
     }
 
+    /// Erase the type of the structured text completion model. This can be used to make multiple implementations of
+    /// [`StructuredTextCompletionModel`] compatible with the same type.
     fn boxed_typed_completion_model<T>(self) -> BoxedStructuredTextCompletionModel<T>
     where
         Self: StructuredTextCompletionModel<


### PR DESCRIPTION
This PR adds methods to the chat and completions traits to turn the models into a boxed version of the models. This lets you use multiple model implementations like llama, openai, and claude together in one application easily