### PR TITLE
Construct MicInput from underlying cpal device

### DIFF
--- a/interfaces/kalosm-sound/src/source/mic.rs
+++ b/interfaces/kalosm-sound/src/source/mic.rs
@@ -39,6 +39,18 @@ impl Default for MicInput {
 }
 
 impl MicInput {
+    /// Create a new MicInput from a specific device.
+    pub fn from_device(device: cpal::Device) -> Self {
+        let host = cpal::default_host();
+        let config = device.default_input_config()
+            .expect("Failed to get default input config");
+        Self {
+            host,
+            device,
+            config,
+        }
+    }
+
     /// Records audio for a given duration.
     pub async fn record_until(&self, deadline: Instant) -> SamplesBuffer<f32> {
         let mut stream = self.stream();


### PR DESCRIPTION
Useful on MacOS when attempting to listen on hidden devices that need to be constructed via given device ID. See cpal https://github.com/RustAudio/cpal/pull/974

[Example usage](https://github.com/ollisten/ollisten/blob/5c1fc28ef70a15b8a18d457b7cb2f34be91d8a63/src-tauri/src/transcription/cpal_macos_hack.rs#L10-L15):
```rust
pub fn create_cpal_mic(audio_device_id: AudioDeviceID) -> Result<MicInput, String> {
    let device_inner: CoreAudioDevice = CoreAudioDevice::new(audio_device_id);
    let device = cpal::platform::Device::from(device_inner);
    let mic_input = MicInput::from_device(device);
    Ok(mic_input)
}
```