### PR TITLE
Use the AnyOf schema for option for openAI compatibility

### DIFF
--- a/interfaces/kalosm-sample/src/structured_parser/schema.rs
+++ b/interfaces/kalosm-sample/src/structured_parser/schema.rs
@@ -909,7 +909,7 @@ pub trait Schema {
 
 impl<T: Schema> Schema for Option<T> {
     fn schema() -> SchemaType {
-        SchemaType::OneOf(OneOfSchema::new([SchemaType::Null, T::schema()]))
+        SchemaType::AnyOf(AnyOfSchema::new([SchemaType::Null, T::schema()]))
     }
 }
 


### PR DESCRIPTION
I changed the derive schema macro to not use OneOf for open AI compatibility, but I forgot to change the implementation for Option. This PR fixes the schema of `Option<T>`