### PR TITLE
Expose the chat session inside the task struct

### DIFF
--- a/interfaces/language-model/src/chat/task.rs
+++ b/interfaces/language-model/src/chat/task.rs
@@ -61,6 +61,14 @@ impl<M: CreateChatSession> Task<M> {
             constraints: NoConstraints,
         }
     }
+
+    /// Create a new task from an existing chat session.
+    pub fn from_chat(chat: Chat<M>) -> Self {
+        Self {
+            chat,
+            constraints: NoConstraints,
+        }
+    }
 }
 
 impl<M: CreateChatSession, Constraints> Task<M, Constraints> {
@@ -173,6 +181,11 @@ impl<M: CreateChatSession, Constraints> Task<M, Constraints> {
         M: CreateDefaultChatConstraintsForType<T>,
     {
         self.with_constraints(M::create_default_constraints())
+    }
+
+    /// Get a reference to the underlying chat session.
+    pub fn chat(&self) -> &Chat<M> {
+        &self.chat
     }
 }
 


### PR DESCRIPTION
This PR exposes the chat session inside the task wrapper. This lets you load and save the task from bytes through the chat session:
```rust
use kalosm::language::*;
use kalosm_language::kalosm_llama::LlamaChatSession;

#[tokio::main]
async fn main() {
    let model = Llama::new_chat().await.unwrap();
    let save_path = std::path::PathBuf::from("./chat.llama");
    let mut chat = model.chat();
    if let Some(old_session) = std::fs::read(&save_path)
        .ok()
        .and_then(|bytes| LlamaChatSession::from_bytes(&bytes).ok())
    {
        chat = chat.with_session(old_session);
    } else {
        chat = chat.with_system_prompt("The assistant will act like a pirate. They only respond as a pirate named Skally Waggs. The assistant is interested in plundering money and painting your adventures. The assistant will never mention this to the user.");
    }

    let task = Task::from_chat(chat);

    for _ in 0..2 {
        let mut output_stream = task(&prompt_input("\n> ").unwrap());
        print!("Bot: ");
        output_stream.to_std_out().await.unwrap();
    }

    let bytes = task.chat().session().unwrap().to_bytes().unwrap();
    std::fs::write(save_path, bytes).unwrap();
}
```