### PR TITLE
Fix subgroups on macos and webgpu, fix caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7336,8 +7336,8 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -12294,8 +12294,8 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
@@ -12323,8 +12323,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -12355,32 +12355,32 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -12427,12 +12427,13 @@ dependencies = [
  "wgpu-types",
  "windows 0.62.2",
  "windows-core 0.62.2",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -12440,8 +12441,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
+version = "29.0.3"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#477d335af5f2bd3f5c25017db67ac7062e53f69a"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5350,7 +5350,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.54.0",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4687,6 +4687,7 @@ dependencies = [
  "pollster",
  "rand 0.9.4",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4713,6 +4714,7 @@ dependencies = [
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "web-time",
 ]
 
@@ -4739,7 +4741,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber 0.3.23",
- "web-sys",
  "web-time",
  "wgpu",
 ]
@@ -4806,7 +4807,7 @@ dependencies = [
  "lru 0.14.0",
  "parking_lot",
  "rustc-hash 2.1.2",
- "web-sys",
+ "tracing",
  "wgpu",
 ]
 
@@ -6409,6 +6410,7 @@ dependencies = [
  "serde",
  "surrealdb",
  "tokio",
+ "tracing",
  "tracing-subscriber 0.2.25",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ dependencies = [
  "heed",
  "memmap2",
  "nohash",
- "ordered-float 4.6.0",
+ "ordered-float",
  "page_size",
  "rand 0.8.6",
  "rayon",
@@ -923,15 +923,6 @@ name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
-dependencies = [
- "bit-vec 0.9.1",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec 0.9.1",
 ]
@@ -2041,7 +2032,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2062,7 +2053,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2902,7 +2893,7 @@ dependencies = [
  "sanitize-filename",
  "tracing",
  "wasm-bindgen-futures",
- "wgpu 29.0.3",
+ "wgpu",
 ]
 
 [[package]]
@@ -4057,7 +4048,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4413,7 +4404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4750,7 +4741,7 @@ dependencies = [
  "tracing-subscriber 0.3.23",
  "web-sys",
  "web-time",
- "wgpu 29.0.0",
+ "wgpu",
 ]
 
 [[package]]
@@ -4789,10 +4780,10 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "half",
- "naga 29.0.0",
+ "naga",
  "pollster",
  "rustc-hash 2.1.2",
- "wgpu 29.0.0",
+ "wgpu",
 ]
 
 [[package]]
@@ -4802,9 +4793,9 @@ dependencies = [
  "bytemuck",
  "fusor-tile-ir",
  "half",
- "naga 29.0.0",
+ "naga",
  "pollster",
- "wgpu 29.0.0",
+ "wgpu",
 ]
 
 [[package]]
@@ -4816,7 +4807,7 @@ dependencies = [
  "parking_lot",
  "rustc-hash 2.1.2",
  "web-sys",
- "wgpu 29.0.0",
+ "wgpu",
 ]
 
 [[package]]
@@ -5359,7 +5350,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -6211,7 +6202,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7346,32 +7337,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
-dependencies = [
- "arrayvec",
- "bit-set 0.10.0",
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting",
- "half",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash 1.1.0",
- "spirv",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "naga"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -7643,7 +7609,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8017,15 +7983,6 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -9663,7 +9620,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10343,7 +10300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10444,7 +10401,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10859,7 +10816,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows 0.57.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -10973,7 +10930,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12338,7 +12295,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "wgpu"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
@@ -12349,36 +12306,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga 29.0.0",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "smallvec 1.15.1",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core 29.0.0",
- "wgpu-hal 29.0.0",
- "wgpu-types 29.0.0",
-]
-
-[[package]]
-name = "wgpu"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
-dependencies = [
- "arrayvec",
- "bitflags 2.13.0",
- "bytemuck",
- "cfg-if",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "js-sys",
- "log",
- "naga 29.0.3",
+ "naga",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -12388,47 +12316,15 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 29.0.3",
- "wgpu-hal 29.0.3",
- "wgpu-types 29.0.3",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
-dependencies = [
- "arrayvec",
- "bit-set 0.10.0",
- "bit-vec 0.9.1",
- "bitflags 2.13.0",
- "bytemuck",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "log",
- "naga 29.0.0",
- "once_cell",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "rustc-hash 1.1.0",
- "smallvec 1.15.1",
- "thiserror 2.0.18",
- "wgpu-core-deps-apple 29.0.0",
- "wgpu-core-deps-windows-linux-android 29.0.0",
- "wgpu-hal 29.0.0",
- "wgpu-naga-bridge 29.0.0",
- "wgpu-types 29.0.0",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -12440,7 +12336,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "log",
- "naga 29.0.3",
+ "naga",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -12449,106 +12345,42 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec 1.15.1",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple 29.0.3",
+ "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android 29.0.3",
- "wgpu-hal 29.0.3",
- "wgpu-naga-bridge 29.0.3",
- "wgpu-types 29.0.3",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
- "wgpu-hal 29.0.0",
-]
-
-[[package]]
-name = "wgpu-core-deps-apple"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
-dependencies = [
- "wgpu-hal 29.0.3",
+ "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
- "wgpu-hal 29.0.3",
+ "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
- "wgpu-hal 29.0.0",
-]
-
-[[package]]
-name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
-dependencies = [
- "wgpu-hal 29.0.3",
+ "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set 0.10.0",
- "bitflags 2.13.0",
- "block2",
- "bytemuck",
- "cfg-if",
- "cfg_aliases",
- "gpu-allocator",
- "hashbrown 0.16.1",
- "libc",
- "libloading 0.8.9",
- "log",
- "naga 29.0.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
- "objc2-quartz-core",
- "once_cell",
- "ordered-float 5.3.0",
- "parking_lot",
- "portable-atomic",
- "portable-atomic-util",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "raw-window-metal",
- "renderdoc-sys",
- "smallvec 1.15.1",
- "static_assertions",
- "thiserror 2.0.18",
- "wgpu-naga-bridge 29.0.0",
- "wgpu-types 29.0.0",
- "windows 0.62.2",
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -12569,7 +12401,7 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "log",
- "naga 29.0.3",
+ "naga",
  "ndk-sys 0.6.0+11769913",
  "objc2",
  "objc2-core-foundation",
@@ -12577,7 +12409,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float 5.3.0",
+ "ordered-float",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -12591,51 +12423,25 @@ dependencies = [
  "wasm-bindgen",
  "wayland-sys",
  "web-sys",
- "wgpu-naga-bridge 29.0.3",
- "wgpu-types 29.0.3",
+ "wgpu-naga-bridge",
+ "wgpu-types",
  "windows 0.62.2",
  "windows-core 0.62.2",
- "windows-result 0.4.1",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
- "naga 29.0.0",
- "wgpu-types 29.0.0",
-]
-
-[[package]]
-name = "wgpu-naga-bridge"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
-dependencies = [
- "naga 29.0.3",
- "wgpu-types 29.0.3",
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
 version = "29.0.0"
-source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
-dependencies = [
- "bitflags 2.13.0",
- "bytemuck",
- "js-sys",
- "log",
- "raw-window-handle",
- "static_assertions",
- "web-sys",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#9ac9608337827c31ab0eb73606ece91956175494"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -12686,7 +12492,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12702,16 +12508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -12748,24 +12544,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings",
@@ -12784,31 +12568,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
 ]
@@ -325,9 +325,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arroy"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8578a72223dfa13dfd9fc144d15260d134361789ebdea9b16e85a511edc73c7d"
+checksum = "699ea33fc45fb11de023c86d7d4dfe7dda934cfa81838d6bc637e2587f0e5d6d"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -335,9 +335,9 @@ dependencies = [
  "heed",
  "memmap2",
  "nohash",
- "ordered-float",
+ "ordered-float 4.6.0",
  "page_size",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "roaring",
  "tempfile",
@@ -426,8 +426,8 @@ dependencies = [
  "bytes",
  "fnv",
  "futures-util",
- "http 1.4.0",
- "indexmap 2.13.0",
+ "http 1.4.1",
+ "indexmap 2.14.0",
  "mime",
  "multer",
  "num-traits",
@@ -476,7 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
 dependencies = [
  "bytes",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
@@ -577,15 +577,14 @@ dependencies = [
 
 [[package]]
 name = "atom_syndication"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f68d23e2cb4fd958c705b91a6b4c80ceeaf27a9e11651272a8389d5ce1a4a3"
+checksum = "39d8b8ef99e33deb2a51504888222225797f48bace2f0cab01975746a39c05bb"
 dependencies = [
  "chrono",
  "derive_builder 0.20.2",
  "diligent-date-parser",
- "never",
- "quick-xml",
+ "quick-xml 0.39.4",
 ]
 
 [[package]]
@@ -631,14 +630,14 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "ureq 3.2.0",
+ "ureq 3.3.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -676,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -693,10 +692,10 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -727,7 +726,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -756,7 +755,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -776,7 +775,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -869,7 +868,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -878,7 +877,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex 1.3.0",
  "syn 2.0.117",
 ]
@@ -889,14 +888,14 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex 1.3.0",
  "syn 2.0.117",
 ]
@@ -924,6 +923,15 @@ name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec 0.9.1",
 ]
@@ -960,20 +968,20 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -999,16 +1007,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq 0.4.2",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1075,25 +1083,35 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1109,15 +1127,15 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burn"
@@ -1644,7 +1662,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr 0.5.1",
  "rayon",
  "safetensors 0.7.0",
@@ -1667,7 +1685,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr 0.5.1",
  "rayon",
  "safetensors 0.7.0",
@@ -1704,7 +1722,7 @@ dependencies = [
  "candle-nn",
  "fancy-regex 0.17.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "serde",
  "serde_json",
@@ -1875,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1953,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1975,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2070,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -2305,15 +2323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "coreaudio-rs"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
 dependencies = [
  "bindgen 0.72.1",
 ]
@@ -2392,7 +2401,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.6.0",
+ "clap 4.6.1",
  "criterion-plot 0.5.0",
  "is-terminal",
  "itertools 0.10.5",
@@ -2419,7 +2428,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.6.0",
+ "clap 4.6.1",
  "criterion-plot 0.8.2",
  "futures",
  "itertools 0.13.0",
@@ -2510,7 +2519,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -2644,7 +2653,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7522e7acf25d7848032c7b5270780f9f2abe84e13c7ed6345aa27ba70c312ca"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "cubecl-common",
  "cubecl-ir",
@@ -2893,7 +2902,7 @@ dependencies = [
  "sanitize-filename",
  "tracing",
  "wasm-bindgen-futures",
- "wgpu",
+ "wgpu 29.0.3",
 ]
 
 [[package]]
@@ -3179,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
@@ -3326,9 +3335,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -3511,7 +3520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69387edbbc60c7cb93ad96d8cc7a22b49a76e21643380b89b1c49a78d347ff60"
 dependencies = [
  "dioxus-cli-config",
- "http 1.4.0",
+ "http 1.4.1",
  "infer",
  "jni",
  "js-sys",
@@ -3574,7 +3583,7 @@ dependencies = [
  "futures-util",
  "generational-box",
  "longest-increasing-subsequence",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustversion",
  "serde",
  "slab",
@@ -3682,7 +3691,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "headers",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "js-sys",
@@ -3725,7 +3734,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "http 1.4.0",
+ "http 1.4.1",
  "inventory",
  "parking_lot",
  "serde",
@@ -3830,7 +3839,7 @@ checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
 dependencies = [
  "js-sys",
  "lazy-js-bundle",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "sledgehammer_bindgen",
  "sledgehammer_utils",
  "wasm-bindgen",
@@ -3937,7 +3946,7 @@ dependencies = [
  "futures-util",
  "generational-box",
  "parking_lot",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "tracing",
  "warnings",
 ]
@@ -3987,7 +3996,7 @@ dependencies = [
  "gloo-timers",
  "js-sys",
  "lazy-js-bundle",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "send_wrapper",
  "serde",
  "serde-wasm-bindgen",
@@ -4068,15 +4077,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4113,16 +4122,16 @@ dependencies = [
 
 [[package]]
 name = "docx-rs"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70395eb132dcc1761533e62c54878a9deb2b637863ecb52e9c5f66148616398e"
+checksum = "ed73cbf5e1c37baa23f4132569ac1187829f03922c206bd68fe109e3001a343d"
 dependencies = [
  "base64 0.22.1",
  "image 0.25.10",
+ "quick-xml 0.36.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "xml-rs",
  "zip 0.6.6",
 ]
 
@@ -4215,9 +4224,9 @@ checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embassy-futures"
@@ -4512,29 +4521,15 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -4547,13 +4542,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -4604,7 +4598,7 @@ checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr 0.5.1",
 ]
 
@@ -4616,7 +4610,7 @@ checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr 0.5.1",
 ]
 
@@ -4700,7 +4694,7 @@ dependencies = [
  "ndarray 0.16.1",
  "paste",
  "pollster",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
 ]
 
@@ -4708,7 +4702,7 @@ dependencies = [
 name = "fusor-cli"
 version = "0.1.0"
 dependencies = [
- "clap 4.6.0",
+ "clap 4.6.1",
  "fusor-gguf",
  "nom 8.0.0",
  "serde_json",
@@ -4725,7 +4719,7 @@ dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",
  "half",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "web-time",
@@ -4747,15 +4741,16 @@ dependencies = [
  "parking_lot",
  "petgraph 0.8.3",
  "pollster",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "tabbycat",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "web-sys",
  "web-time",
- "wgpu",
+ "wgpu 29.0.0",
 ]
 
 [[package]]
@@ -4782,7 +4777,7 @@ dependencies = [
  "paste",
  "pretty_assertions",
  "reqwest 0.12.28",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustversion",
  "thiserror 2.0.18",
  "tokio",
@@ -4794,10 +4789,10 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "half",
- "naga",
+ "naga 29.0.0",
  "pollster",
- "rustc-hash 2.1.1",
- "wgpu",
+ "rustc-hash 2.1.2",
+ "wgpu 29.0.0",
 ]
 
 [[package]]
@@ -4807,9 +4802,9 @@ dependencies = [
  "bytemuck",
  "fusor-tile-ir",
  "half",
- "naga",
+ "naga 29.0.0",
  "pollster",
- "wgpu",
+ "wgpu 29.0.0",
 ]
 
 [[package]]
@@ -4819,8 +4814,9 @@ dependencies = [
  "fusor-tile-ir",
  "lru 0.14.0",
  "parking_lot",
- "rustc-hash 2.1.1",
- "wgpu",
+ "rustc-hash 2.1.2",
+ "web-sys",
+ "wgpu 29.0.0",
 ]
 
 [[package]]
@@ -4941,9 +4937,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -5139,12 +5135,11 @@ dependencies = [
 
 [[package]]
 name = "generic_singleton"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d5de0fc83987dac514f3b910c5d08392b220efe8cf72086c660029a197bf73"
+checksum = "ab6e923c8e978e57cf63e2e200ca967d1d20f0ea2662b28f6d4e11c44aa6ab16"
 dependencies = [
  "anymap3",
- "lazy_static",
  "parking_lot",
 ]
 
@@ -5168,9 +5163,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx 0.5.1",
  "num-traits",
@@ -5255,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -5296,7 +5291,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.4.0",
+ "http 1.4.1",
  "js-sys",
  "pin-project",
  "serde",
@@ -5373,7 +5368,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -5384,7 +5379,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5399,7 +5394,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5408,17 +5403,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.13.0",
+ "http 1.4.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5435,7 +5430,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr 0.5.1",
  "serde",
  "zerocopy",
@@ -5521,6 +5516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5543,7 +5544,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http 1.4.1",
  "httpdate",
  "mime",
  "sha1",
@@ -5555,7 +5556,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -5569,7 +5570,7 @@ dependencies = [
  "base64 0.22.1",
  "derive_builder 0.20.2",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde",
  "serde_json",
@@ -5625,11 +5626,11 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
+checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "byteorder",
  "heed-traits",
  "heed-types",
@@ -5755,9 +5756,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -5781,7 +5782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -5792,7 +5793,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -5841,22 +5842,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec 1.15.1",
  "tokio",
  "want",
@@ -5864,19 +5864,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5900,7 +5899,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5918,14 +5917,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5959,12 +5958,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -5972,9 +5972,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -5985,9 +5985,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -5999,15 +5999,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -6019,15 +6019,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -6063,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -6099,7 +6099,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif 0.14.1",
+ "gif 0.14.2",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -6125,9 +6125,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -6142,12 +6142,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -6204,16 +6204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6268,9 +6258,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -6281,7 +6271,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -6290,9 +6280,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -6315,10 +6327,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -6358,7 +6372,7 @@ dependencies = [
  "kalosm-streams",
  "kalosm-vision",
  "pollster",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rbert",
  "rodio",
  "serde",
@@ -6381,7 +6395,7 @@ dependencies = [
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tracing",
- "ureq 3.2.0",
+ "ureq 3.3.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6429,7 +6443,7 @@ dependencies = [
  "kalosm-streams",
  "lopdf",
  "pulldown-cmark",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rbert",
  "readability",
  "reqwest 0.11.27",
@@ -6501,7 +6515,7 @@ dependencies = [
  "minijinja-contrib",
  "pollster",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "reqwest 0.12.28",
@@ -6544,7 +6558,7 @@ dependencies = [
  "criterion 0.5.1",
  "kalosm-parse-macro",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex-automata 0.4.14",
  "tracing-subscriber 0.3.23",
 ]
@@ -6567,7 +6581,7 @@ dependencies = [
  "ort",
  "ort-sys",
  "pollster",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rodio",
  "rwhisper",
  "serde_json",
@@ -6589,7 +6603,7 @@ dependencies = [
 name = "kalosm-tokenizer"
 version = "0.4.0"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "thiserror 2.0.18",
 ]
 
@@ -6609,7 +6623,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6727,9 +6741,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -6784,14 +6798,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -6802,7 +6813,7 @@ checksum = "56e7562b41c8876d3367897067013bb2884cc78e6893f092ecd26b305176ac82"
 dependencies = [
  "ndarray 0.15.6",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
 ]
 
@@ -6814,9 +6825,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -6826,9 +6837,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
 dependencies = [
  "cc",
  "doxygen-rs",
@@ -6846,9 +6857,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "longest-increasing-subsequence"
@@ -6876,7 +6887,7 @@ dependencies = [
  "chrono",
  "encoding_rs",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "log",
  "md-5",
@@ -7161,9 +7172,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memfd"
@@ -7231,21 +7242,20 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.17.1"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea5ea1e90055f200af6b8e52a4a34e05e77e7fee953a9fb40c631efdc43cab1"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
  "memo-map",
- "self_cell",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "minijinja-contrib"
-version = "2.17.1"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fce60cb2e26ba7ddd485c8f5d3d635535e465c195bfb4af85971b428a985d0"
+checksum = "99df5123c54391e2a228014c1dbbd85a3dab08a25e776c810526f2f47542b3de"
 dependencies = [
  "minijinja",
  "serde",
@@ -7269,9 +7279,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -7325,12 +7335,36 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "memchr",
  "mime",
  "spin 0.9.8",
  "version_check",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -7341,14 +7375,14 @@ checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "libm",
  "log",
  "num-traits",
@@ -7447,7 +7481,7 @@ dependencies = [
  "noisy_float",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -7456,8 +7490,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.11.0",
- "jni-sys",
+ "bitflags 2.13.0",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
@@ -7470,8 +7504,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.0",
- "jni-sys",
+ "bitflags 2.13.0",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -7491,7 +7525,7 @@ version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -7500,14 +7534,8 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
-
-[[package]]
-name = "never"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -7538,6 +7566,15 @@ dependencies = [
  "easyfft",
  "hound",
  "once_cell",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -7646,9 +7683,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -7714,9 +7751,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -7724,9 +7761,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7758,7 +7795,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -7775,7 +7812,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -7796,7 +7833,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -7808,7 +7845,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -7834,7 +7871,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "humantime",
  "itertools 0.14.0",
  "parking_lot",
@@ -7904,7 +7941,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -7928,15 +7965,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -7960,9 +7996,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -7981,6 +8017,15 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -8007,7 +8052,7 @@ dependencies = [
  "pkg-config",
  "sha2",
  "tar",
- "ureq 3.2.0",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -8074,7 +8119,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec 1.15.1",
  "windows-link",
 ]
@@ -8161,9 +8206,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -8191,7 +8236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -8202,7 +8247,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -8262,7 +8307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -8272,7 +8317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -8304,7 +8349,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
  "unicase",
 ]
 
@@ -8316,18 +8361,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8348,15 +8393,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -8405,7 +8444,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -8443,9 +8482,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -8465,9 +8504,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -8560,18 +8599,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -8585,9 +8624,9 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -8629,7 +8668,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "getopts",
  "memchr",
  "unicase",
@@ -8660,9 +8699,9 @@ checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -8681,9 +8720,19 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -8703,9 +8752,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.19"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530e84778a55de0f52645a51d4e3b9554978acd6a1e7cd50b6a6784692b3029e"
+checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -8724,9 +8773,9 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8742,9 +8791,9 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -8763,7 +8812,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8808,9 +8857,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -8819,9 +8868,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -8889,7 +8938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -8941,7 +8990,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -8970,7 +9019,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8999,9 +9048,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -9089,16 +9138,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -9258,11 +9298,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -9292,7 +9332,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -9466,14 +9506,13 @@ dependencies = [
 
 [[package]]
 name = "rss"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2107738f003660f0a91f56fd3e3bd3ab5d918b2ddaf1e1ec2136fb1c46f71bf"
+checksum = "d0e38781082c53bdde56e6081698c06831f69a27eac2593ed6b6cb2511424ad5"
 dependencies = [
  "atom_syndication",
  "derive_builder 0.20.2",
- "never",
- "quick-xml",
+ "quick-xml 0.39.4",
 ]
 
 [[package]]
@@ -9549,18 +9588,19 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -9577,9 +9617,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_lexer"
@@ -9619,7 +9659,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -9628,9 +9668,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -9652,9 +9692,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -9662,9 +9702,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -9695,7 +9735,7 @@ dependencies = [
  "kalosm-common",
  "kalosm-model-types",
  "pollster",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "rodio",
  "rustfft",
@@ -9841,7 +9881,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -9876,7 +9916,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cssparser 0.31.2",
  "derive_more 0.99.20",
  "fxhash",
@@ -9890,16 +9930,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
-
-[[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -9994,11 +10028,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -10039,9 +10073,9 @@ dependencies = [
 
 [[package]]
 name = "serde_regex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
  "serde",
@@ -10070,15 +10104,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -10089,9 +10124,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10163,9 +10198,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_helpers"
@@ -10202,9 +10237,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -10303,9 +10338,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -10324,11 +10359,11 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.15.0"
+version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "num-traits",
  "robust",
  "smallvec 1.15.1",
@@ -10359,7 +10394,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -10401,15 +10436,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10542,9 +10577,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "2.6.3"
+version = "2.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15697afb724b2ee5432b6be91e23dad09c4376ac53b25beecafba02d7998f31"
+checksum = "3429154a8b5a98ca39100ba45ef49ae046fb1d0869dff78d78a2670b1b278982"
 dependencies = [
  "arrayvec",
  "async-channel",
@@ -10554,7 +10589,7 @@ dependencies = [
  "futures",
  "geo",
  "getrandom 0.3.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "path-clean",
  "pharos",
  "reblessive",
@@ -10584,9 +10619,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "2.6.3"
+version = "2.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a825cd689bd35cadcb4edfb668da7315df34033d0ccb0f2be47d17e230035709"
+checksum = "ba423d9e7e665e4c735a1d4669c3a067135e4a574edf88af215f7f2b815e70ed"
 dependencies = [
  "addr",
  "affinitypool",
@@ -10618,7 +10653,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hashbrown 0.14.5",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "ipnet",
  "jsonwebtoken",
  "lexicmp",
@@ -10636,7 +10671,7 @@ dependencies = [
  "pin-project-lite",
  "quick_cache 0.5.2",
  "radix_trie",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "reblessive",
  "regex",
@@ -10688,7 +10723,7 @@ dependencies = [
  "getrandom 0.2.17",
  "lru 0.12.5",
  "parking_lot",
- "quick_cache 0.6.19",
+ "quick_cache 0.6.23",
  "revision 0.10.0",
  "vart 0.9.3",
 ]
@@ -10805,7 +10840,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -10858,7 +10893,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -10902,9 +10937,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -10921,7 +10956,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "ndarray 0.16.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "safetensors 0.3.3",
  "thiserror 1.0.69",
  "torch-sys",
@@ -11130,9 +11165,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -11182,7 +11217,7 @@ dependencies = [
  "macro_rules_attribute",
  "monostate",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -11215,7 +11250,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -11231,9 +11266,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -11241,16 +11276,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11314,7 +11349,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -11334,14 +11369,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 0.7.15",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -11392,20 +11427,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -11651,10 +11686,10 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -11671,10 +11706,10 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -11688,10 +11723,10 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -11712,7 +11747,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -11749,9 +11784,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -11765,7 +11800,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "web-time",
 ]
@@ -11818,9 +11853,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -11884,9 +11919,9 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "der",
@@ -11898,19 +11933,19 @@ dependencies = [
  "rustls-pki-types",
  "socks",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-root-certs",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -11938,6 +11973,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -12085,11 +12126,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -12098,41 +12139,38 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12140,9 +12178,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12153,9 +12191,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -12177,7 +12215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -12201,9 +12239,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -12234,9 +12272,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12266,9 +12304,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12279,14 +12317,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12299,12 +12337,11 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "29.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -12312,7 +12349,36 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga",
+ "naga 29.0.0",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec 1.15.1",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 29.0.0",
+ "wgpu-hal 29.0.0",
+ "wgpu-types 29.0.0",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga 29.0.3",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -12322,9 +12388,40 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 29.0.3",
+ "wgpu-hal 29.0.3",
+ "wgpu-types 29.0.3",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "log",
+ "naga 29.0.0",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec 1.15.1",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple 29.0.0",
+ "wgpu-core-deps-windows-linux-android 29.0.0",
+ "wgpu-hal 29.0.0",
+ "wgpu-naga-bridge 29.0.0",
+ "wgpu-types 29.0.0",
 ]
 
 [[package]]
@@ -12336,14 +12433,14 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bit-vec 0.9.1",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
- "naga",
+ "naga 29.0.3",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -12352,12 +12449,20 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec 1.15.1",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple",
+ "wgpu-core-deps-apple 29.0.3",
  "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-naga-bridge",
- "wgpu-types",
+ "wgpu-core-deps-windows-linux-android 29.0.3",
+ "wgpu-hal 29.0.3",
+ "wgpu-naga-bridge 29.0.3",
+ "wgpu-types 29.0.3",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+dependencies = [
+ "wgpu-hal 29.0.0",
 ]
 
 [[package]]
@@ -12366,7 +12471,7 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 29.0.3",
 ]
 
 [[package]]
@@ -12375,7 +12480,15 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 29.0.3",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+dependencies = [
+ "wgpu-hal 29.0.0",
 ]
 
 [[package]]
@@ -12384,7 +12497,51 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 29.0.3",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.10.0",
+ "bitflags 2.13.0",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "gpu-allocator",
+ "hashbrown 0.16.1",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga 29.0.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float 5.3.0",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec 1.15.1",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "wgpu-naga-bridge 29.0.0",
+ "wgpu-types 29.0.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -12397,7 +12554,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.9.1",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2",
  "bytemuck",
  "cfg-if",
@@ -12412,7 +12569,7 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "log",
- "naga",
+ "naga 29.0.3",
  "ndk-sys 0.6.0+11769913",
  "objc2",
  "objc2-core-foundation",
@@ -12420,7 +12577,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float",
+ "ordered-float 5.3.0",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -12434,11 +12591,20 @@ dependencies = [
  "wasm-bindgen",
  "wayland-sys",
  "web-sys",
- "wgpu-naga-bridge",
- "wgpu-types",
+ "wgpu-naga-bridge 29.0.3",
+ "wgpu-types 29.0.3",
  "windows 0.62.2",
  "windows-core 0.62.2",
  "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+dependencies = [
+ "naga 29.0.0",
+ "wgpu-types 29.0.0",
 ]
 
 [[package]]
@@ -12447,8 +12613,22 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
- "naga",
- "wgpu-types",
+ "naga 29.0.3",
+ "wgpu-types 29.0.3",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.0"
+source = "git+https://github.com/ealmloff/wgpu?branch=yield-now#686cad182b43cf6f58cebaa2ccecf980efd7d57b"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "static_assertions",
+ "web-sys",
 ]
 
 [[package]]
@@ -12457,7 +12637,7 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -13020,6 +13200,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -13051,6 +13234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13069,7 +13258,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -13099,8 +13288,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -13119,7 +13308,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -13131,9 +13320,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -13210,9 +13399,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -13221,9 +13410,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13233,18 +13422,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13253,18 +13442,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13280,9 +13469,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -13291,9 +13480,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -13302,9 +13491,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13338,7 +13527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "typed-path",
 ]
@@ -13395,9 +13584,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ members = [
     "fusor-ml/webgpu-runner",
 ]
 
+[patch.crates-io]
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now" }
+
 [workspace.dependencies]
 kalosm = { path = "./interfaces/kalosm", version = "0.4.0", default-features = false }
 kalosm-sample = { path = "./interfaces/kalosm-sample", version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ pollster = "0.4"
 serde = { version = "1.0.163", features = ["derive"], optional = true }
 surrealdb = { version = "2.4.0", default-features = false, optional = true }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"], optional = true }
+tracing = { version = "0.1.40", optional = true }
 tracing-subscriber = { version = "0.2", optional = true }
 
 [features]
@@ -157,7 +158,7 @@ tokio = [
     "kalosm/tokio",
     "kalosm-language?/tokio",
 ]
-tracing-subscriber = ["dep:tracing-subscriber"]
+tracing-subscriber = ["dep:tracing-subscriber", "dep:tracing"]
 
 [[example]]
 name = "axum"
@@ -375,7 +376,7 @@ required-features = [
 [[example]]
 name = "vision"
 path = "interfaces/kalosm/examples/vision.rs"
-required-features = ["llama-vision", "tracing-subscriber"]
+required-features = ["llama-vision", "tokio", "tracing-subscriber"]
 
 [profile.dist]
 inherits = "release"

--- a/fusor-ml/conformance/Cargo.toml
+++ b/fusor-ml/conformance/Cargo.toml
@@ -13,6 +13,7 @@ thiserror.workspace = true
 bytemuck = "1.14"
 web-time = { workspace = true }
 burn = { version = "0.21.0", default-features = false, features = ["std", "webgpu", "fusion"], optional = true }
+tracing = "0.1.41"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/fusor-ml/conformance/src/bench/registry.rs
+++ b/fusor-ml/conformance/src/bench/registry.rs
@@ -72,7 +72,7 @@ macro_rules! registry {
                 match Device::gpu().await {
                     Ok(device) => Some(device),
                     Err(err) => {
-                        eprintln!("skipping WebGPU benchmark smoke test: {err}");
+                        tracing::warn!("skipping WebGPU benchmark smoke test: {err}");
                         None
                     }
                 }
@@ -99,7 +99,7 @@ macro_rules! registry {
                     .await
                     .unwrap();
                     for report in reports {
-                        eprintln!(
+                        tracing::info!(
                             "{}: mean={:.3} ms median={:.3} ms stddev={:.3} ms samples={} iterations/sample={}",
                             report.name,
                             report.mean_ms,
@@ -164,7 +164,7 @@ mod burn_generated_tests {
         match Device::gpu().await {
             Ok(device) => Some(device),
             Err(err) => {
-                eprintln!("skipping Burn benchmark smoke test: {err}");
+                tracing::warn!("skipping Burn benchmark smoke test: {err}");
                 None
             }
         }
@@ -189,7 +189,7 @@ mod burn_generated_tests {
                     .await
                     .unwrap();
                     for report in reports {
-                        eprintln!(
+                        tracing::info!(
                             "{}: mean={:.3} ms median={:.3} ms stddev={:.3} ms samples={} iterations/sample={}",
                             report.name,
                             report.mean_ms,

--- a/fusor-ml/conformance/src/suite/native/quantized_matmul_paired.rs
+++ b/fusor-ml/conformance/src/suite/native/quantized_matmul_paired.rs
@@ -276,7 +276,11 @@ fn llama_shape_dense_sampled_columns_case() -> AssertionCase {
             Tensor::from_slice(&device, [sample_count], &expected)
         }
     })
-    .compare_with(approx_or_relative_compare::<1>(2.0, 1e-4))
+    // This case multiplies SiLU(gate) by up after two independent 4096-term
+    // q4k reductions. Subgroup and no-subgroup paths use different reduction
+    // trees, so the final product needs a little more relative slack than a
+    // single qmatmul output.
+    .compare_with(approx_or_relative_compare::<1>(2.0, 2e-4))
     .baseline_on_test_device()
     .devices_async(gpu_devices())
     .runs(1)

--- a/fusor-ml/conformance/src/suite/native/vision_block_pattern.rs
+++ b/fusor-ml/conformance/src/suite/native/vision_block_pattern.rs
@@ -157,7 +157,7 @@ pub async fn vision_block_pattern_flush_vs_no_flush_timing() {
             flush_total += t.elapsed();
         }
 
-        eprintln!(
+        tracing::info!(
             "device={device:?} blocks={BLOCKS} iters={ITERS}: no_flush_avg={:.2?} flush_every_4_avg={:.2?}",
             no_flush_total / ITERS as u32,
             flush_total / ITERS as u32,

--- a/fusor-ml/conformance/src/suite/webgpu.rs
+++ b/fusor-ml/conformance/src/suite/webgpu.rs
@@ -534,7 +534,7 @@ mod tests {
                 ran_on_gpu = true;
                 if std::env::var_os("FUSOR_CONFORMANCE_PROGRESS").is_some() {
                     run_webgpu_kernel_suite_with_progress(&device, |case| {
-                        eprintln!("webgpu_conformance {case}");
+                        tracing::info!("webgpu_conformance {case}");
                     })
                     .await
                     .expect("webgpu kernel suite should pass on the GPU device");

--- a/fusor-ml/core/Cargo.toml
+++ b/fusor-ml/core/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 edition = "2024"
 
 [dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["std", "naga-ir"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["std", "naga-ir"] }
 bytemuck = { version = "1.14", features = ["derive"] }
 futures-channel = { workspace = true }
 tabbycat = { version = "0.1.3", optional = true }
@@ -30,16 +30,17 @@ web-time.workspace = true
 reqwest = { version = "0.12.15", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["metal"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["metal"] }
 
 [target.'cfg(windows)'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["dx12"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["dx12"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["vulkan"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["vulkan"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["webgpu"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["webgpu"] }
+web-sys = { version = "0.3", features = ["console"] }
 
 [features]
 default = []

--- a/fusor-ml/core/Cargo.toml
+++ b/fusor-ml/core/Cargo.toml
@@ -40,7 +40,6 @@ wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["webgpu"] }
-web-sys = { version = "0.3", features = ["console"] }
 
 [features]
 default = []

--- a/fusor-ml/core/examples/wgpu_overhead_probe.rs
+++ b/fusor-ml/core/examples/wgpu_overhead_probe.rs
@@ -71,10 +71,12 @@ fn print_samples(label: &str, samples: &[Duration]) {
     let median = sorted[sorted.len() / 2];
     let min = sorted[0];
     let max = sorted[sorted.len() - 1];
-    eprintln!("{label}: median={median:?} min={min:?} max={max:?} samples={samples:?}");
+    tracing::info!("{label}: median={median:?} min={min:?} max={max:?} samples={samples:?}");
 }
 
 fn main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
     pollster::block_on(async {
         let repeats = std::env::args()
             .nth(1)
@@ -82,7 +84,7 @@ fn main() {
             .unwrap_or(20);
 
         let device = Device::new().await.unwrap();
-        eprintln!("device={:?}", device.wgpu_adapter().get_info());
+        tracing::info!("device={:?}", device.wgpu_adapter().get_info());
 
         let data = vec![vec![1.0f32; 100]; 100];
         let tensor = Tensor::new(&device, &data);

--- a/fusor-ml/core/src/compute_graph/mod.rs
+++ b/fusor-ml/core/src/compute_graph/mod.rs
@@ -3,7 +3,6 @@ use std::{any::Any, sync::Arc};
 use parking_lot::RwLock;
 pub use petgraph::graph::NodeIndex;
 use petgraph::prelude::StableGraph;
-pub(crate) use resolve::DecodePlanCache;
 use resolve::Resolver;
 use rustc_hash::FxHashMap;
 #[cfg(feature = "graphvis")]

--- a/fusor-ml/core/src/compute_graph/mod.rs
+++ b/fusor-ml/core/src/compute_graph/mod.rs
@@ -3,6 +3,7 @@ use std::{any::Any, sync::Arc};
 use parking_lot::RwLock;
 pub use petgraph::graph::NodeIndex;
 use petgraph::prelude::StableGraph;
+pub(crate) use resolve::DecodePlanCache;
 use resolve::Resolver;
 use rustc_hash::FxHashMap;
 #[cfg(feature = "graphvis")]

--- a/fusor-ml/core/src/compute_graph/resolve/mod.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/mod.rs
@@ -2,6 +2,16 @@ use std::{collections::VecDeque, str::FromStr, sync::Arc};
 
 use web_time::{Duration, Instant};
 
+// Diagnostic: route the resolve host-profile `eprintln!`s (the build/encode/
+// submit breakdown) to the browser console on wasm, where std eprintln is
+// invisible. Native keeps the real eprintln!.
+#[cfg(target_arch = "wasm32")]
+macro_rules! eprintln {
+    ($($arg:tt)*) => {{
+        web_sys::console::log_1(&format!($($arg)*).into());
+    }};
+}
+
 use crate::{
     DataTypeEnum, Layout,
     compute_graph::layout_pass::LayoutPass,
@@ -21,7 +31,10 @@ use super::{ComputeGraphInner, ComputeGraphNode, ComputeGraphNodeVariant, NodeIn
 mod execution;
 mod fusion_basic;
 mod fusion_matmul;
+mod plan_cache;
 mod run;
+
+pub(crate) use plan_cache::{DecodePlanCache, structural_kernel_key};
 
 pub(crate) struct ResolverResult {
     pub(crate) data: TensorData,

--- a/fusor-ml/core/src/compute_graph/resolve/mod.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/mod.rs
@@ -24,7 +24,7 @@ mod fusion_matmul;
 mod plan_cache;
 mod run;
 
-pub(crate) use plan_cache::{DecodePlanCache, structural_kernel_key};
+pub(crate) use plan_cache::structural_kernel_key;
 
 pub(crate) struct ResolverResult {
     pub(crate) data: TensorData,

--- a/fusor-ml/core/src/compute_graph/resolve/mod.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/mod.rs
@@ -2,16 +2,6 @@ use std::{collections::VecDeque, str::FromStr, sync::Arc};
 
 use web_time::{Duration, Instant};
 
-// Diagnostic: route the resolve host-profile `eprintln!`s (the build/encode/
-// submit breakdown) to the browser console on wasm, where std eprintln is
-// invisible. Native keeps the real eprintln!.
-#[cfg(target_arch = "wasm32")]
-macro_rules! eprintln {
-    ($($arg:tt)*) => {{
-        web_sys::console::log_1(&format!($($arg)*).into());
-    }};
-}
-
 use crate::{
     DataTypeEnum, Layout,
     compute_graph::layout_pass::LayoutPass,
@@ -152,7 +142,7 @@ struct OptimizeProfile {
 
 impl OptimizeProfile {
     fn print(&self) {
-        eprintln!(
+        tracing::info!(
             "resolve_optimize_profile iterations={} changed={} \
 fuse_naries_count={} fuse_naries={:?} \
 fuse_reduce_count={} fuse_reduce={:?} \
@@ -184,7 +174,7 @@ fn optimize_node_limit() -> usize {
 
 impl ResolveHostProfile {
     fn print(&self, total: Duration, queued_ops: usize, kernels: usize) {
-        eprintln!(
+        tracing::info!(
             "resolve_host_profile queued_ops={queued_ops} kernels={kernels} total={total:?} \
 build_execution_graph={:?} optimize={:?} toposort={:?} queue_lowering={:?} \
 consumer_count={:?} encoder_create={:?} map_layout={:?} inputs={:?} output={:?} \
@@ -227,7 +217,7 @@ fn print_host_category_profile(profile: FxHashMap<&'static str, ResolveHostCateg
         })
         .collect::<Vec<_>>();
     profile.sort_by_key(|entry| std::cmp::Reverse(entry.5));
-    eprintln!("resolve_host_category_profile {profile:?}");
+    tracing::info!("resolve_host_category_profile {profile:?}");
 }
 
 fn node_category(variant: &ComputeGraphNodeVariant) -> &'static str {
@@ -333,7 +323,7 @@ fn print_gpu_kernel_profile(
     names.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
     names.truncate(32);
 
-    eprintln!(
+    tracing::info!(
         "resolve_gpu_kernel_profile mode={} kernels={} accounted_ms={:.3} span_ms={:.3} timestamp_period_ns={:.3}",
         timestamp_mode,
         records.len(),
@@ -341,8 +331,8 @@ fn print_gpu_kernel_profile(
         span_ns / 1_000_000.0,
         timestamp_period_ns
     );
-    eprintln!("resolve_gpu_kernel_categories {categories:?}");
-    eprintln!("resolve_gpu_kernel_top_names {names:?}");
+    tracing::info!("resolve_gpu_kernel_categories {categories:?}");
+    tracing::info!("resolve_gpu_kernel_top_names {names:?}");
 }
 
 pub(crate) struct Resolver {

--- a/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
@@ -1,51 +1,11 @@
-//! Decode plan cache.
-//!
-//! During autoregressive decode, every token resolves a structurally identical
-//! compute graph: the same operations, in the same toposorted order, with the
-//! same shapes (only the KV-cache-dependent attention ops and the live buffer
-//! handles change token-to-token). Yet `build_kernel` re-runs the full per-op
-//! analysis — kernel-variant selection, workgroup solving, epilogue hashing,
-//! tile-IR lowering checks — every token, even though the compiled pipelines
-//! are already cached. On the web build that analysis dominates the per-token
-//! host cost (~10ms of a ~16ms token).
-//!
-//! This cache memoizes bufferless [`DirectKernelTemplate`]s per operation and,
-//! on a structurally-matching token, rebinds only the buffers (which is cheap)
-//! instead of rebuilding the kernels. It is correctness-safe by construction:
-//! the cache key carries the operation's structural kernel key (op type,
-//! kernel fields, dispatch, workgroup, and every input/output layout/format), so
-//! any structural change is a miss (full rebuild). Buffers are *always*
-//! re-derived from the current token's inputs/output, so a cached template never
-//! carries a stale activation buffer.
-//!
-//! Disable with `FUSOR_DISABLE_DECODE_PLAN_CACHE` (native only; `var_os` is
-//! always `None` on wasm, so the cache is always on for the web build).
-
-use std::{
-    hash::{Hash, Hasher},
-    num::NonZeroUsize,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-};
-
-use lru::LruCache;
-use parking_lot::Mutex;
-use rustc_hash::{FxBuildHasher, FxHasher};
+//! Structural plan-cache keys for resolved operations.
 
 use crate::mir::inputs::MirValue;
-use crate::mir::kernel_backend::{
-    DirectKernel, DirectKernelTemplate, KernelCacheKey, KernelVariantKey,
-};
+use crate::mir::kernel_backend::{KernelCacheKey, KernelVariantKey};
 use crate::mir::operation::Operation;
 use crate::mir::workgroup_shape::WorkgroupShape;
-use crate::tensor::TensorData;
 
-struct DecodePlanCacheKernelVariant;
-const DECODE_PLAN_CACHE_SIZE: usize = 4096;
-
-type DecodePlanCacheKey = (KernelCacheKey, u64);
+struct DirectPlanCacheKernelVariant;
 
 pub(crate) fn structural_kernel_key(
     operation: &dyn Operation,
@@ -54,195 +14,11 @@ pub(crate) fn structural_kernel_key(
 ) -> KernelCacheKey {
     let dispatch_size = operation.dispatch_size(workgroup, inputs);
     operation.kernel_cache_key_with_dispatch(
-        KernelVariantKey::of::<DecodePlanCacheKernelVariant>(),
+        KernelVariantKey::of::<DirectPlanCacheKernelVariant>(),
         Some(workgroup),
         dispatch_size,
         inputs,
     )
-}
-
-/// Where one of a kernel's bound buffers comes from on each decode token.
-enum BufSource {
-    /// The operation's output buffer (freshly allocated every token).
-    Output,
-    /// The buffer of `inputs[i]` (a graph tensor or a quantized matrix).
-    Input(usize),
-    /// A buffer that is neither an input nor the output — a model weight or a
-    /// scratch buffer allocated during the build. Stable across tokens, so we
-    /// hold the `Arc` and reuse it. (Reuse is safe: submits execute in queue
-    /// order, so a scratch buffer is never read by token N while token N+1
-    /// writes it.)
-    Const(Arc<wgpu::Buffer>),
-}
-
-/// A memoized build result for a single operation: the kernel templates plus,
-/// for each kernel, where to source its buffers from on a replay.
-struct CachedOpPlan {
-    kernels: Vec<(DirectKernelTemplate, Vec<BufSource>)>,
-}
-
-impl CachedOpPlan {
-    fn record(built: &[DirectKernel], inputs: &[MirValue], output: &TensorData) -> Self {
-        let output_buf = output.buffer();
-        let kernels = built
-            .iter()
-            .map(|kernel| {
-                let sources = kernel
-                    .binding_buffers()
-                    .iter()
-                    .map(|buffer| classify_buffer(buffer, inputs, output_buf))
-                    .collect();
-                (kernel.to_template(), sources)
-            })
-            .collect();
-        Self { kernels }
-    }
-
-    fn rebind(&self, inputs: &[MirValue], output: &TensorData) -> Vec<DirectKernel> {
-        self.kernels
-            .iter()
-            .map(|(template, sources)| {
-                let new_buffers = sources
-                    .iter()
-                    .map(|source| match source {
-                        BufSource::Output => output.buffer().clone(),
-                        BufSource::Input(i) => mir_buffer(&inputs[*i])
-                            .expect("cached Input source must resolve to a buffer")
-                            .clone(),
-                        BufSource::Const(buffer) => buffer.clone(),
-                    })
-                    .collect::<Vec<_>>();
-                template.bind_buffers(&new_buffers)
-            })
-            .collect()
-    }
-}
-
-fn mir_buffer(value: &MirValue) -> Option<&Arc<wgpu::Buffer>> {
-    match value {
-        MirValue::Tensor(tensor) => Some(tensor.buffer()),
-        MirValue::QMatrix(matrix) => Some(matrix.buffer()),
-        MirValue::Integer(_) | MirValue::Float(_) => None,
-    }
-}
-
-fn classify_buffer(
-    buffer: &Arc<wgpu::Buffer>,
-    inputs: &[MirValue],
-    output_buf: &Arc<wgpu::Buffer>,
-) -> BufSource {
-    if Arc::ptr_eq(buffer, output_buf) {
-        return BufSource::Output;
-    }
-    for (i, input) in inputs.iter().enumerate() {
-        if let Some(input_buf) = mir_buffer(input)
-            && Arc::ptr_eq(buffer, input_buf)
-        {
-            return BufSource::Input(i);
-        }
-    }
-    BufSource::Const(buffer.clone())
-}
-
-fn fingerprint_aliases(inputs: &[MirValue], output: &TensorData) -> u64 {
-    let mut hasher = FxHasher::default();
-    1u8.hash(&mut hasher);
-    inputs.len().hash(&mut hasher);
-    let mut seen = Vec::new();
-    for input in inputs {
-        let class = mir_buffer(input).map(|buffer| alias_class(&mut seen, buffer));
-        class.hash(&mut hasher);
-    }
-    alias_class(&mut seen, output.buffer()).hash(&mut hasher);
-    hasher.finish()
-}
-
-fn alias_class<'a>(seen: &mut Vec<&'a Arc<wgpu::Buffer>>, buffer: &'a Arc<wgpu::Buffer>) -> usize {
-    if let Some(index) = seen
-        .iter()
-        .position(|candidate| Arc::ptr_eq(*candidate, buffer))
-    {
-        index
-    } else {
-        let index = seen.len();
-        seen.push(buffer);
-        index
-    }
-}
-
-/// Persistent, device-wide cache of decode plans, keyed by the structural
-/// kernel key plus the current input/output aliasing pattern.
-pub(crate) struct DecodePlanCache {
-    enabled: bool,
-    plans: Mutex<LruCache<DecodePlanCacheKey, CachedOpPlan, FxBuildHasher>>,
-    hits: AtomicU64,
-    misses: AtomicU64,
-}
-
-impl std::fmt::Debug for DecodePlanCache {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DecodePlanCache")
-            .field("enabled", &self.enabled)
-            .finish()
-    }
-}
-
-impl DecodePlanCache {
-    pub(crate) fn new() -> Self {
-        Self {
-            enabled: std::env::var_os("FUSOR_DISABLE_DECODE_PLAN_CACHE").is_none(),
-            plans: Mutex::new(LruCache::with_hasher(
-                NonZeroUsize::new(DECODE_PLAN_CACHE_SIZE)
-                    .expect("decode plan cache size must be non-zero"),
-                Default::default(),
-            )),
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
-        }
-    }
-
-    pub(crate) fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    /// Return kernels for a structurally unchanged operation by rebinding a
-    /// cached template to the current token's buffers. On miss, build and cache
-    /// a new bufferless plan.
-    pub(crate) fn resolve_op(
-        &self,
-        kernel_key: KernelCacheKey,
-        inputs: &[MirValue],
-        output: &TensorData,
-        build: impl FnOnce() -> Vec<DirectKernel>,
-    ) -> Vec<DirectKernel> {
-        let alias_fp = fingerprint_aliases(inputs, output);
-        let cache_key = (kernel_key, alias_fp);
-
-        {
-            let mut plans = self.plans.lock();
-            if let Some(plan) = plans.get(&cache_key) {
-                let hit_total = self.hits.fetch_add(1, Ordering::Relaxed) + 1;
-                trace_cache_event(hit_total, self.misses.load(Ordering::Relaxed));
-                return plan.rebind(inputs, output);
-            }
-        }
-
-        let miss_total = self.misses.fetch_add(1, Ordering::Relaxed) + 1;
-        trace_cache_event(self.hits.load(Ordering::Relaxed), miss_total);
-        let built = build();
-        self.plans
-            .lock()
-            .put(cache_key, CachedOpPlan::record(&built, inputs, output));
-        built
-    }
-}
-
-fn trace_cache_event(hits: u64, misses: u64) {
-    // Mirror the resolve host-trace gate (always on for wasm, env-gated on
-    // native) so the cache hit rate shows up alongside `resolve_host_profile`.
-    if cfg!(target_arch = "wasm32") || std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some() {
-        tracing::info!("decode_plan_cache hit={hits} miss={misses}");
-    }
 }
 
 #[cfg(test)]
@@ -301,6 +77,11 @@ mod tests {
         read_rows(&(&a + &b)).await
     }
 
+    async fn run_pairwise_self_add(device: &Device) -> Vec<f32> {
+        let a = Tensor::new::<f32, 2, _>(device, &[[1.0f32, 2.0, 3.0, 4.0]]);
+        read_rows(&(&a + &a)).await
+    }
+
     async fn run_pairwise_mul(device: &Device) -> Vec<f32> {
         let a = Tensor::new::<f32, 2, _>(device, &[[1.0f32, 2.0, 3.0, 4.0]]);
         let b = Tensor::new::<f32, 2, _>(device, &[[0.5f32, -1.0, 2.0, -0.25]]);
@@ -320,9 +101,10 @@ mod tests {
         read_rows(&base.slice_assign(slices, &value)).await
     }
 
-    // Exercises the `Sequence` kernel arm (scratch + reduce + write passes) with
-    // its scratch buffer reused across tokens: a large softmax takes the split
-    // path. `seed` makes the input (and output) input-dependent.
+    // Exercises the `Sequence` kernel arm (scratch + reduce + write passes). A
+    // large softmax takes the split path; candidate direct-plan bindings are not
+    // inserted because scratch bindings are allocated inside the build.
+    // `seed` makes the input (and output) input-dependent.
     async fn run_softmax(device: &Device, seed: f32) -> Vec<f32> {
         let data: Vec<f32> = (0..4096)
             .map(|i| ((i as f32) * 0.001 + seed).sin())
@@ -354,7 +136,7 @@ mod tests {
     // reference. Covers both build arms, including the fused-epilogue qmatmul the
     // old fast cache could not key.
     #[test]
-    fn decode_plan_cache_rebind_matches_fresh_build() {
+    fn direct_plan_cache_rebind_matches_fresh_build() {
         pollster::block_on(async {
             let Ok(device) = Device::new().await else {
                 return;
@@ -389,22 +171,22 @@ mod tests {
             assert_close(&hit_u, &golden_u, "nary: rebind with new buffers");
             assert!(hit_u != hit_v, "nary: different inputs must differ");
 
-            // --- Sequence arm (split softmax with a reused scratch buffer) ---
+            // --- Sequence arm (split softmax, not direct-plan cached yet) ---
             let miss_v = run_softmax(&device, 0.0).await;
-            let hit_v = run_softmax(&device, 0.0).await;
+            let repeat_v = run_softmax(&device, 0.0).await;
             assert_eq!(
-                miss_v, hit_v,
-                "softmax: rebind must byte-match the cold build"
+                miss_v, repeat_v,
+                "softmax: repeat build must byte-match the cold build"
             );
-            let hit_u = run_softmax(&device, 0.7).await;
+            let next_u = run_softmax(&device, 0.7).await;
             let golden_u = run_softmax(&golden, 0.7).await;
-            assert_close(&hit_u, &golden_u, "softmax: rebind with new buffers");
-            assert!(hit_u != hit_v, "softmax: different inputs must differ");
+            assert_close(&next_u, &golden_u, "softmax: rebuild with new buffers");
+            assert!(next_u != repeat_v, "softmax: different inputs must differ");
         });
     }
 
     #[test]
-    fn decode_plan_cache_distinguishes_same_shape_generic_ops() {
+    fn direct_plan_cache_distinguishes_same_shape_generic_ops() {
         pollster::block_on(async {
             let Ok(device) = Device::new().await else {
                 return;
@@ -423,7 +205,33 @@ mod tests {
     }
 
     #[test]
-    fn decode_plan_cache_distinguishes_same_shape_slice_assign_ranges() {
+    fn direct_plan_cache_rebinds_repeated_binding_slots_positionally() {
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            let Ok(golden) = Device::new().await else {
+                return;
+            };
+
+            let alias_add = run_pairwise_self_add(&device).await;
+            let distinct_add = run_pairwise_add(&device).await;
+            let golden_distinct_add = run_pairwise_add(&golden).await;
+
+            assert_close(
+                &distinct_add,
+                &golden_distinct_add,
+                "repeated binding slots: distinct add after self add",
+            );
+            assert!(
+                distinct_add != alias_add,
+                "repeated binding slots: distinct add must not reuse the repeated buffer"
+            );
+        });
+    }
+
+    #[test]
+    fn direct_plan_cache_distinguishes_same_shape_slice_assign_ranges() {
         pollster::block_on(async {
             let Ok(device) = Device::new().await else {
                 return;

--- a/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
@@ -141,10 +141,10 @@ fn classify_buffer(
         return BufSource::Output;
     }
     for (i, input) in inputs.iter().enumerate() {
-        if let Some(input_buf) = mir_buffer(input) {
-            if Arc::ptr_eq(buffer, input_buf) {
-                return BufSource::Input(i);
-            }
+        if let Some(input_buf) = mir_buffer(input)
+            && Arc::ptr_eq(buffer, input_buf)
+        {
+            return BufSource::Input(i);
         }
     }
     BufSource::Const(buffer.clone())
@@ -201,11 +201,11 @@ impl OpPlanSlots {
     ) -> Vec<DirectKernel> {
         let alias_fp = fingerprint_aliases(inputs, output);
 
-        if let Some(Some(plan)) = self.slots.get(index) {
-            if plan.matches(kernel_key, alias_fp) {
-                self.hits += 1;
-                return plan.rebind(inputs, output);
-            }
+        if let Some(Some(plan)) = self.slots.get(index)
+            && plan.matches(kernel_key, alias_fp)
+        {
+            self.hits += 1;
+            return plan.rebind(inputs, output);
         }
 
         self.misses += 1;
@@ -285,6 +285,8 @@ impl DecodePlanCache {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Range;
+
     use crate::{Device, QMatrix, Tensor};
     use fusor_gguf::GgmlType;
 
@@ -341,6 +343,19 @@ mod tests {
         let a = Tensor::new::<f32, 2, _>(device, &[[1.0f32, 2.0, 3.0, 4.0]]);
         let b = Tensor::new::<f32, 2, _>(device, &[[0.5f32, -1.0, 2.0, -0.25]]);
         read_rows(&(&a * &b)).await
+    }
+
+    async fn run_slice_assign(device: &Device, slices: [Range<usize>; 2]) -> Vec<f32> {
+        let base = Tensor::new::<f32, 2, _>(
+            device,
+            &[
+                [0.0f32, 0.0, 0.0, 0.0],
+                [0.0f32, 0.0, 0.0, 0.0],
+                [0.0f32, 0.0, 0.0, 0.0],
+            ],
+        );
+        let value = Tensor::new::<f32, 2, _>(device, &[[1.0f32, 2.0], [3.0, 4.0]]);
+        read_rows(&base.slice_assign(slices, &value)).await
     }
 
     // Exercises the `Sequence` kernel arm (scratch + reduce + write passes) with
@@ -442,6 +457,32 @@ mod tests {
 
             assert_close(&mul, &golden_mul, "generic op key: multiply after add");
             assert!(mul != add, "generic op key: multiply must not replay add");
+        });
+    }
+
+    #[test]
+    fn decode_plan_cache_distinguishes_same_shape_slice_assign_ranges() {
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            let Ok(golden) = Device::new().await else {
+                return;
+            };
+
+            let first = run_slice_assign(&device, [0..2, 0..2]).await;
+            let second = run_slice_assign(&device, [1..3, 1..3]).await;
+            let golden_second = run_slice_assign(&golden, [1..3, 1..3]).await;
+
+            assert_close(
+                &second,
+                &golden_second,
+                "slice_assign key: shifted range after top-left range",
+            );
+            assert!(
+                second != first,
+                "slice_assign key: shifted range must not replay top-left range"
+            );
         });
     }
 }

--- a/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
@@ -1,0 +1,447 @@
+//! Decode plan cache.
+//!
+//! During autoregressive decode, every token resolves a structurally identical
+//! compute graph: the same operations, in the same toposorted order, with the
+//! same shapes (only the KV-cache-dependent attention ops and the live buffer
+//! handles change token-to-token). Yet `build_kernel` re-runs the full per-op
+//! analysis — kernel-variant selection, workgroup solving, epilogue hashing,
+//! tile-IR lowering checks — every token, even though the compiled pipelines
+//! are already cached. On the web build that analysis dominates the per-token
+//! host cost (~10ms of a ~16ms token).
+//!
+//! This cache memoizes bufferless [`DirectKernelTemplate`]s per operation and,
+//! on a structurally-matching token, rebinds only the buffers (which is cheap)
+//! instead of rebuilding the kernels. It is correctness-safe by construction:
+//! the cache key carries the operation's structural kernel key (op type,
+//! kernel fields, dispatch, workgroup, and every input/output layout/format), so
+//! any structural change is a miss (full rebuild). Buffers are *always*
+//! re-derived from the current token's inputs/output, so a cached template never
+//! carries a stale activation buffer.
+//!
+//! Disable with `FUSOR_DISABLE_DECODE_PLAN_CACHE` (native only; `var_os` is
+//! always `None` on wasm, so the cache is always on for the web build).
+
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use rustc_hash::{FxHashMap, FxHasher};
+
+use crate::mir::inputs::MirValue;
+use crate::mir::kernel_backend::{
+    DirectKernel, DirectKernelTemplate, KernelCacheKey, KernelVariantKey,
+};
+use crate::mir::operation::Operation;
+use crate::mir::workgroup_shape::WorkgroupShape;
+use crate::tensor::TensorData;
+
+struct DecodePlanCacheKernelVariant;
+
+pub(crate) fn structural_kernel_key(
+    operation: &dyn Operation,
+    inputs: &[MirValue],
+    workgroup: &WorkgroupShape,
+) -> KernelCacheKey {
+    let dispatch_size = operation.dispatch_size(workgroup, inputs);
+    operation.kernel_cache_key_with_dispatch(
+        KernelVariantKey::of::<DecodePlanCacheKernelVariant>(),
+        Some(workgroup),
+        dispatch_size,
+        inputs,
+    )
+}
+
+/// Where one of a kernel's bound buffers comes from on each decode token.
+enum BufSource {
+    /// The operation's output buffer (freshly allocated every token).
+    Output,
+    /// The buffer of `inputs[i]` (a graph tensor or a quantized matrix).
+    Input(usize),
+    /// A buffer that is neither an input nor the output — a model weight or a
+    /// scratch buffer allocated during the build. Stable across tokens, so we
+    /// hold the `Arc` and reuse it. (Reuse is safe: submits execute in queue
+    /// order, so a scratch buffer is never read by token N while token N+1
+    /// writes it.)
+    Const(Arc<wgpu::Buffer>),
+}
+
+/// A memoized build result for a single operation: the kernel templates plus,
+/// for each kernel, where to source its buffers from on a replay.
+struct CachedOpPlan {
+    kernel_key: KernelCacheKey,
+    alias_fp: u64,
+    kernels: Vec<(DirectKernelTemplate, Vec<BufSource>)>,
+}
+
+impl CachedOpPlan {
+    fn record(
+        kernel_key: KernelCacheKey,
+        alias_fp: u64,
+        built: &[DirectKernel],
+        inputs: &[MirValue],
+        output: &TensorData,
+    ) -> Self {
+        let output_buf = output.buffer();
+        let kernels = built
+            .iter()
+            .map(|kernel| {
+                let sources = kernel
+                    .binding_buffers()
+                    .iter()
+                    .map(|buffer| classify_buffer(buffer, inputs, output_buf))
+                    .collect();
+                (kernel.to_template(), sources)
+            })
+            .collect();
+        Self {
+            kernel_key,
+            alias_fp,
+            kernels,
+        }
+    }
+
+    fn matches(&self, kernel_key: KernelCacheKey, alias_fp: u64) -> bool {
+        self.kernel_key == kernel_key && self.alias_fp == alias_fp
+    }
+
+    fn rebind(&self, inputs: &[MirValue], output: &TensorData) -> Vec<DirectKernel> {
+        self.kernels
+            .iter()
+            .map(|(template, sources)| {
+                let new_buffers = sources
+                    .iter()
+                    .map(|source| match source {
+                        BufSource::Output => output.buffer().clone(),
+                        BufSource::Input(i) => mir_buffer(&inputs[*i])
+                            .expect("cached Input source must resolve to a buffer")
+                            .clone(),
+                        BufSource::Const(buffer) => buffer.clone(),
+                    })
+                    .collect::<Vec<_>>();
+                template.bind_buffers(&new_buffers)
+            })
+            .collect()
+    }
+}
+
+fn mir_buffer(value: &MirValue) -> Option<&Arc<wgpu::Buffer>> {
+    match value {
+        MirValue::Tensor(tensor) => Some(tensor.buffer()),
+        MirValue::QMatrix(matrix) => Some(matrix.buffer()),
+        MirValue::Integer(_) | MirValue::Float(_) => None,
+    }
+}
+
+fn classify_buffer(
+    buffer: &Arc<wgpu::Buffer>,
+    inputs: &[MirValue],
+    output_buf: &Arc<wgpu::Buffer>,
+) -> BufSource {
+    if Arc::ptr_eq(buffer, output_buf) {
+        return BufSource::Output;
+    }
+    for (i, input) in inputs.iter().enumerate() {
+        if let Some(input_buf) = mir_buffer(input) {
+            if Arc::ptr_eq(buffer, input_buf) {
+                return BufSource::Input(i);
+            }
+        }
+    }
+    BufSource::Const(buffer.clone())
+}
+
+fn fingerprint_aliases(inputs: &[MirValue], output: &TensorData) -> u64 {
+    let mut hasher = FxHasher::default();
+    1u8.hash(&mut hasher);
+    inputs.len().hash(&mut hasher);
+    let mut seen = Vec::new();
+    for input in inputs {
+        let class = mir_buffer(input).map(|buffer| alias_class(&mut seen, buffer));
+        class.hash(&mut hasher);
+    }
+    alias_class(&mut seen, output.buffer()).hash(&mut hasher);
+    hasher.finish()
+}
+
+fn alias_class<'a>(seen: &mut Vec<&'a Arc<wgpu::Buffer>>, buffer: &'a Arc<wgpu::Buffer>) -> usize {
+    if let Some(index) = seen
+        .iter()
+        .position(|candidate| Arc::ptr_eq(*candidate, buffer))
+    {
+        index
+    } else {
+        let index = seen.len();
+        seen.push(buffer);
+        index
+    }
+}
+
+/// The per-resolve view of the cache: the slots for the current graph size,
+/// taken out of the shared map so the resolve loop can read/write them without
+/// locking on every op. Returned to the cache via [`DecodePlanCache::put`].
+pub(crate) struct OpPlanSlots {
+    op_count: usize,
+    slots: Vec<Option<CachedOpPlan>>,
+    hits: u32,
+    misses: u32,
+}
+
+impl OpPlanSlots {
+    /// Return the kernels for operation `index`, reusing the cached build if the
+    /// op is structurally unchanged, otherwise invoking `build` and caching the
+    /// result. `kernel_key` must uniquely describe the generated kernel IR for
+    /// the current operation, including every input and output layout/format.
+    pub(crate) fn resolve_op(
+        &mut self,
+        index: usize,
+        kernel_key: KernelCacheKey,
+        inputs: &[MirValue],
+        output: &TensorData,
+        build: impl FnOnce() -> Vec<DirectKernel>,
+    ) -> Vec<DirectKernel> {
+        let alias_fp = fingerprint_aliases(inputs, output);
+
+        if let Some(Some(plan)) = self.slots.get(index) {
+            if plan.matches(kernel_key, alias_fp) {
+                self.hits += 1;
+                return plan.rebind(inputs, output);
+            }
+        }
+
+        self.misses += 1;
+        let built = build();
+        if index < self.slots.len() {
+            self.slots[index] = Some(CachedOpPlan::record(
+                kernel_key, alias_fp, &built, inputs, output,
+            ));
+        }
+        built
+    }
+}
+
+/// Persistent, device-wide cache of decode plans, keyed by graph size so that
+/// distinct graphs (prefill / decode / sampler) never evict one another.
+pub(crate) struct DecodePlanCache {
+    enabled: bool,
+    by_op_count: Mutex<FxHashMap<usize, Vec<Option<CachedOpPlan>>>>,
+}
+
+impl std::fmt::Debug for DecodePlanCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DecodePlanCache")
+            .field("enabled", &self.enabled)
+            .finish()
+    }
+}
+
+impl DecodePlanCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            enabled: std::env::var_os("FUSOR_DISABLE_DECODE_PLAN_CACHE").is_none(),
+            by_op_count: Mutex::new(FxHashMap::default()),
+        }
+    }
+
+    pub(crate) fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Take the slot vector for a graph of `op_count` operations, sized exactly
+    /// to `op_count` (padding with empty slots / truncating as needed).
+    pub(crate) fn take(&self, op_count: usize) -> OpPlanSlots {
+        let mut slots = self
+            .by_op_count
+            .lock()
+            .remove(&op_count)
+            .unwrap_or_default();
+        slots.resize_with(op_count, || None);
+        OpPlanSlots {
+            op_count,
+            slots,
+            hits: 0,
+            misses: 0,
+        }
+    }
+
+    /// Return slots taken via [`take`](Self::take) to the shared cache.
+    pub(crate) fn put(&self, slots: OpPlanSlots) {
+        // Mirror the resolve host-trace gate (always on for wasm, env-gated on
+        // native) so the cache hit rate shows up alongside `resolve_host_profile`.
+        let trace =
+            cfg!(target_arch = "wasm32") || std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some();
+        if trace && (slots.hits != 0 || slots.misses != 0) {
+            let msg = format!(
+                "decode_plan_cache op_count={} hit={} miss={}",
+                slots.op_count, slots.hits, slots.misses
+            );
+            #[cfg(target_arch = "wasm32")]
+            web_sys::console::log_1(&msg.into());
+            #[cfg(not(target_arch = "wasm32"))]
+            eprintln!("{msg}");
+        }
+        self.by_op_count.lock().insert(slots.op_count, slots.slots);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Device, QMatrix, Tensor};
+    use fusor_gguf::GgmlType;
+
+    const N: usize = 4;
+    const K: usize = 8;
+
+    // An F32 (native) quantized matrix [N, K] so `q_mat_mul` is a plain matmul.
+    fn weight(device: &Device) -> QMatrix {
+        let bytes: Vec<u8> = (0..N * K)
+            .map(|i| 0.1 + (i as f32) * 0.05)
+            .flat_map(f32::to_le_bytes)
+            .collect();
+        QMatrix::from_parts(device, &bytes, vec![N, K].into_boxed_slice(), GgmlType::F32).unwrap()
+    }
+
+    fn bias(device: &Device) -> Tensor {
+        Tensor::new::<f32, 2, _>(device, &[[0.5f32, -1.0, 2.0, -0.25]])
+    }
+
+    async fn read_rows(out: &Tensor) -> Vec<f32> {
+        let slice = out.as_slice::<2, f32>().await.unwrap();
+        let shape = slice.shape();
+        let (rows, cols) = (shape[0], shape[1]);
+        let mut values = Vec::with_capacity(rows * cols);
+        for r in 0..rows {
+            for c in 0..cols {
+                values.push(slice[[r, c]]);
+            }
+        }
+        values
+    }
+
+    // Exercises the qmatmul build arm: the trailing add keeps the resolve target
+    // off the single-qmatmul fast path, so the resolver (and the plan cache) runs.
+    async fn run_qmatmul(device: &Device, w: &QMatrix, input: [f32; K]) -> Vec<f32> {
+        let out = Tensor::new::<f32, 2, _>(device, &[input]).q_mat_mul(w);
+        read_rows(&(&out + &bias(device))).await
+    }
+
+    // Exercises the generic (nary) build arm with two distinct tensor inputs.
+    async fn run_nary(device: &Device, input: [f32; K]) -> Vec<f32> {
+        let row: [f32; N] = input[..N].try_into().unwrap();
+        let a = Tensor::new::<f32, 2, _>(device, &[row]);
+        read_rows(&(&a + &bias(device))).await
+    }
+
+    async fn run_pairwise_add(device: &Device) -> Vec<f32> {
+        let a = Tensor::new::<f32, 2, _>(device, &[[1.0f32, 2.0, 3.0, 4.0]]);
+        let b = Tensor::new::<f32, 2, _>(device, &[[0.5f32, -1.0, 2.0, -0.25]]);
+        read_rows(&(&a + &b)).await
+    }
+
+    async fn run_pairwise_mul(device: &Device) -> Vec<f32> {
+        let a = Tensor::new::<f32, 2, _>(device, &[[1.0f32, 2.0, 3.0, 4.0]]);
+        let b = Tensor::new::<f32, 2, _>(device, &[[0.5f32, -1.0, 2.0, -0.25]]);
+        read_rows(&(&a * &b)).await
+    }
+
+    // Exercises the `Sequence` kernel arm (scratch + reduce + write passes) with
+    // its scratch buffer reused across tokens: a large softmax takes the split
+    // path. `seed` makes the input (and output) input-dependent.
+    async fn run_softmax(device: &Device, seed: f32) -> Vec<f32> {
+        let data: Vec<f32> = (0..4096)
+            .map(|i| ((i as f32) * 0.001 + seed).sin())
+            .collect();
+        let out = Tensor::new(device, data.as_slice()).softmax(0);
+        let slice = out.as_slice::<1, f32>().await.unwrap();
+        let len = slice.shape()[0];
+        (0..len).step_by(257).map(|i| slice[[i]]).collect()
+    }
+
+    fn assert_close(a: &[f32], b: &[f32], context: &str) {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "{context}: length mismatch ({a:?} vs {b:?})"
+        );
+        for (i, (x, y)) in a.iter().zip(b).enumerate() {
+            assert!(
+                (x - y).abs() <= 1e-3 + 1e-3 * x.abs().max(y.abs()),
+                "{context}: element {i} differs: {x} vs {y}"
+            );
+        }
+    }
+
+    // The rebind-on-cache-hit replay must (a) byte-match the cold build for the
+    // same input, and (b) for a different input, match a cold build on a fresh
+    // device (whose plan cache is empty, forcing the normal build path).
+    // `device2` shares the same GPU, so the normal-path results are the golden
+    // reference. Covers both build arms, including the fused-epilogue qmatmul the
+    // old fast cache could not key.
+    #[test]
+    fn decode_plan_cache_rebind_matches_fresh_build() {
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            let Ok(golden) = Device::new().await else {
+                return;
+            };
+
+            let v = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+            let u = [-2.0, 1.5, 0.0, 3.0, -1.0, 2.5, 4.0, -0.5];
+
+            // --- qmatmul arm ---
+            let w = weight(&device);
+            let w_golden = weight(&golden);
+            let miss_v = run_qmatmul(&device, &w, v).await; // cold build
+            let hit_v = run_qmatmul(&device, &w, v).await; // rebind replay
+            assert_eq!(
+                miss_v, hit_v,
+                "qmatmul: rebind must byte-match the cold build"
+            );
+            let hit_u = run_qmatmul(&device, &w, u).await; // rebind, new buffers
+            let golden_u = run_qmatmul(&golden, &w_golden, u).await; // cold build, fresh cache
+            assert_close(&hit_u, &golden_u, "qmatmul: rebind with new buffers");
+            assert!(hit_u != hit_v, "qmatmul: different inputs must differ");
+
+            // --- generic (nary) arm ---
+            let miss_v = run_nary(&device, v).await;
+            let hit_v = run_nary(&device, v).await;
+            assert_eq!(miss_v, hit_v, "nary: rebind must byte-match the cold build");
+            let hit_u = run_nary(&device, u).await;
+            let golden_u = run_nary(&golden, u).await;
+            assert_close(&hit_u, &golden_u, "nary: rebind with new buffers");
+            assert!(hit_u != hit_v, "nary: different inputs must differ");
+
+            // --- Sequence arm (split softmax with a reused scratch buffer) ---
+            let miss_v = run_softmax(&device, 0.0).await;
+            let hit_v = run_softmax(&device, 0.0).await;
+            assert_eq!(
+                miss_v, hit_v,
+                "softmax: rebind must byte-match the cold build"
+            );
+            let hit_u = run_softmax(&device, 0.7).await;
+            let golden_u = run_softmax(&golden, 0.7).await;
+            assert_close(&hit_u, &golden_u, "softmax: rebind with new buffers");
+            assert!(hit_u != hit_v, "softmax: different inputs must differ");
+        });
+    }
+
+    #[test]
+    fn decode_plan_cache_distinguishes_same_shape_generic_ops() {
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            let Ok(golden) = Device::new().await else {
+                return;
+            };
+
+            let add = run_pairwise_add(&device).await;
+            let mul = run_pairwise_mul(&device).await;
+            let golden_mul = run_pairwise_mul(&golden).await;
+
+            assert_close(&mul, &golden_mul, "generic op key: multiply after add");
+            assert!(mul != add, "generic op key: multiply must not replay add");
+        });
+    }
+}

--- a/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
@@ -21,11 +21,18 @@
 //! Disable with `FUSOR_DISABLE_DECODE_PLAN_CACHE` (native only; `var_os` is
 //! always `None` on wasm, so the cache is always on for the web build).
 
-use std::hash::{Hash, Hasher};
-use std::sync::Arc;
+use std::{
+    hash::{Hash, Hasher},
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
+use lru::LruCache;
 use parking_lot::Mutex;
-use rustc_hash::{FxHashMap, FxHasher};
+use rustc_hash::{FxBuildHasher, FxHasher};
 
 use crate::mir::inputs::MirValue;
 use crate::mir::kernel_backend::{
@@ -36,6 +43,9 @@ use crate::mir::workgroup_shape::WorkgroupShape;
 use crate::tensor::TensorData;
 
 struct DecodePlanCacheKernelVariant;
+const DECODE_PLAN_CACHE_SIZE: usize = 4096;
+
+type DecodePlanCacheKey = (KernelCacheKey, u64);
 
 pub(crate) fn structural_kernel_key(
     operation: &dyn Operation,
@@ -68,19 +78,11 @@ enum BufSource {
 /// A memoized build result for a single operation: the kernel templates plus,
 /// for each kernel, where to source its buffers from on a replay.
 struct CachedOpPlan {
-    kernel_key: KernelCacheKey,
-    alias_fp: u64,
     kernels: Vec<(DirectKernelTemplate, Vec<BufSource>)>,
 }
 
 impl CachedOpPlan {
-    fn record(
-        kernel_key: KernelCacheKey,
-        alias_fp: u64,
-        built: &[DirectKernel],
-        inputs: &[MirValue],
-        output: &TensorData,
-    ) -> Self {
+    fn record(built: &[DirectKernel], inputs: &[MirValue], output: &TensorData) -> Self {
         let output_buf = output.buffer();
         let kernels = built
             .iter()
@@ -93,15 +95,7 @@ impl CachedOpPlan {
                 (kernel.to_template(), sources)
             })
             .collect();
-        Self {
-            kernel_key,
-            alias_fp,
-            kernels,
-        }
-    }
-
-    fn matches(&self, kernel_key: KernelCacheKey, alias_fp: u64) -> bool {
-        self.kernel_key == kernel_key && self.alias_fp == alias_fp
+        Self { kernels }
     }
 
     fn rebind(&self, inputs: &[MirValue], output: &TensorData) -> Vec<DirectKernel> {
@@ -176,54 +170,13 @@ fn alias_class<'a>(seen: &mut Vec<&'a Arc<wgpu::Buffer>>, buffer: &'a Arc<wgpu::
     }
 }
 
-/// The per-resolve view of the cache: the slots for the current graph size,
-/// taken out of the shared map so the resolve loop can read/write them without
-/// locking on every op. Returned to the cache via [`DecodePlanCache::put`].
-pub(crate) struct OpPlanSlots {
-    op_count: usize,
-    slots: Vec<Option<CachedOpPlan>>,
-    hits: u32,
-    misses: u32,
-}
-
-impl OpPlanSlots {
-    /// Return the kernels for operation `index`, reusing the cached build if the
-    /// op is structurally unchanged, otherwise invoking `build` and caching the
-    /// result. `kernel_key` must uniquely describe the generated kernel IR for
-    /// the current operation, including every input and output layout/format.
-    pub(crate) fn resolve_op(
-        &mut self,
-        index: usize,
-        kernel_key: KernelCacheKey,
-        inputs: &[MirValue],
-        output: &TensorData,
-        build: impl FnOnce() -> Vec<DirectKernel>,
-    ) -> Vec<DirectKernel> {
-        let alias_fp = fingerprint_aliases(inputs, output);
-
-        if let Some(Some(plan)) = self.slots.get(index)
-            && plan.matches(kernel_key, alias_fp)
-        {
-            self.hits += 1;
-            return plan.rebind(inputs, output);
-        }
-
-        self.misses += 1;
-        let built = build();
-        if index < self.slots.len() {
-            self.slots[index] = Some(CachedOpPlan::record(
-                kernel_key, alias_fp, &built, inputs, output,
-            ));
-        }
-        built
-    }
-}
-
-/// Persistent, device-wide cache of decode plans, keyed by graph size so that
-/// distinct graphs (prefill / decode / sampler) never evict one another.
+/// Persistent, device-wide cache of decode plans, keyed by the structural
+/// kernel key plus the current input/output aliasing pattern.
 pub(crate) struct DecodePlanCache {
     enabled: bool,
-    by_op_count: Mutex<FxHashMap<usize, Vec<Option<CachedOpPlan>>>>,
+    plans: Mutex<LruCache<DecodePlanCacheKey, CachedOpPlan, FxBuildHasher>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
 }
 
 impl std::fmt::Debug for DecodePlanCache {
@@ -238,7 +191,13 @@ impl DecodePlanCache {
     pub(crate) fn new() -> Self {
         Self {
             enabled: std::env::var_os("FUSOR_DISABLE_DECODE_PLAN_CACHE").is_none(),
-            by_op_count: Mutex::new(FxHashMap::default()),
+            plans: Mutex::new(LruCache::with_hasher(
+                NonZeroUsize::new(DECODE_PLAN_CACHE_SIZE)
+                    .expect("decode plan cache size must be non-zero"),
+                Default::default(),
+            )),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
         }
     }
 
@@ -246,38 +205,43 @@ impl DecodePlanCache {
         self.enabled
     }
 
-    /// Take the slot vector for a graph of `op_count` operations, sized exactly
-    /// to `op_count` (padding with empty slots / truncating as needed).
-    pub(crate) fn take(&self, op_count: usize) -> OpPlanSlots {
-        let mut slots = self
-            .by_op_count
-            .lock()
-            .remove(&op_count)
-            .unwrap_or_default();
-        slots.resize_with(op_count, || None);
-        OpPlanSlots {
-            op_count,
-            slots,
-            hits: 0,
-            misses: 0,
-        }
-    }
+    /// Return kernels for a structurally unchanged operation by rebinding a
+    /// cached template to the current token's buffers. On miss, build and cache
+    /// a new bufferless plan.
+    pub(crate) fn resolve_op(
+        &self,
+        kernel_key: KernelCacheKey,
+        inputs: &[MirValue],
+        output: &TensorData,
+        build: impl FnOnce() -> Vec<DirectKernel>,
+    ) -> Vec<DirectKernel> {
+        let alias_fp = fingerprint_aliases(inputs, output);
+        let cache_key = (kernel_key, alias_fp);
 
-    /// Return slots taken via [`take`](Self::take) to the shared cache.
-    pub(crate) fn put(&self, slots: OpPlanSlots) {
-        // Mirror the resolve host-trace gate (always on for wasm, env-gated on
-        // native) so the cache hit rate shows up alongside `resolve_host_profile`.
-        let trace =
-            cfg!(target_arch = "wasm32") || std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some();
-        if trace && (slots.hits != 0 || slots.misses != 0) {
-            tracing::info!(
-                "decode_plan_cache op_count={} hit={} miss={}",
-                slots.op_count,
-                slots.hits,
-                slots.misses
-            );
+        {
+            let mut plans = self.plans.lock();
+            if let Some(plan) = plans.get(&cache_key) {
+                let hit_total = self.hits.fetch_add(1, Ordering::Relaxed) + 1;
+                trace_cache_event(hit_total, self.misses.load(Ordering::Relaxed));
+                return plan.rebind(inputs, output);
+            }
         }
-        self.by_op_count.lock().insert(slots.op_count, slots.slots);
+
+        let miss_total = self.misses.fetch_add(1, Ordering::Relaxed) + 1;
+        trace_cache_event(self.hits.load(Ordering::Relaxed), miss_total);
+        let built = build();
+        self.plans
+            .lock()
+            .put(cache_key, CachedOpPlan::record(&built, inputs, output));
+        built
+    }
+}
+
+fn trace_cache_event(hits: u64, misses: u64) {
+    // Mirror the resolve host-trace gate (always on for wasm, env-gated on
+    // native) so the cache hit rate shows up alongside `resolve_host_profile`.
+    if cfg!(target_arch = "wasm32") || std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some() {
+        tracing::info!("decode_plan_cache hit={hits} miss={misses}");
     }
 }
 

--- a/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/plan_cache.rs
@@ -270,14 +270,12 @@ impl DecodePlanCache {
         let trace =
             cfg!(target_arch = "wasm32") || std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some();
         if trace && (slots.hits != 0 || slots.misses != 0) {
-            let msg = format!(
+            tracing::info!(
                 "decode_plan_cache op_count={} hit={} miss={}",
-                slots.op_count, slots.hits, slots.misses
+                slots.op_count,
+                slots.hits,
+                slots.misses
             );
-            #[cfg(target_arch = "wasm32")]
-            web_sys::console::log_1(&msg.into());
-            #[cfg(not(target_arch = "wasm32"))]
-            eprintln!("{msg}");
         }
         self.by_op_count.lock().insert(slots.op_count, slots.slots);
     }

--- a/fusor-ml/core/src/compute_graph/resolve/run.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/run.rs
@@ -143,9 +143,7 @@ impl Resolver {
         let mut commands = Vec::<CommandRecord>::with_capacity(queued_operations.len());
         let mut dispatch_categories = FxHashMap::<String, usize>::default();
         let mut dispatch_names = FxHashMap::<String, usize>::default();
-        // Decode plan cache: reuse the per-op `build_kernel` analysis across
-        // structurally-identical decode tokens, rebinding only the buffers.
-        let plan_cache_enabled = device.decode_plan_cache().enabled();
+        let plan_cache_enabled = device.kernel_cache().direct_plan_cache().enabled();
         for (node, queued_operation) in queued_operations {
             let operation_category = host_category_trace
                 .then(|| {
@@ -257,10 +255,10 @@ impl Resolver {
                     let kernels = if plan_cache_enabled {
                         let kernel_key =
                             structural_kernel_key(qmatmul.as_ref(), &new_inputs, &workgroup_shape);
-                        device.decode_plan_cache().resolve_op(
+                        resolve_cached_direct_plan(
+                            device.kernel_cache().direct_plan_cache(),
                             kernel_key,
-                            &new_inputs,
-                            &resolved,
+                            direct_plan_binding_buffers(&new_inputs),
                             build_kernels,
                         )
                     } else {
@@ -377,10 +375,10 @@ impl Resolver {
                 let kernels = if plan_cache_enabled {
                     let kernel_key =
                         structural_kernel_key(operation.as_ref(), &new_inputs, &workgroup_shape);
-                    device.decode_plan_cache().resolve_op(
+                    resolve_cached_direct_plan(
+                        device.kernel_cache().direct_plan_cache(),
                         kernel_key,
-                        &new_inputs,
-                        &resolved,
+                        direct_plan_binding_buffers(&new_inputs),
                         build_kernels,
                     )
                 } else {
@@ -679,6 +677,35 @@ impl Resolver {
             tail_result,
         )
     }
+}
+
+fn resolve_cached_direct_plan(
+    plan_cache: &fusor_tile_ir_runtime::DirectPlanCache,
+    cache_key: crate::mir::kernel_backend::KernelCacheKey,
+    binding_buffers: Vec<Vec<std::sync::Arc<wgpu::Buffer>>>,
+    build: impl FnOnce() -> Vec<crate::mir::kernel_backend::DirectKernel>,
+) -> Vec<crate::mir::kernel_backend::DirectKernel> {
+    let binding_slices = binding_buffers
+        .iter()
+        .map(Vec::as_slice)
+        .collect::<Vec<_>>();
+    plan_cache
+        .try_get_or_insert_many(cache_key, &binding_slices, || {
+            Ok::<_, std::convert::Infallible>(build())
+        })
+        .expect("infallible direct plan cache build failed")
+}
+
+fn direct_plan_binding_buffers(inputs: &[MirValue]) -> Vec<Vec<std::sync::Arc<wgpu::Buffer>>> {
+    let buffers = inputs
+        .iter()
+        .filter_map(|input| match input {
+            MirValue::Tensor(tensor) => Some(tensor.buffer().clone()),
+            MirValue::QMatrix(matrix) => Some(matrix.buffer().clone()),
+            MirValue::Integer(_) | MirValue::Float(_) => None,
+        })
+        .collect();
+    vec![buffers]
 }
 
 fn dispatches_per_pass(total_kernels: usize) -> usize {

--- a/fusor-ml/core/src/compute_graph/resolve/run.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/run.rs
@@ -146,8 +146,7 @@ impl Resolver {
         // Decode plan cache: reuse the per-op `build_kernel` analysis across
         // structurally-identical decode tokens, rebinding only the buffers.
         let plan_cache_enabled = device.decode_plan_cache().enabled();
-        let mut plan_slots = device.decode_plan_cache().take(queued_operation_count);
-        for (op_index, (node, queued_operation)) in queued_operations.into_iter().enumerate() {
+        for (node, queued_operation) in queued_operations {
             let operation_category = host_category_trace
                 .then(|| {
                     graph
@@ -258,8 +257,7 @@ impl Resolver {
                     let kernels = if plan_cache_enabled {
                         let kernel_key =
                             structural_kernel_key(qmatmul.as_ref(), &new_inputs, &workgroup_shape);
-                        plan_slots.resolve_op(
-                            op_index,
+                        device.decode_plan_cache().resolve_op(
                             kernel_key,
                             &new_inputs,
                             &resolved,
@@ -379,8 +377,7 @@ impl Resolver {
                 let kernels = if plan_cache_enabled {
                     let kernel_key =
                         structural_kernel_key(operation.as_ref(), &new_inputs, &workgroup_shape);
-                    plan_slots.resolve_op(
-                        op_index,
+                    device.decode_plan_cache().resolve_op(
                         kernel_key,
                         &new_inputs,
                         &resolved,
@@ -450,7 +447,6 @@ impl Resolver {
                 }
             };
         }
-        device.decode_plan_cache().put(plan_slots);
 
         let total_kernels = commands
             .iter()

--- a/fusor-ml/core/src/compute_graph/resolve/run.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/run.rs
@@ -16,7 +16,8 @@ impl Resolver {
         _removed: &mut Vec<ComputeGraphNode>,
         tail: impl FnOnce(&TensorData, &mut wgpu::CommandEncoder) -> T,
     ) -> (ResolverResult, T) {
-        let host_trace = std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some();
+        let host_trace =
+            cfg!(target_arch = "wasm32") || std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some();
         let host_category_trace = std::env::var_os("FUSOR_TRACE_RESOLVE_HOST_CATEGORIES").is_some();
         let host_total_start = host_trace.then(Instant::now);
         let mut host_profile = ResolveHostProfile::default();
@@ -142,7 +143,11 @@ impl Resolver {
         let mut commands = Vec::<CommandRecord>::with_capacity(queued_operations.len());
         let mut dispatch_categories = FxHashMap::<String, usize>::default();
         let mut dispatch_names = FxHashMap::<String, usize>::default();
-        for (node, queued_operation) in queued_operations {
+        // Decode plan cache: reuse the per-op `build_kernel` analysis across
+        // structurally-identical decode tokens, rebinding only the buffers.
+        let plan_cache_enabled = device.decode_plan_cache().enabled();
+        let mut plan_slots = device.decode_plan_cache().take(queued_operation_count);
+        for (op_index, (node, queued_operation)) in queued_operations.into_iter().enumerate() {
             let operation_category = host_category_trace
                 .then(|| {
                     graph
@@ -219,7 +224,7 @@ impl Resolver {
                     let MirValue::Tensor(resolved) = result else {
                         panic!("QMatMul output value is not a tensor");
                     };
-                    graph.set_cached_result(node, resolved);
+                    graph.set_cached_result(node, resolved.clone());
                     if let Some(start) = start {
                         let elapsed = start.elapsed();
                         host_profile.output += elapsed;
@@ -244,20 +249,36 @@ impl Resolver {
                     }
 
                     let start = host_trace.then(Instant::now);
-                    let direct_kernel_plan = qmatmul
-                        .build_direct_kernels(graph, &workgroup_shape, &new_inputs)
-                        .unwrap_or_else(|error| panic!("{error}"));
+                    let build_kernels = || {
+                        qmatmul
+                            .build_direct_kernels(graph, &workgroup_shape, &new_inputs)
+                            .unwrap_or_else(|error| panic!("{error}"))
+                            .into_kernels()
+                    };
+                    let kernels = if plan_cache_enabled {
+                        let kernel_key =
+                            structural_kernel_key(qmatmul.as_ref(), &new_inputs, &workgroup_shape);
+                        plan_slots.resolve_op(
+                            op_index,
+                            kernel_key,
+                            &new_inputs,
+                            &resolved,
+                            build_kernels,
+                        )
+                    } else {
+                        build_kernels()
+                    };
                     if let Some(start) = start {
                         let elapsed = start.elapsed();
                         host_profile.build_kernel += elapsed;
                         if let Some(category) = operation_category {
                             let profile = host_category_profile.entry(category).or_default();
-                            profile.count += direct_kernel_plan.dispatch_count();
+                            profile.count += kernels.len();
                             profile.build_kernel += elapsed;
                         }
                     }
 
-                    for direct_kernel in direct_kernel_plan.into_kernels() {
+                    for direct_kernel in kernels {
                         let start = host_trace.then(Instant::now);
                         if let Some(dispatch) =
                             direct_kernel.prepare_dispatch(device.kernel_cache())
@@ -321,7 +342,7 @@ impl Resolver {
                 let MirValue::Tensor(resolved) = result else {
                     panic!("Kernel input value is not a tensor");
                 };
-                graph.set_cached_result(node, resolved);
+                graph.set_cached_result(node, resolved.clone());
                 if let Some(start) = start {
                     let elapsed = start.elapsed();
                     host_profile.output += elapsed;
@@ -343,27 +364,70 @@ impl Resolver {
                     }
                 }
                 let start = host_trace.then(Instant::now);
-                let Some(direct_kernel) =
-                    operation.build_direct_kernel(graph, &workgroup_shape, &new_inputs)
-                else {
-                    panic!(
-                        "operation did not provide a direct kernel: {}",
-                        operation.name()
-                    );
+                let build_kernels = || {
+                    vec![
+                        operation
+                            .build_direct_kernel(graph, &workgroup_shape, &new_inputs)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "operation did not provide a direct kernel: {}",
+                                    operation.name()
+                                )
+                            }),
+                    ]
+                };
+                let kernels = if plan_cache_enabled {
+                    let kernel_key =
+                        structural_kernel_key(operation.as_ref(), &new_inputs, &workgroup_shape);
+                    plan_slots.resolve_op(
+                        op_index,
+                        kernel_key,
+                        &new_inputs,
+                        &resolved,
+                        build_kernels,
+                    )
+                } else {
+                    build_kernels()
                 };
                 if let Some(start) = start {
                     let elapsed = start.elapsed();
                     host_profile.build_kernel += elapsed;
                     if let Some(category) = operation_category {
                         let profile = host_category_profile.entry(category).or_default();
-                        profile.count += 1;
+                        profile.count += kernels.len();
                         profile.build_kernel += elapsed;
                     }
                 }
-                let start = host_trace.then(Instant::now);
-                if let Some(dispatch) = direct_kernel.prepare_dispatch(device.kernel_cache()) {
-                    let name = direct_kernel.name().to_string();
-                    if let Some(start) = start {
+                for direct_kernel in kernels {
+                    let start = host_trace.then(Instant::now);
+                    if let Some(dispatch) = direct_kernel.prepare_dispatch(device.kernel_cache()) {
+                        let name = direct_kernel.name().to_string();
+                        if let Some(start) = start {
+                            let elapsed = start.elapsed();
+                            host_profile.prepare_dispatch += elapsed;
+                            if let Some(category) = operation_category {
+                                host_category_profile
+                                    .entry(category)
+                                    .or_default()
+                                    .prepare_dispatch += elapsed;
+                            }
+                        }
+                        let category = collect_dispatch_metadata.then(|| {
+                            let category = dispatch_category(&name);
+                            if trace {
+                                *dispatch_categories.entry(category.clone()).or_default() += 1;
+                                if trace_names {
+                                    *dispatch_names.entry(name.clone()).or_default() += 1;
+                                }
+                            }
+                            category
+                        });
+                        commands.push(CommandRecord::Dispatch(DispatchRecord {
+                            dispatch,
+                            name,
+                            category,
+                        }));
+                    } else if let Some(start) = start {
                         let elapsed = start.elapsed();
                         host_profile.prepare_dispatch += elapsed;
                         if let Some(category) = operation_category {
@@ -372,30 +436,6 @@ impl Resolver {
                                 .or_default()
                                 .prepare_dispatch += elapsed;
                         }
-                    }
-                    let category = collect_dispatch_metadata.then(|| {
-                        let category = dispatch_category(&name);
-                        if trace {
-                            *dispatch_categories.entry(category.clone()).or_default() += 1;
-                            if trace_names {
-                                *dispatch_names.entry(name.clone()).or_default() += 1;
-                            }
-                        }
-                        category
-                    });
-                    commands.push(CommandRecord::Dispatch(DispatchRecord {
-                        dispatch,
-                        name,
-                        category,
-                    }));
-                } else if let Some(start) = start {
-                    let elapsed = start.elapsed();
-                    host_profile.prepare_dispatch += elapsed;
-                    if let Some(category) = operation_category {
-                        host_category_profile
-                            .entry(category)
-                            .or_default()
-                            .prepare_dispatch += elapsed;
                     }
                 }
                 let start = host_trace.then(Instant::now);
@@ -410,6 +450,7 @@ impl Resolver {
                 }
             };
         }
+        device.decode_plan_cache().put(plan_slots);
 
         let total_kernels = commands
             .iter()
@@ -599,7 +640,7 @@ impl Resolver {
                 device.poll_wait();
                 match receiver.recv() {
                     Ok(Ok(())) => {
-                        let view = slice.get_mapped_range();
+                        let view = slice.get_mapped_range().unwrap();
                         let timestamps = bytemuck::cast_slice::<u8, u64>(&view);
                         print_gpu_kernel_profile(
                             &dispatch_metadata,

--- a/fusor-ml/core/src/compute_graph/resolve/run.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/run.rs
@@ -58,7 +58,7 @@ impl Resolver {
                 host_profile.optimize += start.elapsed();
             }
             if host_trace && skip_large_graph_optimize {
-                eprintln!(
+                tracing::info!(
                     "resolve_host_profile optimize_large_graph node_count={} limit={optimize_limit} skipped_decode={skip_decode_optimize}",
                     self.execution_graph.node_count(),
                 );
@@ -459,11 +459,11 @@ impl Resolver {
         if trace {
             let mut categories = dispatch_categories.into_iter().collect::<Vec<_>>();
             categories.sort_by(|a, b| a.0.cmp(&b.0));
-            eprintln!("resolve_dispatch_categories {categories:?}");
+            tracing::info!("resolve_dispatch_categories {categories:?}");
             if trace_names {
                 let mut names = dispatch_names.into_iter().collect::<Vec<_>>();
                 names.sort_by(|a, b| a.0.cmp(&b.0));
-                eprintln!("resolve_dispatch_names {names:?}");
+                tracing::info!("resolve_dispatch_names {names:?}");
             }
         }
         #[cfg(not(target_arch = "wasm32"))]
@@ -515,7 +515,7 @@ impl Resolver {
                 Some((query_set, query_buffer, readback_buffer, raw_query_size))
             } else {
                 if profile_gpu_kernels {
-                    eprintln!(
+                    tracing::warn!(
                         "resolve_gpu_kernel_profile unavailable timestamp_features={:?} kernels={}",
                         device.features(),
                         total_kernels
@@ -656,10 +656,10 @@ impl Resolver {
                         readback_buffer.unmap();
                     }
                     Ok(Err(error)) => {
-                        eprintln!("resolve_gpu_kernel_profile map_failed {error:?}");
+                        tracing::warn!("resolve_gpu_kernel_profile map_failed {error:?}");
                     }
                     Err(error) => {
-                        eprintln!("resolve_gpu_kernel_profile map_channel_failed {error:?}");
+                        tracing::warn!("resolve_gpu_kernel_profile map_channel_failed {error:?}");
                     }
                 }
                 if let Some(start) = profile_readback_start {

--- a/fusor-ml/core/src/compute_graph/resolve/run.rs
+++ b/fusor-ml/core/src/compute_graph/resolve/run.rs
@@ -640,7 +640,7 @@ impl Resolver {
                 device.poll_wait();
                 match receiver.recv() {
                     Ok(Ok(())) => {
-                        let view = slice.get_mapped_range().unwrap();
+                        let view = slice.get_mapped_range();
                         let timestamps = bytemuck::cast_slice::<u8, u64>(&view);
                         print_gpu_kernel_profile(
                             &dispatch_metadata,

--- a/fusor-ml/core/src/device.rs
+++ b/fusor-ml/core/src/device.rs
@@ -104,10 +104,7 @@ fn adapter_preference_rank(adapter: &wgpu::Adapter) -> u8 {
 }
 
 fn log_gpu_diagnostic(message: String) {
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::error_1(&message.into());
-    #[cfg(not(target_arch = "wasm32"))]
-    eprintln!("{message}");
+    tracing::error!("{message}");
 }
 
 fn install_device_diagnostics(device: &wgpu::Device) {
@@ -272,17 +269,14 @@ impl Device {
         #[cfg(target_arch = "wasm32")]
         {
             let info = adapter.get_info();
-            web_sys::console::log_1(
-                &format!(
-                    "fusor: adapter subgroups={} subgroup_min={} subgroup_max={} shader_f16={} backend={:?} name={:?} (note: the wasm build never requests wgpu::Features::SUBGROUP, so subgroups_supported() stays false regardless of adapter support)",
-                    adapter_features.contains(wgpu::Features::SUBGROUP),
-                    info.subgroup_min_size,
-                    info.subgroup_max_size,
-                    adapter_features.contains(wgpu::Features::SHADER_F16),
-                    info.backend,
-                    info.name,
-                )
-                .into(),
+            tracing::info!(
+                "fusor: adapter subgroups={} subgroup_min={} subgroup_max={} shader_f16={} backend={:?} name={:?} (note: the wasm build never requests wgpu::Features::SUBGROUP, so subgroups_supported() stays false regardless of adapter support)",
+                adapter_features.contains(wgpu::Features::SUBGROUP),
+                info.subgroup_min_size,
+                info.subgroup_max_size,
+                adapter_features.contains(wgpu::Features::SHADER_F16),
+                info.backend,
+                info.name,
             );
         }
         let mut required_features = wgpu::Features::empty();
@@ -299,7 +293,7 @@ impl Device {
                     required_features |= wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES;
                 }
             } else {
-                eprintln!(
+                tracing::warn!(
                     "FUSOR_TRACE_GPU_KERNELS requested, but adapter does not support timestamp queries"
                 );
             }
@@ -329,8 +323,10 @@ impl Device {
         if std::env::var_os("FUSOR_TRACE_GPU_KERNELS").is_some()
             && !cooperative_matrix_properties.is_empty()
         {
-            eprintln!("Fusor cooperative matrix properties: {cooperative_matrix_properties:?}");
-            eprintln!("Fusor cooperative matrix caps: {cooperative_matrix_caps:?}");
+            tracing::info!(
+                "Fusor cooperative matrix properties: {cooperative_matrix_properties:?}"
+            );
+            tracing::info!("Fusor cooperative matrix caps: {cooperative_matrix_caps:?}");
         }
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {

--- a/fusor-ml/core/src/device.rs
+++ b/fusor-ml/core/src/device.rs
@@ -78,7 +78,6 @@ async fn select_adapter(
                 power_preference,
                 force_fallback_adapter: false,
                 compatible_surface: None,
-                apply_limit_buckets: false,
             })
             .await
         {
@@ -646,7 +645,7 @@ mod dirty_buffer_tests {
                 }
             }
 
-            let view = buffer.slice(..).get_mapped_range().unwrap();
+            let view = buffer.slice(..).get_mapped_range();
             assert_eq!(&*view, &[1, 2, 3, 4]);
             drop(view);
             buffer.unmap();
@@ -692,7 +691,7 @@ mod dirty_buffer_tests {
                 });
             device.poll_wait();
             receiver.await.unwrap().unwrap();
-            let view = download.slice(..).get_mapped_range().unwrap();
+            let view = download.slice(..).get_mapped_range();
             let bytes: &[u8] = &view;
             let poison = bytes.iter().filter(|b| **b == 0xCD).count();
             assert_eq!(

--- a/fusor-ml/core/src/device.rs
+++ b/fusor-ml/core/src/device.rs
@@ -9,7 +9,7 @@ use fusor_tile_ir_runtime::{BufferPool, KernelCache};
 use wgpu::{BackendOptions, Dx12BackendOptions};
 
 use crate::{
-    compute_graph::ComputeGraph,
+    compute_graph::{ComputeGraph, DecodePlanCache},
     kernel_selection::{CooperativeMatrixCaps, CooperativeMatrixKind},
 };
 
@@ -78,6 +78,7 @@ async fn select_adapter(
                 power_preference,
                 force_fallback_adapter: false,
                 compatible_surface: None,
+                apply_limit_buckets: false,
             })
             .await
         {
@@ -103,12 +104,58 @@ fn adapter_preference_rank(adapter: &wgpu::Adapter) -> u8 {
     }
 }
 
+fn log_gpu_diagnostic(message: String) {
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::error_1(&message.into());
+    #[cfg(not(target_arch = "wasm32"))]
+    eprintln!("{message}");
+}
+
+fn install_device_diagnostics(device: &wgpu::Device) {
+    device.set_device_lost_callback(|reason, message| {
+        log_gpu_diagnostic(format!(
+            "fusor: WebGPU device lost reason={reason:?} message={message:?}"
+        ));
+    });
+
+    device.on_uncaptured_error(Arc::new(|error| {
+        let message = match &error {
+            wgpu::Error::OutOfMemory { source } => {
+                format!("fusor: uncaptured WebGPU out-of-memory error: {source}")
+            }
+            wgpu::Error::Validation {
+                description,
+                source,
+            } => {
+                format!("fusor: uncaptured WebGPU validation error: {description}; source={source}")
+            }
+            wgpu::Error::Internal {
+                description,
+                source,
+            } => {
+                format!("fusor: uncaptured WebGPU internal error: {description}; source={source}")
+            }
+        };
+        log_gpu_diagnostic(message);
+    }));
+}
+
 struct DeviceInner {
     device: Arc<wgpu::Device>,
     adapter: wgpu::Adapter,
+    /// Cached `adapter.get_info()` / `adapter.limits()`. These are constant for
+    /// the device's lifetime; re-querying them per kernel build (every op, every
+    /// token) is pure overhead — and on wasm each `get_info()` is a JS round-trip
+    /// that allocates an `AdapterInfo`.
+    adapter_info: wgpu::AdapterInfo,
+    limits: wgpu::Limits,
     queue: Arc<wgpu::Queue>,
     kernel_cache: KernelCache,
     buffer_pool: BufferPool,
+    /// Memoizes per-op `build_kernel` results across structurally-identical
+    /// decode tokens (see [`DecodePlanCache`]). The dominant per-token host
+    /// cost on the web build.
+    decode_plan_cache: DecodePlanCache,
     cooperative_matrix_caps: CooperativeMatrixCaps,
     compute_graph: OnceLock<ComputeGraph>,
     /// When set, this device reports `subgroups_supported() == false` so kernel
@@ -166,9 +213,12 @@ impl Device {
         let inner = Arc::new(DeviceInner {
             device,
             adapter,
+            adapter_info: src.adapter_info.clone(),
+            limits: src.limits.clone(),
             queue,
             kernel_cache,
             buffer_pool,
+            decode_plan_cache: DecodePlanCache::new(),
             cooperative_matrix_caps: src.cooperative_matrix_caps,
             compute_graph: OnceLock::new(),
             disable_subgroups,
@@ -220,8 +270,23 @@ impl Device {
         });
         let adapter = select_adapter(&instance, backends).await?;
         let adapter_features = adapter.features();
+        #[cfg(target_arch = "wasm32")]
+        {
+            let info = adapter.get_info();
+            web_sys::console::log_1(
+                &format!(
+                    "fusor: adapter subgroups={} subgroup_min={} subgroup_max={} shader_f16={} backend={:?} name={:?} (note: the wasm build never requests wgpu::Features::SUBGROUP, so subgroups_supported() stays false regardless of adapter support)",
+                    adapter_features.contains(wgpu::Features::SUBGROUP),
+                    info.subgroup_min_size,
+                    info.subgroup_max_size,
+                    adapter_features.contains(wgpu::Features::SHADER_F16),
+                    info.backend,
+                    info.name,
+                )
+                .into(),
+            );
+        }
         let mut required_features = wgpu::Features::empty();
-        #[cfg(not(target_arch = "wasm32"))]
         if adapter_features.contains(wgpu::Features::SUBGROUP) {
             required_features |= wgpu::Features::SUBGROUP;
         }
@@ -278,6 +343,8 @@ impl Device {
             })
             .await?;
 
+        install_device_diagnostics(&device);
+
         let device = Arc::new(device);
         let queue = Arc::new(queue);
 
@@ -292,12 +359,17 @@ impl Device {
         let disable_subgroups = std::env::var_os("FUSOR_DISABLE_SUBGROUPS").is_some();
         let poison_allocations = std::env::var_os("FUSOR_DIRTY_BUFFERS").is_some();
 
+        let adapter_info = adapter.get_info();
+        let limits = adapter.limits();
         let inner = Arc::new(DeviceInner {
             device,
             adapter,
+            adapter_info,
+            limits,
             queue,
             kernel_cache,
             buffer_pool,
+            decode_plan_cache: DecodePlanCache::new(),
             cooperative_matrix_caps,
             compute_graph: OnceLock::new(),
             disable_subgroups,
@@ -348,7 +420,7 @@ impl Device {
     }
 
     pub fn limits(&self) -> wgpu::Limits {
-        self.inner.adapter.limits()
+        self.inner.limits.clone()
     }
 
     #[doc(hidden)]
@@ -402,22 +474,22 @@ impl Device {
     /// (`is_fixed`). Pinning the true fixed width of 32 keeps those fast routes
     /// available.
     fn apple_fixed_subgroup_size(&self) -> Option<u32> {
-        let info = self.inner.adapter.get_info();
+        let info = &self.inner.adapter_info;
         (info.backend == wgpu::Backend::Metal && info.name.starts_with("Apple")).then_some(32)
     }
 
     pub fn min_subgroup_size(&self) -> u32 {
         self.apple_fixed_subgroup_size()
-            .unwrap_or_else(|| self.inner.adapter.get_info().subgroup_min_size)
+            .unwrap_or(self.inner.adapter_info.subgroup_min_size)
     }
 
     pub fn max_subgroup_size(&self) -> u32 {
         self.apple_fixed_subgroup_size()
-            .unwrap_or_else(|| self.inner.adapter.get_info().subgroup_max_size)
+            .unwrap_or(self.inner.adapter_info.subgroup_max_size)
     }
 
     pub(crate) fn backend(&self) -> wgpu::Backend {
-        self.inner.adapter.get_info().backend
+        self.inner.adapter_info.backend
     }
 
     pub fn fixed_width_subgroup_size(&self) -> Option<u32> {
@@ -478,6 +550,10 @@ impl Device {
 
     pub(crate) fn kernel_cache(&self) -> &KernelCache {
         &self.inner.kernel_cache
+    }
+
+    pub(crate) fn decode_plan_cache(&self) -> &DecodePlanCache {
+        &self.inner.decode_plan_cache
     }
 
     /// Reset the initialized flag on all cached buffers.
@@ -570,7 +646,7 @@ mod dirty_buffer_tests {
                 }
             }
 
-            let view = buffer.slice(..).get_mapped_range();
+            let view = buffer.slice(..).get_mapped_range().unwrap();
             assert_eq!(&*view, &[1, 2, 3, 4]);
             drop(view);
             buffer.unmap();
@@ -616,7 +692,7 @@ mod dirty_buffer_tests {
                 });
             device.poll_wait();
             receiver.await.unwrap().unwrap();
-            let view = download.slice(..).get_mapped_range();
+            let view = download.slice(..).get_mapped_range().unwrap();
             let bytes: &[u8] = &view;
             let poison = bytes.iter().filter(|b| **b == 0xCD).count();
             assert_eq!(

--- a/fusor-ml/core/src/device.rs
+++ b/fusor-ml/core/src/device.rs
@@ -9,7 +9,7 @@ use fusor_tile_ir_runtime::{BufferPool, KernelCache};
 use wgpu::{BackendOptions, Dx12BackendOptions};
 
 use crate::{
-    compute_graph::{ComputeGraph, DecodePlanCache},
+    compute_graph::ComputeGraph,
     kernel_selection::{CooperativeMatrixCaps, CooperativeMatrixKind},
 };
 
@@ -148,10 +148,6 @@ struct DeviceInner {
     queue: Arc<wgpu::Queue>,
     kernel_cache: KernelCache,
     buffer_pool: BufferPool,
-    /// Memoizes per-op `build_kernel` results across structurally-identical
-    /// decode tokens (see [`DecodePlanCache`]). The dominant per-token host
-    /// cost on the web build.
-    decode_plan_cache: DecodePlanCache,
     cooperative_matrix_caps: CooperativeMatrixCaps,
     compute_graph: OnceLock<ComputeGraph>,
     /// When set, this device reports `subgroups_supported() == false` so kernel
@@ -214,7 +210,6 @@ impl Device {
             queue,
             kernel_cache,
             buffer_pool,
-            decode_plan_cache: DecodePlanCache::new(),
             cooperative_matrix_caps: src.cooperative_matrix_caps,
             compute_graph: OnceLock::new(),
             disable_subgroups,
@@ -364,7 +359,6 @@ impl Device {
             queue,
             kernel_cache,
             buffer_pool,
-            decode_plan_cache: DecodePlanCache::new(),
             cooperative_matrix_caps,
             compute_graph: OnceLock::new(),
             disable_subgroups,
@@ -545,10 +539,6 @@ impl Device {
 
     pub(crate) fn kernel_cache(&self) -> &KernelCache {
         &self.inner.kernel_cache
-    }
-
-    pub(crate) fn decode_plan_cache(&self) -> &DecodePlanCache {
-        &self.inner.decode_plan_cache
     }
 
     /// Reset the initialized flag on all cached buffers.

--- a/fusor-ml/core/src/map_layout.rs
+++ b/fusor-ml/core/src/map_layout.rs
@@ -49,6 +49,8 @@ impl MapLayoutOperation {
 }
 
 impl Operation for MapLayoutOperation {
+    fn hash_kernel_fields(&self, _state: &mut rustc_hash::FxHasher) {}
+
     fn workgroup_shape_constraints(
         &self,
         _: &crate::Device,

--- a/fusor-ml/core/src/matmul/sgemv.rs
+++ b/fusor-ml/core/src/matmul/sgemv.rs
@@ -9,9 +9,13 @@ pub(crate) fn dispatch_size(
     params: &SgemvParams,
 ) -> [u32; 3] {
     let total = m.div_ceil(params.chunk_size) * n * batch_size;
+    let max_workgroups_per_dimension = max_workgroups_per_dimension.max(1);
     let x = total.min(max_workgroups_per_dimension);
-    let y = total.div_ceil(x).min(max_workgroups_per_dimension);
-    let z = total.div_ceil(x * y);
+    let y = total
+        .div_ceil(x.max(1))
+        .min(max_workgroups_per_dimension)
+        .max(1);
+    let z = total.div_ceil(x.max(1) * y);
     [x, y, z]
 }
 

--- a/fusor-ml/core/src/mir/kernel_backend.rs
+++ b/fusor-ml/core/src/mir/kernel_backend.rs
@@ -1,6 +1,6 @@
 pub(crate) use fusor_tile_ir_runtime::{
-    DirectKernel, DirectKernelTemplate, KernelCacheKey, KernelVariantKey, PreparedDirectDispatch,
-    dynamic_kernel_from_ir, run_direct_kernel, run_kernel, three_buffer_pipeline_from_ir,
+    DirectKernel, KernelCacheKey, KernelVariantKey, PreparedDirectDispatch, dynamic_kernel_from_ir,
+    run_direct_kernel, run_kernel, three_buffer_pipeline_from_ir,
 };
 
 /// Marker returned by device-specific direct-kernel builders when the current

--- a/fusor-ml/core/src/mir/kernel_backend.rs
+++ b/fusor-ml/core/src/mir/kernel_backend.rs
@@ -1,6 +1,6 @@
 pub(crate) use fusor_tile_ir_runtime::{
-    DirectKernel, DirectKernelBinding, KernelCacheKey, KernelVariantKey, ModuleCache,
-    PreparedDirectDispatch, cached_hashed_naga, dynamic_kernel_from_hashed_ir,
+    DirectKernel, DirectKernelBinding, DirectKernelTemplate, KernelCacheKey, KernelVariantKey,
+    ModuleCache, PreparedDirectDispatch, cached_hashed_naga, dynamic_kernel_from_hashed_ir,
     dynamic_kernel_from_ir, module_cache, run_direct_kernel, run_kernel,
     three_buffer_pipeline_from_cached_module, three_buffer_pipeline_from_ir,
 };

--- a/fusor-ml/core/src/mir/kernel_backend.rs
+++ b/fusor-ml/core/src/mir/kernel_backend.rs
@@ -1,8 +1,6 @@
 pub(crate) use fusor_tile_ir_runtime::{
-    DirectKernel, DirectKernelBinding, DirectKernelTemplate, KernelCacheKey, KernelVariantKey,
-    ModuleCache, PreparedDirectDispatch, cached_hashed_naga, dynamic_kernel_from_hashed_ir,
-    dynamic_kernel_from_ir, module_cache, run_direct_kernel, run_kernel,
-    three_buffer_pipeline_from_cached_module, three_buffer_pipeline_from_ir,
+    DirectKernel, DirectKernelTemplate, KernelCacheKey, KernelVariantKey, PreparedDirectDispatch,
+    dynamic_kernel_from_ir, run_direct_kernel, run_kernel, three_buffer_pipeline_from_ir,
 };
 
 /// Marker returned by device-specific direct-kernel builders when the current

--- a/fusor-ml/core/src/mir/kernel_backend/flash_attention/kernel.rs
+++ b/fusor-ml/core/src/mir/kernel_backend/flash_attention/kernel.rs
@@ -22,8 +22,7 @@ use super::{
     FlashAttentionDirectKernelVariant, FlashAttentionKernelVariant, FlashAttentionOperation,
     FlashDecodeSmallMeta, FlashDecodeSmallTensors, TensorMeta, build_flash_decode_small_meta,
     dispatch_streaming_flash_attention, dispatch_streaming_tiled_flash_attention,
-    flash_attention_module_cache, flash_streaming_tiled_eligible, select_flash_attention_variant,
-    streaming_dispatch_size,
+    flash_streaming_tiled_eligible, select_flash_attention_variant, streaming_dispatch_size,
 };
 
 fn flash_decode_cache_variant(
@@ -52,14 +51,14 @@ fn hash_flash_decode_dims(
     dims.head_dim.hash(state);
 }
 
-pub(super) fn flash_decode_module_key(
+pub(super) fn flash_decode_cache_key(
     workgroup_shape: Option<&WorkgroupShape>,
     dispatch_size: [u32; 3],
     input_dtype: DataTypeEnum,
     scale: f32,
     meta: &FlashDecodeSmallMeta,
 ) -> kernel_backend::KernelCacheKey {
-    flash_decode_module_key_for_variant(
+    flash_decode_cache_key_for_variant(
         FlashAttentionKernelVariant::DecodeSmall,
         workgroup_shape,
         dispatch_size,
@@ -69,7 +68,7 @@ pub(super) fn flash_decode_module_key(
     )
 }
 
-fn flash_decode_module_key_for_variant(
+fn flash_decode_cache_key_for_variant(
     decode_variant: FlashAttentionKernelVariant,
     workgroup_shape: Option<&WorkgroupShape>,
     dispatch_size: [u32; 3],
@@ -81,7 +80,7 @@ fn flash_decode_module_key_for_variant(
     kernel_backend::KernelCacheKey::from_hash_inputs(|state| {
         // Decode kernels take the active KV length from a params buffer. Do
         // not hash `active_kv_len`, or every generated token would miss the
-        // module cache even though the IR is otherwise bucketed by block size.
+        // kernel cache even though the IR is otherwise bucketed by block size.
         2u64.hash(state);
         variant.hash(state);
         TypeId::of::<FlashAttentionOperation>().hash(state);
@@ -345,7 +344,7 @@ impl Operation for FlashAttentionOperation {
             let reduce_dispatch = [rows, 1, 1];
             let layout = tile_ir_kernels::linear_storage_layout();
 
-            let partial_key = flash_decode_module_key_for_variant(
+            let partial_key = flash_decode_cache_key_for_variant(
                 FlashAttentionKernelVariant::DecodeSplitPartials,
                 Some(workgroup_shape),
                 partial_dispatch,
@@ -361,13 +360,10 @@ impl Operation for FlashAttentionOperation {
                 params_buffer,
             ];
             let partial_layout = layout.clone();
-            let partial_kernel = kernel_backend::dynamic_kernel_from_hashed_ir(
+            let partial_kernel = kernel_backend::dynamic_kernel_from_ir(
                 device.kernel_cache(),
-                flash_attention_module_cache(),
                 "flash_attention_decode_split_partials",
                 partial_key,
-                partial_buffers,
-                partial_dispatch,
                 move || {
                     let mut kb = tile_ir::KernelBuilder::<()>::new();
                     let q_ref = tile_ir::KernelTensorRef::new((), partial_layout.clone());
@@ -386,9 +382,11 @@ impl Operation for FlashAttentionOperation {
                     )?;
                     Some(kb.finish().0)
                 },
+                partial_buffers,
+                partial_dispatch,
             )?;
 
-            let reduce_key = flash_decode_module_key_for_variant(
+            let reduce_key = flash_decode_cache_key_for_variant(
                 FlashAttentionKernelVariant::DecodeSplitReduce,
                 Some(workgroup_shape),
                 reduce_dispatch,
@@ -398,13 +396,10 @@ impl Operation for FlashAttentionOperation {
             );
             let reduce_buffers = vec![scratch_buffer, output.buffer().clone()];
             let reduce_layout = layout.clone();
-            let reduce_kernel = kernel_backend::dynamic_kernel_from_hashed_ir(
+            let reduce_kernel = kernel_backend::dynamic_kernel_from_ir(
                 device.kernel_cache(),
-                flash_attention_module_cache(),
                 "flash_attention_decode_split_reduce",
                 reduce_key,
-                reduce_buffers,
-                reduce_dispatch,
                 move || {
                     let mut kb = tile_ir::KernelBuilder::<()>::new();
                     let scratch_ref = tile_ir::KernelTensorRef::new((), reduce_layout.clone());
@@ -417,6 +412,8 @@ impl Operation for FlashAttentionOperation {
                     )?;
                     Some(kb.finish().0)
                 },
+                reduce_buffers,
+                reduce_dispatch,
             )?;
 
             return Some(kernel_backend::DirectKernel::sequence(
@@ -434,8 +431,8 @@ impl Operation for FlashAttentionOperation {
             }
             FlashAttentionKernelVariant::DecodeSplitReduce => "flash_attention_decode_split_reduce",
         };
-        let module_key = if let Some(meta) = decode_meta.as_ref() {
-            flash_decode_module_key(
+        let cache_key = if let Some(meta) = decode_meta.as_ref() {
+            flash_decode_cache_key(
                 Some(workgroup_shape),
                 dispatch_size,
                 input_dtype,
@@ -450,7 +447,7 @@ impl Operation for FlashAttentionOperation {
                 self.scale.to_bits().hash(state);
                 self.causal.hash(state);
             });
-            self.kernel_module_key_with_dispatch(
+            self.kernel_cache_key_with_dispatch(
                 cache_variant,
                 Some(workgroup_shape),
                 dispatch_size,
@@ -495,13 +492,10 @@ impl Operation for FlashAttentionOperation {
             buffers.push(params_buffer);
         }
 
-        kernel_backend::dynamic_kernel_from_hashed_ir(
+        kernel_backend::dynamic_kernel_from_ir(
             device.kernel_cache(),
-            flash_attention_module_cache(),
             kernel_label,
-            module_key,
-            buffers,
-            dispatch_size,
+            cache_key,
             move || {
                 let mut kb = tile_ir::KernelBuilder::<()>::new();
                 let q_ref = tile_ir::KernelTensorRef::new((), layout.clone());
@@ -568,6 +562,8 @@ impl Operation for FlashAttentionOperation {
                 }?;
                 Some(kb.finish().0)
             },
+            buffers,
+            dispatch_size,
         )
     }
 

--- a/fusor-ml/core/src/mir/kernel_backend/flash_attention/kernel.rs
+++ b/fusor-ml/core/src/mir/kernel_backend/flash_attention/kernel.rs
@@ -107,6 +107,16 @@ fn flash_decode_module_key_for_variant(
 }
 
 impl Operation for FlashAttentionOperation {
+    fn hash_kernel_fields(&self, state: &mut rustc_hash::FxHasher) {
+        self.out_shape.hash(state);
+        self.q_shape.hash(state);
+        self.k_shape.hash(state);
+        self.mask.is_some().hash(state);
+        self.scale.to_bits().hash(state);
+        self.input_dtype.hash(state);
+        self.causal.hash(state);
+    }
+
     fn workgroup_shape_constraints(&self, _device: &crate::Device) -> WorkgroupShapeConstraints {
         let mut constraints = WorkgroupShapeConstraints::new();
         constraints.add_constraint(0, Constraint::Equals(1));

--- a/fusor-ml/core/src/mir/kernel_backend/flash_attention/mod.rs
+++ b/fusor-ml/core/src/mir/kernel_backend/flash_attention/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::OnceLock;
-
 use fusor_tile_ir as tile_ir;
 use fusor_tile_ir_kernels as tile_ir_kernels;
 
@@ -9,7 +7,6 @@ use crate::{
     kernel_selection::{
         Axis, DimConstraint, KernelDeviceCaps, KernelShape, ShapeRule, ShapeSelector, eq, range,
     },
-    mir::kernel_backend,
     tensor::TensorData,
 };
 
@@ -22,17 +19,11 @@ const DECODE_MID_BLOCK: u32 = 256;
 const DECODE_MEDIUM_BLOCK: u32 = 512;
 const DECODE_LARGE_BLOCK: u32 = 1024;
 pub(crate) const MIN_DECODE_KV_SEQ: usize = 32;
-const FLASH_ATTENTION_MODULE_CACHE_SIZE: usize = 128;
 /// Hardware subgroup sizes the streaming flash kernel emits IR for. The
 /// kernel layout assumes one subgroup per output dim and uses subgroup
 /// reductions across a `SIZE`-wide KV chunk, so the runtime subgroup width
 /// must match one of these exactly.
 const FLASH_STREAMING_SUBGROUP_SIZES: &[u32] = &[4, 8, 16, 32, 64];
-
-fn flash_attention_module_cache() -> &'static kernel_backend::ModuleCache {
-    static CACHE: OnceLock<kernel_backend::ModuleCache> = OnceLock::new();
-    CACHE.get_or_init(|| kernel_backend::module_cache(FLASH_ATTENTION_MODULE_CACHE_SIZE))
-}
 
 #[allow(clippy::too_many_arguments)]
 fn dispatch_streaming_flash_attention(

--- a/fusor-ml/core/src/mir/kernel_backend/flash_attention/tests.rs
+++ b/fusor-ml/core/src/mir/kernel_backend/flash_attention/tests.rs
@@ -125,7 +125,7 @@ fn decode_small_meta_buckets_dynamic_kv_len() {
 }
 
 #[test]
-fn decode_module_key_uses_bucketed_kv_len() {
+fn decode_cache_key_uses_bucketed_kv_len() {
     let meta = build_flash_decode_small_meta(
         decode_dims(DECODE_SMALL_BLOCK + 1),
         1.0,
@@ -144,14 +144,14 @@ fn decode_module_key_uses_bucketed_kv_len() {
 
     let workgroup_shape = WorkgroupShape::new(1, 1, 1);
     let dispatch_size = [meta.dims.batch * meta.dims.num_heads, 1, 1];
-    let key = kernel::flash_decode_module_key(
+    let key = kernel::flash_decode_cache_key(
         Some(&workgroup_shape),
         dispatch_size,
         DataTypeEnum::F32,
         1.0,
         &meta,
     );
-    let next_token_key = kernel::flash_decode_module_key(
+    let next_token_key = kernel::flash_decode_cache_key(
         Some(&workgroup_shape),
         dispatch_size,
         DataTypeEnum::F32,
@@ -163,7 +163,7 @@ fn decode_module_key_uses_bucketed_kv_len() {
 
     let mut different_stride_meta = meta;
     different_stride_meta.k_strides[1] += TEST_HEAD_DIM as u32;
-    let different_stride_key = kernel::flash_decode_module_key(
+    let different_stride_key = kernel::flash_decode_cache_key(
         Some(&workgroup_shape),
         dispatch_size,
         DataTypeEnum::F32,

--- a/fusor-ml/core/src/mir/kernel_backend/rms_norm.rs
+++ b/fusor-ml/core/src/mir/kernel_backend/rms_norm.rs
@@ -1,8 +1,4 @@
-use std::{
-    any::Any,
-    hash::Hash,
-    sync::{Arc, OnceLock},
-};
+use std::{any::Any, hash::Hash, sync::Arc};
 
 use crate::{
     DataTypeEnum, Layout,
@@ -39,12 +35,6 @@ use rustc_hash::FxHasher;
 // matmul also uses 512 for the same reason) and is still wide enough
 // to feed a 128-block subgroup-reduce on Apple Silicon / NVIDIA.
 const BLOCK: usize = 512;
-const RMS_NORM_MODULE_CACHE_SIZE: usize = 128;
-
-fn rms_norm_module_cache() -> &'static kernel_backend::ModuleCache {
-    static CACHE: OnceLock<kernel_backend::ModuleCache> = OnceLock::new();
-    CACHE.get_or_init(|| kernel_backend::module_cache(RMS_NORM_MODULE_CACHE_SIZE))
-}
 
 fn collect_rms_buffers(
     input: &TensorData,
@@ -317,7 +307,7 @@ impl Operation for RmsNormOperation {
             kernel_backend::KernelVariantKey::with_payload::<RmsNormDirectKernelVariant>(|state| {
                 variant.hash(state);
             });
-        let module_key = self.kernel_module_key_with_dispatch(
+        let cache_key = self.kernel_cache_key_with_dispatch(
             cache_variant,
             Some(workgroup_shape),
             dispatch_size,
@@ -332,13 +322,10 @@ impl Operation for RmsNormOperation {
         if let Some(meta) = vec4_meta {
             let has_residual = residual.is_some();
             let has_bias = bias.is_some();
-            kernel_backend::dynamic_kernel_from_hashed_ir(
+            kernel_backend::dynamic_kernel_from_ir(
                 graph.device().kernel_cache(),
-                rms_norm_module_cache(),
                 kernel_label,
-                module_key,
-                buffers,
-                dispatch_size,
+                cache_key,
                 move || {
                     let vec_layout = tile_ir::Layout::strided(
                         tile_ir::MemoryLevel::Storage,
@@ -389,16 +376,15 @@ impl Operation for RmsNormOperation {
                     )?;
                     Some(kb.finish().0)
                 },
+                buffers,
+                dispatch_size,
             )
         } else {
             let post_chain = self.post_element_wise.clone();
-            kernel_backend::dynamic_kernel_from_hashed_ir(
+            kernel_backend::dynamic_kernel_from_ir(
                 graph.device().kernel_cache(),
-                rms_norm_module_cache(),
                 kernel_label,
-                module_key,
-                buffers,
-                dispatch_size,
+                cache_key,
                 || {
                     build_rms_norm_tile_ir(RmsNormTileIrParams {
                         input_view,
@@ -411,6 +397,8 @@ impl Operation for RmsNormOperation {
                         storage_datatype,
                     })
                 },
+                buffers,
+                dispatch_size,
             )
         }
     }

--- a/fusor-ml/core/src/mir/operation.rs
+++ b/fusor-ml/core/src/mir/operation.rs
@@ -39,7 +39,7 @@ pub(crate) trait Operation: Debug + 'static {
     /// The concrete operation type is added by `kernel_module_key_with_dispatch`;
     /// implementations only hash fields not represented by MIR inputs,
     /// dispatch, or workgroup shape.
-    fn hash_kernel_fields(&self, _state: &mut FxHasher) {}
+    fn hash_kernel_fields(&self, state: &mut FxHasher);
 
     fn kernel_module_key_with_dispatch(
         &self,

--- a/fusor-ml/core/src/mir/operation.rs
+++ b/fusor-ml/core/src/mir/operation.rs
@@ -36,12 +36,12 @@ pub(crate) trait Operation: Debug + 'static {
 
     /// Hash structural operation fields that affect generated kernel IR.
     ///
-    /// The concrete operation type is added by `kernel_module_key_with_dispatch`;
+    /// The concrete operation type is added by `kernel_cache_key_with_dispatch`;
     /// implementations only hash fields not represented by MIR inputs,
     /// dispatch, or workgroup shape.
     fn hash_kernel_fields(&self, state: &mut FxHasher);
 
-    fn kernel_module_key_with_dispatch(
+    fn kernel_cache_key_with_dispatch(
         &self,
         variant: kernel_backend::KernelVariantKey,
         workgroup_shape: Option<&WorkgroupShape>,
@@ -64,16 +64,6 @@ pub(crate) trait Operation: Debug + 'static {
                 hash_mir_value(hasher, input);
             }
         })
-    }
-
-    fn kernel_cache_key_with_dispatch(
-        &self,
-        variant: kernel_backend::KernelVariantKey,
-        workgroup_shape: Option<&WorkgroupShape>,
-        dispatch_size: [u32; 3],
-        inputs: &[MirValue],
-    ) -> kernel_backend::KernelCacheKey {
-        self.kernel_module_key_with_dispatch(variant, workgroup_shape, dispatch_size, inputs)
     }
 }
 

--- a/fusor-ml/core/src/nary_direct.rs
+++ b/fusor-ml/core/src/nary_direct.rs
@@ -65,9 +65,6 @@ fn build_nary_direct_kernel_with_output_index(
     }
 
     let total_elements = total_elements(&operation.shape)?;
-    if total_elements == 0 {
-        return Some(DirectKernel::sequence("nary_direct_empty", Vec::new()));
-    }
     let small_dispatch = total_elements < BLOCK as u32;
     let dispatch_size = if small_dispatch {
         [total_elements, 1, 1]

--- a/fusor-ml/core/src/nary_direct.rs
+++ b/fusor-ml/core/src/nary_direct.rs
@@ -71,6 +71,9 @@ fn build_nary_direct_kernel_with_output_index(
     }
 
     let total_elements = total_elements(&operation.shape)?;
+    if total_elements == 0 {
+        return Some(DirectKernel::sequence("nary_direct_empty", Vec::new()));
+    }
     let small_dispatch = total_elements < BLOCK as u32;
     let dispatch_size = if small_dispatch {
         [total_elements, 1, 1]

--- a/fusor-ml/core/src/nary_direct.rs
+++ b/fusor-ml/core/src/nary_direct.rs
@@ -1,11 +1,11 @@
-use std::{hash::Hash, sync::Arc, sync::OnceLock};
+use std::hash::Hash;
 
 use fusor_tile_ir as tile_ir;
 
 use crate::{
     mir::{
         inputs::MirValue,
-        kernel_backend::{self, DirectKernel, DirectKernelBinding},
+        kernel_backend::{self, DirectKernel},
         operation::Operation,
         workgroup_shape::WorkgroupShape,
     },
@@ -15,14 +15,8 @@ use crate::{
 
 const BLOCK: usize = 256;
 const SMALL_BLOCK: usize = 1;
-const NARY_DIRECT_MODULE_CACHE_SIZE: usize = 1024;
 
 struct NaryDirectKernelVariant;
-
-fn nary_direct_module_cache() -> &'static kernel_backend::ModuleCache {
-    static CACHE: OnceLock<kernel_backend::ModuleCache> = OnceLock::new();
-    CACHE.get_or_init(|| kernel_backend::module_cache(NARY_DIRECT_MODULE_CACHE_SIZE))
-}
 
 pub(crate) fn build_nary_direct_kernel(
     operation: &NaryOperation,
@@ -84,48 +78,35 @@ fn build_nary_direct_kernel_with_output_index(
         kernel_backend::KernelVariantKey::with_payload::<NaryDirectKernelVariant>(|state| {
             output_index.hash(state);
         });
-    let module_key = operation.kernel_module_key_with_dispatch(
+    let cache_key = operation.kernel_cache_key_with_dispatch(
         variant,
         Some(workgroup_shape),
         dispatch_size,
         inputs,
     );
-    let kernel =
-        kernel_backend::cached_hashed_naga(nary_direct_module_cache(), module_key, || {
-            let ir = if small_dispatch {
-                build_nary_tile_ir::<SMALL_BLOCK>(operation, &tensors, output_index, dispatch_size)?
-            } else {
-                build_nary_tile_ir::<BLOCK>(operation, &tensors, output_index, dispatch_size)?
-            };
-            Some(Arc::new(ir.lower_to_naga().ok()?))
-        })?;
-    let cached = graph
-        .device()
-        .kernel_cache()
-        .get_or_insert_kernel(module_key, || kernel);
-
-    let bindings = tensors
-        .iter()
-        .enumerate()
-        .map(|(binding, tensor)| DirectKernelBinding {
-            binding: binding as u32,
-            buffer: tensor.buffer().clone(),
-            read_only: binding != output_index,
-        })
-        .collect();
-
     let name = if std::env::var_os("FUSOR_TRACE_DECODE_NAMES").is_some() {
         operation.name()
     } else {
         format!("nary_direct_out_{output_index}")
     };
-
-    Some(DirectKernel::from_cached(
+    let buffers = tensors
+        .iter()
+        .map(|tensor| tensor.buffer().clone())
+        .collect::<Vec<_>>();
+    kernel_backend::dynamic_kernel_from_ir(
+        graph.device().kernel_cache(),
         name,
-        cached,
-        bindings,
+        cache_key,
+        move || {
+            if small_dispatch {
+                build_nary_tile_ir::<SMALL_BLOCK>(operation, &tensors, output_index, dispatch_size)
+            } else {
+                build_nary_tile_ir::<BLOCK>(operation, &tensors, output_index, dispatch_size)
+            }
+        },
+        buffers,
         dispatch_size,
-    ))
+    )
 }
 
 fn total_elements(shape: &[usize]) -> Option<u32> {

--- a/fusor-ml/core/src/quantized/dequantize.rs
+++ b/fusor-ml/core/src/quantized/dequantize.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use fusor_gguf::GgmlType;
 use fusor_tile_ir as tile_ir;
 use fusor_tile_ir_kernels as tile_ir_kernels;
@@ -111,6 +113,14 @@ impl DequantizeOperation {
 }
 
 impl Operation for DequantizeOperation {
+    fn hash_kernel_fields(&self, state: &mut rustc_hash::FxHasher) {
+        self.matrix.datatype().hash(state);
+        self.matrix.storage_layout().hash(state);
+        self.matrix.shape().hash(state);
+        self.datatype.hash(state);
+        self.post_dequantize.hash(state);
+    }
+
     fn workgroup_shape_constraints(
         &self,
         _device: &Device,

--- a/fusor-ml/core/src/quantized/dequantize.rs
+++ b/fusor-ml/core/src/quantized/dequantize.rs
@@ -200,7 +200,7 @@ impl Operation for DequantizeOperation {
             .max_compute_workgroups_per_dimension
             .max(1);
         let dispatch_x = workgroups.min(max_workgroups);
-        let dispatch_y = workgroups.div_ceil(dispatch_x);
+        let dispatch_y = workgroups.div_ceil(dispatch_x.max(1)).max(1);
         if dispatch_y > max_workgroups {
             return None;
         }
@@ -214,7 +214,7 @@ impl Operation for DequantizeOperation {
         let output_buffer = output.buffer().clone();
         let output_layout = tile_ir::Layout::contiguous(
             tile_ir::MemoryLevel::Storage,
-            tile_ir::Shape::new([total]),
+            tile_ir::Shape::new([total.max(1)]),
         );
         let output_datatype = self.datatype;
         kernel_backend::run_kernel(

--- a/fusor-ml/core/src/quantized/embedding.rs
+++ b/fusor-ml/core/src/quantized/embedding.rs
@@ -159,11 +159,13 @@ fn u32_layout_2d(layout: &crate::Layout) -> Option<(u32, tile_ir::Layout)> {
     if shape.len() != 2 || strides.len() != 2 {
         return None;
     }
+    let rows = u32::try_from(shape[0]).ok()?.max(1);
+    let cols = u32::try_from(shape[1]).ok()?.max(1);
     Some((
         offset,
         tile_ir::Layout::strided(
             tile_ir::MemoryLevel::Storage,
-            tile_ir::Shape::new([shape[0].try_into().ok()?, shape[1].try_into().ok()?]),
+            tile_ir::Shape::new([rows, cols]),
             &[strides[0].try_into().ok()?, strides[1].try_into().ok()?],
         ),
     ))
@@ -176,11 +178,12 @@ fn u32_index_layout(layout: &crate::Layout) -> Option<(u32, tile_ir::Layout)> {
     if shape.len() != 1 || strides.len() != 1 {
         return None;
     }
+    let len = u32::try_from(shape[0]).ok()?.max(1);
     Some((
         offset,
         tile_ir::Layout::strided(
             tile_ir::MemoryLevel::Storage,
-            tile_ir::Shape::new([1, shape[0].try_into().ok()?]),
+            tile_ir::Shape::new([1, len]),
             &[0, strides[0].try_into().ok()?],
         ),
     ))

--- a/fusor-ml/core/src/quantized/embedding.rs
+++ b/fusor-ml/core/src/quantized/embedding.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use fusor_gguf::GgmlType;
 use fusor_tile_ir as tile_ir;
 use fusor_tile_ir_kernels as tile_ir_kernels;
@@ -185,6 +187,14 @@ fn u32_index_layout(layout: &crate::Layout) -> Option<(u32, tile_ir::Layout)> {
 }
 
 impl Operation for QEmbeddingOperation {
+    fn hash_kernel_fields(&self, state: &mut rustc_hash::FxHasher) {
+        self.matrix.datatype().hash(state);
+        self.matrix.storage_layout().hash(state);
+        self.matrix.shape().hash(state);
+        self.out_shape.hash(state);
+        self.datatype.hash(state);
+    }
+
     fn workgroup_shape_constraints(&self, _device: &Device) -> WorkgroupShapeConstraints {
         let mut constraints = WorkgroupShapeConstraints::new();
         constraints.add_constraint(0, Constraint::equals(BLOCK as u32));

--- a/fusor-ml/core/src/quantized/matmul/kernel.rs
+++ b/fusor-ml/core/src/quantized/matmul/kernel.rs
@@ -599,7 +599,32 @@ impl QMatMulOperation {
     }
 }
 
+fn hash_qmatmul_epilogue(state: &mut FxHasher, epilogue: &Option<ElementwiseEpilogue>) {
+    match epilogue {
+        Some(epilogue) => {
+            true.hash(state);
+            epilogue.expression.hash(state);
+            epilogue.extras.len().hash(state);
+            epilogue.input_datatype.hash(state);
+            epilogue.output_datatype.hash(state);
+        }
+        None => false.hash(state),
+    }
+}
+
 impl Operation for QMatMulOperation {
+    fn hash_kernel_fields(&self, state: &mut FxHasher) {
+        self.input_datatype.hash(state);
+        self.in_shape.hash(state);
+        self.out_shape.hash(state);
+        self.matrix.datatype().hash(state);
+        self.matrix.storage_layout().hash(state);
+        self.matrix.shape().hash(state);
+        hash_qmatmul_epilogue(state, &self.pre_element_wise_expr);
+        hash_qmatmul_epilogue(state, &self.post_element_wise_expr);
+        self.post_accumulator_offsets.hash(state);
+    }
+
     fn workgroup_shape_constraints(
         &self,
         _device: &Device,

--- a/fusor-ml/core/src/quantized/matmul/kernel.rs
+++ b/fusor-ml/core/src/quantized/matmul/kernel.rs
@@ -322,46 +322,6 @@ impl QMatMulOperation {
             ) {
                 return Some(kernel);
             }
-            let cache_key = qmatmul_direct_module_key::<QMatmulDirectFastKernelVariant>(
-                |state| {
-                    variant.hash(state);
-                    subgroup_size_range.hash(state);
-                    QMATMUL_DIRECT_KERNEL_GENERATION.hash(state);
-                },
-                |state| {
-                    QMATMUL_DIRECT_KERNEL_GENERATION.hash(state);
-                    hash_qmatmul_shape(state, format, m, k, matrix_n);
-                    subgroup_size_range.hash(state);
-                    hash_qmatmul_dispatch_layouts(
-                        state,
-                        dispatch_size,
-                        input.layout(),
-                        output.layout(),
-                    );
-                },
-                dispatch_size,
-                None,
-            );
-            if let Some(pipeline) = kernel_backend::three_buffer_pipeline_from_cached_module(
-                device.kernel_cache(),
-                &kernel_name,
-                cache_key,
-            ) {
-                matrix
-                    .direct_pipeline_cache()
-                    .write()
-                    .get_or_insert(pipeline_key, || pipeline.clone());
-                return Some(
-                    kernel_backend::DirectKernel::from_prepared_three_buffer_pipeline(
-                        kernel_name.clone(),
-                        pipeline,
-                        input.buffer().clone(),
-                        matrix.buffer().clone(),
-                        output.buffer().clone(),
-                        dispatch_size,
-                    ),
-                );
-            }
         }
         let pre_with_extras_for_ir = pre_epilogue_with_extras.clone();
         let post_with_extras_for_ir = post_epilogue_with_extras.clone();
@@ -556,7 +516,7 @@ impl QMatMulOperation {
             input.layout(),
             output.layout(),
         );
-        let cache_key = qmatmul_direct_module_key::<QMatmulDirectEpilogueKernelVariant>(
+        let cache_key = qmatmul_direct_cache_key::<QMatmulDirectEpilogueKernelVariant>(
             |state| {
                 variant.hash(state);
                 epilogue_identity.hash(state);

--- a/fusor-ml/core/src/quantized/matmul/mod.rs
+++ b/fusor-ml/core/src/quantized/matmul/mod.rs
@@ -797,13 +797,9 @@ fn split_workgroups_2d(
     total_workgroups: u32,
     max_workgroups_per_dimension: u32,
 ) -> Option<[u32; 2]> {
-    if total_workgroups == 0 {
-        return Some([1, 1]);
-    }
-
     let max_workgroups_per_dimension = max_workgroups_per_dimension.max(1);
     let x = total_workgroups.min(max_workgroups_per_dimension);
-    let y = total_workgroups.div_ceil(x);
+    let y = total_workgroups.div_ceil(x.max(1)).max(1);
     (y <= max_workgroups_per_dimension).then_some([x, y])
 }
 

--- a/fusor-ml/core/src/quantized/matmul/mod.rs
+++ b/fusor-ml/core/src/quantized/matmul/mod.rs
@@ -71,9 +71,9 @@ fn hash_qmatmul_dispatch_layouts(
 }
 
 /// Build a qmatmul-direct cache key in either the operation-bound or
-/// module-only path. Both arms wrap the same `KernelVariantKey<M>(payload)`;
-/// the unbound arm additionally hashes `outer` into the module key.
-fn qmatmul_direct_module_key<M: 'static>(
+/// standalone path. Both arms wrap the same `KernelVariantKey<M>(payload)`;
+/// the unbound arm additionally hashes `outer` into the key.
+fn qmatmul_direct_cache_key<M: 'static>(
     payload_hash: impl Fn(&mut FxHasher),
     outer_hash: impl Fn(&mut FxHasher),
     dispatch_size: [u32; 3],
@@ -120,7 +120,6 @@ enum QMatmulPath {
     Tile { tile: CoopTile, cached: bool },
 }
 
-struct QMatmulDirectFastKernelVariant;
 struct QMatmulDirectEpilogueKernelVariant;
 
 const QMATMUL_DIRECT_KERNEL_GENERATION: u64 = 0x514D_4154_4D49_5832;

--- a/fusor-ml/core/src/quantized/matmul/tests.rs
+++ b/fusor-ml/core/src/quantized/matmul/tests.rs
@@ -284,7 +284,7 @@ mod selection_tests {
 mod tests {
     use std::{mem::size_of, sync::Arc};
 
-    use fusor_gguf::{BlockQ4_0, BlockQ4K, BlockQ5K, BlockQ6K, BlockQ8_0, GgufBlock};
+    use fusor_gguf::{BlockQ4_0, BlockQ4K, BlockQ5_0, BlockQ5K, BlockQ6K, BlockQ8_0, GgufBlock};
 
     use super::*;
     use crate::{
@@ -477,6 +477,34 @@ mod tests {
         });
     }
 
+    fn patterned_q8_0_bytes(shape: [usize; 2]) -> Vec<u8> {
+        let block_count = shape.iter().product::<usize>() / BlockQ8_0::BLOCK_SIZE;
+        let mut bytes = Vec::with_capacity(block_count * size_of::<BlockQ8_0>());
+        for block in 0..block_count {
+            push_f16(&mut bytes, 0.01);
+            for i in 0..BlockQ8_0::WEIGHTS_SIZE {
+                let value = (((block * 5 + i * 3) % 64) as i32 - 32) as i8;
+                bytes.push(value as u8);
+            }
+        }
+        bytes
+    }
+
+    fn patterned_q5_0_bytes(shape: [usize; 2]) -> Vec<u8> {
+        let block_count = shape.iter().product::<usize>() / BlockQ5_0::BLOCK_SIZE;
+        let mut bytes = Vec::with_capacity(block_count * size_of::<BlockQ5_0>());
+        for block in 0..block_count {
+            push_f16(&mut bytes, 0.01);
+            for i in 0..BlockQ5_0::WEIGHTS_HIGH_BITS_SIZE {
+                bytes.push(((block * 7 + i * 13) & 0xFF) as u8);
+            }
+            for i in 0..BlockQ5_0::WEIGHTS_LOW_BITS_SIZE {
+                bytes.push(packed_nibble_byte(block + i, block * 2 + i + 1));
+            }
+        }
+        bytes
+    }
+
     #[test]
     fn q4k_native_dequantize_matches_patterned_blocks() {
         pollster::block_on(async {
@@ -541,6 +569,289 @@ mod tests {
 
             assert_eq!(result.shape(), &[1, weight_shape[0] / 2]);
             assert!(result.as_slice().iter().all(|value| value.is_finite()));
+        });
+    }
+
+    #[test]
+    fn q4k_large_single_row_qgemv_handles_tail_columns_with_subgroups() {
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            if !device.subgroups_supported() {
+                return;
+            }
+
+            let weight_shape = [8193usize, 4096usize];
+            let blocks_per_row = weight_shape[1] / BlockQ4K::BLOCK_SIZE;
+            let raw_bytes = patterned_q4k_bytes(weight_shape);
+            let matrix =
+                QMatrix::from_parts(&device, &raw_bytes, weight_shape.into(), GgmlType::Q4K)
+                    .unwrap();
+            let blocks: &[BlockQ4K] = bytemuck::cast_slice(&raw_bytes);
+            let input_values = (0..weight_shape[1])
+                .map(|index| {
+                    let bucket = (index.wrapping_mul(37).wrapping_add(11)) % 101;
+                    (bucket as f32 - 50.0) * 0.0025
+                })
+                .collect::<Vec<_>>();
+            let input = Tensor::from_slice::<f32>(&device, [1, weight_shape[1]], &input_values);
+
+            let result = input.q_mat_mul(&matrix).as_slice::<2, f32>().await.unwrap();
+
+            assert_eq!(result.shape(), &[1, weight_shape[0]]);
+            for col in [0usize, 1, 63, 64, 511, 1024, 8191, 8192] {
+                let expected = (0..blocks_per_row)
+                    .map(|block_col| {
+                        let block = &blocks[col * blocks_per_row + block_col];
+                        let weights = block.dequantize();
+                        weights
+                            .as_ref()
+                            .iter()
+                            .enumerate()
+                            .map(|(offset, weight)| {
+                                input_values[block_col * BlockQ4K::BLOCK_SIZE + offset] * *weight
+                            })
+                            .sum::<f32>()
+                    })
+                    .sum::<f32>();
+                let actual = result[[0, col]];
+                assert!(
+                    (actual - expected).abs() <= 1e-2_f32.max(expected.abs() * 1.0e-4),
+                    "col={col} actual={actual} expected={expected}"
+                );
+            }
+        });
+    }
+
+    // Regression test for native decode gibberish: the single-row (m=1, decode)
+    // subgroup qgemv must agree with the no-subgroup path, which is the
+    // reference web/native-without-subgroups run and is known-correct. A
+    // divergence here is exactly the per-token logit corruption that turns
+    // generation into token-salad. Covers each quantized format the model uses,
+    // at a Llama-ish projection shape.
+    // Isolates whether the cooperative-matrix bug is quantized-specific (the
+    // dequantizing tile fill) or general to the coop matmul codegen: a plain
+    // dense f32 matmul at coop-eligible dims must also agree between the
+    // subgroup (coop) and no-subgroup paths. If THIS diverges, the bug is the
+    // cooperative-matrix path itself (independent of quantization).
+    #[test]
+    fn dense_coop_matmul_subgroup_matches_no_subgroup() {
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            if !device.subgroups_supported() {
+                return;
+            }
+            let no_sg = device.without_subgroups();
+
+            let (m, k, n) = (128usize, 256usize, 128usize);
+            let a = (0..m * k)
+                .map(|i| ((i.wrapping_mul(31).wrapping_add(7)) % 97) as f32 * 0.003 - 0.14)
+                .collect::<Vec<_>>();
+            let b = (0..k * n)
+                .map(|i| ((i.wrapping_mul(53).wrapping_add(3)) % 89) as f32 * 0.004 - 0.17)
+                .collect::<Vec<_>>();
+
+            let out_sg = {
+                let a_t = Tensor::from_slice::<f32>(&device, [m, k], &a);
+                let b_t = Tensor::from_slice::<f32>(&device, [k, n], &b);
+                let s = a_t.mat_mul(&b_t).as_slice::<2, f32>().await.unwrap();
+                (0..m)
+                    .flat_map(|r| (0..n).map(move |c| (r, c)))
+                    .map(|(r, c)| s[[r, c]])
+                    .collect::<Vec<_>>()
+            };
+            let out_no = {
+                let a_t = Tensor::from_slice::<f32>(&no_sg, [m, k], &a);
+                let b_t = Tensor::from_slice::<f32>(&no_sg, [k, n], &b);
+                let s = a_t.mat_mul(&b_t).as_slice::<2, f32>().await.unwrap();
+                (0..m)
+                    .flat_map(|r| (0..n).map(move |c| (r, c)))
+                    .map(|(r, c)| s[[r, c]])
+                    .collect::<Vec<_>>()
+            };
+
+            let mut worst = 0.0f32;
+            let mut wi = 0usize;
+            let (mut wa, mut wb) = (0.0f32, 0.0f32);
+            for (i, (x, y)) in out_sg.iter().zip(&out_no).enumerate() {
+                let err = (x - y).abs();
+                if err > worst {
+                    worst = err;
+                    wi = i;
+                    wa = *x;
+                    wb = *y;
+                }
+            }
+            assert!(
+                worst <= 1.0e-3 + wb.abs() * 1.0e-3,
+                "dense coop matmul diverges from no-subgroup at {wi}: subgroup={wa} no_subgroup={wb} abs_err={worst}"
+            );
+        });
+    }
+
+    #[test]
+    fn single_row_qgemv_subgroup_matches_no_subgroup() {
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            if !device.subgroups_supported() {
+                return;
+            }
+            let no_sg = device.without_subgroups();
+
+            // (name, [n, k], bytes, format). The large-block K-quants (q4k/q6k)
+            // are exercised at the ffn k=4096 regime; the small-block formats
+            // (q8_0/q5_0) at the k=896 projection regime the model actually uses
+            // for its attention/mlp projections (896 is not a multiple of 256, so
+            // those weights can only be block-32 formats).
+            let cases: [(&str, [usize; 2], Vec<u8>, GgmlType); 5] = [
+                (
+                    "q4k",
+                    [896, 4096],
+                    patterned_q4k_bytes([896, 4096]),
+                    GgmlType::Q4K,
+                ),
+                (
+                    "q6k",
+                    [896, 4096],
+                    patterned_q6k_bytes([896, 4096]),
+                    GgmlType::Q6K,
+                ),
+                (
+                    "q8_0",
+                    [896, 896],
+                    patterned_q8_0_bytes([896, 896]),
+                    GgmlType::Q8_0,
+                ),
+                (
+                    "q5_0",
+                    [896, 896],
+                    patterned_q5_0_bytes([896, 896]),
+                    GgmlType::Q5_0,
+                ),
+                // lm-head / tied-embedding shape: huge n, q5_0, k=hidden. Produces
+                // the logits every token, so a wrong subgroup qgemv here is exactly
+                // "wrong token sampled => gibberish".
+                (
+                    "q5_0_lmhead",
+                    [151936, 896],
+                    patterned_q5_0_bytes([151936, 896]),
+                    GgmlType::Q5_0,
+                ),
+            ];
+
+            async fn row(t: Tensor) -> Vec<f32> {
+                let slice = t.as_slice::<2, f32>().await.unwrap();
+                let cols = slice.shape()[1];
+                (0..cols).map(|col| slice[[0, col]]).collect()
+            }
+            async fn rows(t: Tensor) -> Vec<f32> {
+                let slice = t.as_slice::<2, f32>().await.unwrap();
+                let shape = slice.shape();
+                let (m, cols) = (shape[0], shape[1]);
+                let mut out = Vec::with_capacity(m * cols);
+                for r in 0..m {
+                    for c in 0..cols {
+                        out.push(slice[[r, c]]);
+                    }
+                }
+                out
+            }
+            // The two paths use different reduction kernels, so allow FP rounding
+            // slack; gibberish (a stale/miscompiled subgroup kernel) is orders of
+            // magnitude larger.
+            fn assert_match(name: &str, op: &str, sg: &[f32], no: &[f32]) {
+                assert_eq!(sg.len(), no.len(), "{name}/{op}: length mismatch");
+                let mut worst = 0.0f32;
+                let (mut wc, mut wa, mut wb) = (0usize, 0.0f32, 0.0f32);
+                for (col, (a, b)) in sg.iter().zip(no).enumerate() {
+                    let err = (a - b).abs();
+                    if err > worst {
+                        worst = err;
+                        wc = col;
+                        wa = *a;
+                        wb = *b;
+                    }
+                }
+                assert!(
+                    worst <= 1.0e-2 + wb.abs() * 1.0e-2,
+                    "{name}/{op}: subgroup qgemv diverges from no-subgroup at col {wc}: \
+                     subgroup={wa} no_subgroup={wb} abs_err={worst}"
+                );
+            }
+
+            for (name, weight_shape, raw_bytes, ty) in cases {
+                let [n, k] = weight_shape;
+                let input_values = (0..k)
+                    .map(|index| {
+                        let bucket = (index.wrapping_mul(37).wrapping_add(11)) % 101;
+                        (bucket as f32 - 50.0) * 0.0025
+                    })
+                    .collect::<Vec<_>>();
+                let extra = (0..n)
+                    .map(|i| (i % 13) as f32 * 0.01 - 0.06)
+                    .collect::<Vec<_>>();
+                let mat_sg =
+                    QMatrix::from_parts(&device, &raw_bytes, weight_shape.into(), ty).unwrap();
+                let mat_no =
+                    QMatrix::from_parts(&no_sg, &raw_bytes, weight_shape.into(), ty).unwrap();
+                let in_sg = Tensor::from_slice::<f32>(&device, [1, k], &input_values);
+                let in_no = Tensor::from_slice::<f32>(&no_sg, [1, k], &input_values);
+
+                // Plain qgemv.
+                assert_match(
+                    name,
+                    "plain",
+                    &row(in_sg.q_mat_mul(&mat_sg)).await,
+                    &row(in_no.q_mat_mul(&mat_no)).await,
+                );
+
+                // Fused paired-silu-product epilogue (the MLP gate/up matmul) —
+                // the dominant matmul in decode and the one the previous fast
+                // cache could not key.
+                assert_match(
+                    name,
+                    "silu_product",
+                    &row(in_sg.q_mat_mul_paired_silu_product(&mat_sg)).await,
+                    &row(in_no.q_mat_mul_paired_silu_product(&mat_no)).await,
+                );
+
+                // Fused add2 epilogue (residual add after a projection).
+                let first_sg = Tensor::from_slice::<f32>(&device, [1, n], &extra);
+                let second_sg = Tensor::from_slice::<f32>(&device, [1, n], &extra);
+                let first_no = Tensor::from_slice::<f32>(&no_sg, [1, n], &extra);
+                let second_no = Tensor::from_slice::<f32>(&no_sg, [1, n], &extra);
+                assert_match(
+                    name,
+                    "add2",
+                    &row(in_sg.q_mat_mul_add2(&mat_sg, &first_sg, &second_sg)).await,
+                    &row(in_no.q_mat_mul_add2(&mat_no, &first_no, &second_no)).await,
+                );
+
+                // Multi-row (prefill) regime: the prompt is processed at m>1 with
+                // a different (tile/coop) subgroup kernel than decode's qgemv. A
+                // wrong prefill matmul poisons the KV cache, so every later decode
+                // token reads bad context and produces gibberish.
+                let m = 16usize;
+                let multi = (0..m * k)
+                    .map(|i| {
+                        let bucket = (i.wrapping_mul(53).wrapping_add(7)) % 97;
+                        (bucket as f32 - 48.0) * 0.0021
+                    })
+                    .collect::<Vec<_>>();
+                let multi_sg = Tensor::from_slice::<f32>(&device, [m, k], &multi);
+                let multi_no = Tensor::from_slice::<f32>(&no_sg, [m, k], &multi);
+                assert_match(
+                    name,
+                    "plain_multirow",
+                    &rows(multi_sg.q_mat_mul(&mat_sg)).await,
+                    &rows(multi_no.q_mat_mul(&mat_no)).await,
+                );
+            }
         });
     }
 

--- a/fusor-ml/core/src/quantized/matmul/tests.rs
+++ b/fusor-ml/core/src/quantized/matmul/tests.rs
@@ -285,12 +285,10 @@ mod tests {
     use std::{mem::size_of, sync::Arc};
 
     use fusor_gguf::{BlockQ4_0, BlockQ4K, BlockQ5_0, BlockQ5K, BlockQ6K, BlockQ8_0, GgufBlock};
+    use fusor_tile_ir_runtime::DirectKernelBinding;
 
     use super::*;
-    use crate::{
-        compute_graph::ComputeGraphInner, mir::kernel_backend::DirectKernelBinding,
-        mir::workgroup_shape::WorkgroupShape,
-    };
+    use crate::{compute_graph::ComputeGraphInner, mir::workgroup_shape::WorkgroupShape};
 
     fn push_f16(bytes: &mut Vec<u8>, value: f32) {
         bytes.extend_from_slice(&half::f16::from_f32(value).to_le_bytes());

--- a/fusor-ml/core/src/quantized/matmul/tests.rs
+++ b/fusor-ml/core/src/quantized/matmul/tests.rs
@@ -691,6 +691,158 @@ mod tests {
     }
 
     #[test]
+    fn primitive_f32_coop_mma_matches_logical_a_times_b() {
+        use std::hash::Hash;
+
+        use crate::kernel_selection::CooperativeMatrixKind;
+        use crate::mir::kernel_backend;
+        use fusor_tile_ir::{
+            ElementType, KernelTensorRef, Layout, MemoryLevel, ScalarElement, Shape,
+        };
+
+        pollster::block_on(async {
+            let Ok(device) = Device::new().await else {
+                return;
+            };
+            let Some(coop_token) = device.coop_token(CooperativeMatrixKind::F32F32M8N8K8) else {
+                return;
+            };
+
+            const DIM: usize = 8;
+            let a = (0..DIM * DIM)
+                .map(|i| ((i.wrapping_mul(31).wrapping_add(7)) % 97) as f32 * 0.003 - 0.14)
+                .collect::<Vec<_>>();
+            let b = (0..DIM * DIM)
+                .map(|i| ((i.wrapping_mul(53).wrapping_add(3)) % 89) as f32 * 0.004 - 0.17)
+                .collect::<Vec<_>>();
+            let a_buffer = device.create_buffer_init(
+                bytemuck::cast_slice(&a),
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            let b_buffer = device.create_buffer_init(
+                bytemuck::cast_slice(&b),
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            let y_buffer = device.create_buffer(
+                (DIM * DIM * size_of::<f32>()) as u64,
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            );
+            let layout =
+                Layout::contiguous(MemoryLevel::Storage, Shape::new([DIM as u32, DIM as u32]));
+            let cache_key = kernel_backend::KernelCacheKey::from_hash_inputs(|state| {
+                "primitive_f32_coop_mma_matches_logical_a_times_b".hash(state);
+            });
+            let kernel = kernel_backend::run_kernel(
+                device.kernel_cache(),
+                "primitive_f32_coop_mma_matches_logical_a_times_b",
+                cache_key,
+                [1, 1, 1],
+                |kb| {
+                    let a_storage = kb.read(
+                        ElementType::F32,
+                        KernelTensorRef::new(a_buffer.clone(), layout.clone()),
+                    );
+                    let b_storage = kb.read(
+                        ElementType::F32,
+                        KernelTensorRef::new(b_buffer.clone(), layout.clone()),
+                    );
+                    let y_storage = kb.write(
+                        ElementType::F32,
+                        KernelTensorRef::new(y_buffer.clone(), layout),
+                    );
+                    let program = kb.program();
+                    let a_tile = program.alloc_workgroup_tile(ScalarElement::F32, 8, 8);
+                    let b_tile = program.alloc_workgroup_tile(ScalarElement::F32, 8, 8);
+                    program.program_grid(32, [1, 1, 1], |program| {
+                        program.fill_tile(&a_tile, &a_storage, 0u32, 0u32);
+                        program.fill_tile(&b_tile, &b_storage, 0u32, 0u32);
+                        program.workgroup_barrier();
+
+                        let acc = coop_token.alloc_coop_acc(program, ScalarElement::F32, 8, 8);
+                        let zero = coop_token.coop_zero(program, ScalarElement::F32, 8, 8);
+                        coop_token.store_local_coop(program, &acc, zero);
+                        let a_frag = coop_token.coop_load_a(
+                            program,
+                            &a_tile,
+                            0u32,
+                            0u32,
+                            ScalarElement::F32,
+                            8,
+                            8,
+                        );
+                        let b_frag = coop_token.coop_load_b(
+                            program,
+                            &b_tile,
+                            0u32,
+                            0u32,
+                            ScalarElement::F32,
+                            8,
+                            8,
+                        );
+                        let c_value = coop_token.load_local_coop(program, &acc);
+                        let mma = coop_token.coop_mma(program, a_frag, b_frag, c_value);
+                        coop_token.store_local_coop(program, &acc, mma);
+                        coop_token.coop_store(program, &acc, &y_storage, 0u32, 0u32);
+                    });
+                    Some(())
+                },
+            )
+            .expect("kernel should build");
+
+            let output_bytes = (DIM * DIM * size_of::<f32>()) as u64;
+            let download = device.wgpu_device().create_buffer(&wgpu::BufferDescriptor {
+                label: Some("primitive f32 coop mma download"),
+                size: output_bytes,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            });
+            let mut encoder = device
+                .wgpu_device()
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            kernel.run(device.kernel_cache(), &mut encoder);
+            encoder.copy_buffer_to_buffer(&y_buffer, 0, &download, 0, output_bytes);
+            device.wgpu_queue().submit(Some(encoder.finish()));
+
+            let (sender, receiver) = std::sync::mpsc::channel();
+            download
+                .slice(..)
+                .map_async(wgpu::MapMode::Read, move |result| {
+                    let _ = sender.send(result);
+                });
+            device.poll_wait();
+            receiver.recv().unwrap().unwrap();
+            let view = download.slice(..).get_mapped_range();
+            let actual = bytemuck::cast_slice::<u8, f32>(&view).to_vec();
+            drop(view);
+            download.unmap();
+
+            let mut expected = [0.0f32; DIM * DIM];
+            for r in 0..DIM {
+                for c in 0..DIM {
+                    expected[r * DIM + c] =
+                        (0..DIM).map(|kk| a[r * DIM + kk] * b[kk * DIM + c]).sum();
+                }
+            }
+
+            let mut worst = 0.0f32;
+            let mut wi = 0usize;
+            for (i, (x, y)) in actual.iter().zip(expected.iter()).enumerate() {
+                let err = (x - y).abs();
+                if err > worst {
+                    worst = err;
+                    wi = i;
+                }
+            }
+            assert!(
+                worst < 1e-4,
+                "primitive f32 coop MMA mismatch at {wi}: actual={} expected={} worst={worst} actual={actual:?} expected={expected:?}",
+                actual[wi],
+                expected[wi]
+            );
+        });
+    }
+
+    #[test]
     fn single_row_qgemv_subgroup_matches_no_subgroup() {
         pollster::block_on(async {
             let Ok(device) = Device::new().await else {

--- a/fusor-ml/core/src/quantized/mod.rs
+++ b/fusor-ml/core/src/quantized/mod.rs
@@ -543,7 +543,6 @@ mod tests {
             GgmlType::Q8_0,
             GgmlType::Q4K,
             GgmlType::Q5K,
-            GgmlType::Q6K,
         ] {
             assert_eq!(
                 qmatrix_storage_layout_for_parts_with_env(ty, true, None),
@@ -554,6 +553,14 @@ mod tests {
                 QMatrixStorageLayout::GpuF32Scales
             );
         }
+        assert_eq!(
+            qmatrix_storage_layout_for_parts_with_env(GgmlType::Q6K, true, None),
+            QMatrixStorageLayout::GpuF32Scales
+        );
+        assert_eq!(
+            qmatrix_storage_layout_for_parts_with_env(GgmlType::Q6K, false, None),
+            QMatrixStorageLayout::GpuF32Scales
+        );
     }
 
     #[test]

--- a/fusor-ml/core/src/resize.rs
+++ b/fusor-ml/core/src/resize.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use crate::{
     DataTypeEnum, Layout, TILE_SIZE, Tensor, TensorData,
     compute_graph::NodeIndex,
@@ -162,6 +164,12 @@ fn is_row_major_contiguous(layout: &Layout) -> bool {
 }
 
 impl Operation for ResizeOperation {
+    fn hash_kernel_fields(&self, state: &mut rustc_hash::FxHasher) {
+        self.current_shape.hash(state);
+        self.new_shape.hash(state);
+        self.fill_shape.hash(state);
+    }
+
     fn workgroup_shape_constraints(
         &self,
         _: &crate::Device,

--- a/fusor-ml/core/src/sampling/mod.rs
+++ b/fusor-ml/core/src/sampling/mod.rs
@@ -70,7 +70,7 @@ impl PendingGpuSampledToken {
             eprintln!("{msg}");
         }
 
-        let view = self.download.slice(..).get_mapped_range().unwrap();
+        let view = self.download.slice(..).get_mapped_range();
         let word_size = std::mem::size_of::<u32>();
         let status = view
             .get(..word_size)

--- a/fusor-ml/core/src/sampling/mod.rs
+++ b/fusor-ml/core/src/sampling/mod.rs
@@ -53,9 +53,24 @@ impl PendingGpuSampledToken {
     }
 
     pub async fn read_token(self) -> Result<Option<u32>, wgpu::BufferAsyncError> {
+        // Diagnostic: time the wait for GPU completion + token readback (the
+        // per-token sync the pending decode path stalls on). On wasm this is
+        // always on and logged to the browser console; native gates on the
+        // FUSOR_TRACE_* env vars.
+        let trace = cfg!(target_arch = "wasm32")
+            || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+            || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some();
+        let await_start = trace.then(web_time::Instant::now);
         self.receiver.await.map_err(|_| wgpu::BufferAsyncError)??;
+        if let Some(start) = await_start {
+            let msg = format!("sampler_trace pending_await elapsed={:?}", start.elapsed());
+            #[cfg(target_arch = "wasm32")]
+            web_sys::console::log_1(&msg.into());
+            #[cfg(not(target_arch = "wasm32"))]
+            eprintln!("{msg}");
+        }
 
-        let view = self.download.slice(..).get_mapped_range();
+        let view = self.download.slice(..).get_mapped_range().unwrap();
         let word_size = std::mem::size_of::<u32>();
         let status = view
             .get(..word_size)

--- a/fusor-ml/core/src/sampling/mod.rs
+++ b/fusor-ml/core/src/sampling/mod.rs
@@ -55,19 +55,14 @@ impl PendingGpuSampledToken {
     pub async fn read_token(self) -> Result<Option<u32>, wgpu::BufferAsyncError> {
         // Diagnostic: time the wait for GPU completion + token readback (the
         // per-token sync the pending decode path stalls on). On wasm this is
-        // always on and logged to the browser console; native gates on the
-        // FUSOR_TRACE_* env vars.
+        // always on; native gates on the FUSOR_TRACE_* env vars.
         let trace = cfg!(target_arch = "wasm32")
             || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
             || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some();
         let await_start = trace.then(web_time::Instant::now);
         self.receiver.await.map_err(|_| wgpu::BufferAsyncError)??;
         if let Some(start) = await_start {
-            let msg = format!("sampler_trace pending_await elapsed={:?}", start.elapsed());
-            #[cfg(target_arch = "wasm32")]
-            web_sys::console::log_1(&msg.into());
-            #[cfg(not(target_arch = "wasm32"))]
-            eprintln!("{msg}");
+            tracing::info!("sampler_trace pending_await elapsed={:?}", start.elapsed());
         }
 
         let view = self.download.slice(..).get_mapped_range();

--- a/fusor-ml/core/src/sampling/pipeline.rs
+++ b/fusor-ml/core/src/sampling/pipeline.rs
@@ -4,6 +4,16 @@ use crate::{
     tensor::{DataTypeEnum, LazyTensorData, TensorData},
 };
 use web_time::Instant;
+
+// Diagnostic: the std `eprintln!` used for the `sampler_trace` timing below is
+// invisible on wasm, so on the web target route those lines to the browser
+// console instead. Native keeps the real `eprintln!`.
+#[cfg(target_arch = "wasm32")]
+macro_rules! eprintln {
+    ($($arg:tt)*) => {{
+        web_sys::console::log_1(&format!($($arg)*).into());
+    }};
+}
 use wgpu::CommandEncoder;
 
 use super::{
@@ -69,7 +79,8 @@ pub(crate) async fn qmat_mirostat2_sample_token_to_host(
                 label: Some("qmat_mirostat2_sample_token_to_host encoder"),
             });
 
-    let trace = std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+    let trace = cfg!(target_arch = "wasm32")
+        || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
         || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some();
     let qmat_start = trace.then(Instant::now);
     let Some(logits) = qmat_logits_data_with_encoder(hidden, matrix, &mut encoder) else {
@@ -118,7 +129,7 @@ pub(crate) async fn qmat_mirostat2_sample_token_to_host(
         #[cfg(not(target_arch = "wasm32"))]
         device.poll_wait();
         let _ = rx.await;
-        let view = hidden_dl.slice(..).get_mapped_range();
+        let view = hidden_dl.slice(..).get_mapped_range().unwrap();
         let hidden_vec: Vec<f32> = bytemuck::cast_slice(&view).to_vec();
         drop(view);
         hidden_dl.unmap();
@@ -183,7 +194,8 @@ pub(crate) async fn qmat_mirostat2_sample_lazy_token_to_host(
         return Ok(None);
     }
 
-    let trace = std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+    let trace = cfg!(target_arch = "wasm32")
+        || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
         || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some();
     let qmat_start = trace.then(Instant::now);
     let (materialized_hidden, _, logits) = hidden.materialize_with_tail(|hidden_data, encoder| {
@@ -253,7 +265,8 @@ pub(crate) async fn qmat_standard_sample_lazy_token_to_host(
         return Ok(None);
     }
 
-    let trace = std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+    let trace = cfg!(target_arch = "wasm32")
+        || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
         || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some();
     let qmat_start = trace.then(Instant::now);
     let (materialized_hidden, _, logits) = hidden.materialize_with_tail(|hidden_data, encoder| {
@@ -356,7 +369,8 @@ pub(crate) fn qmat_mirostat2_sample_lazy_token_pending(
         return None;
     }
 
-    let qmat_start = (std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+    let qmat_start = (cfg!(target_arch = "wasm32")
+        || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
         || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some())
     .then(Instant::now);
     let (materialized_hidden, _) = hidden.materialize();
@@ -406,7 +420,8 @@ pub(crate) fn qmat_standard_sample_lazy_token_pending(
         return None;
     }
 
-    let qmat_start = (std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+    let qmat_start = (cfg!(target_arch = "wasm32")
+        || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
         || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some())
     .then(Instant::now);
     let (materialized_hidden, _) = hidden.materialize();
@@ -552,7 +567,7 @@ fn sample_processed_logits_pending(
             chunks,
             input_len,
             candidate_count,
-            trace: false,
+            trace: cfg!(target_arch = "wasm32"),
             encoder_label: "mirostat2_sample_token_pending encoder",
         },
         &mut initial_encoder,
@@ -863,7 +878,7 @@ fn sample_processed_standard_logits_pending(
             chunks,
             input_len,
             candidate_count,
-            trace: false,
+            trace: cfg!(target_arch = "wasm32"),
             encoder_label: "standard_sample_token_pending encoder",
         },
         &mut initial_encoder,
@@ -895,7 +910,8 @@ async fn sample_processed_standard_logits_to_host(
 
     let chunks = input_len.div_ceil(TOP_K_CHUNK);
     let mut candidate_count = initial_sampler_candidate_count(top_k, chunks);
-    let trace = std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+    let trace = cfg!(target_arch = "wasm32")
+        || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
         || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some();
     let mut attempt = 0usize;
     loop {
@@ -954,7 +970,7 @@ async fn sample_processed_standard_logits_to_host(
             );
         }
 
-        let view = download.slice(..).get_mapped_range();
+        let view = download.slice(..).get_mapped_range().unwrap();
         let word_size = std::mem::size_of::<u32>();
         let status = view
             .get(..word_size)
@@ -1023,7 +1039,8 @@ async fn sample_processed_logits_to_host(
 
     let chunks = input_len.div_ceil(TOP_K_CHUNK);
     let mut candidate_count = initial_sampler_candidate_count(top_k, chunks);
-    let trace = std::env::var_os("FUSOR_TRACE_DECODE").is_some()
+    let trace = cfg!(target_arch = "wasm32")
+        || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
         || std::env::var_os("FUSOR_TRACE_SAMPLER").is_some();
     let debug_dump = std::env::var_os("FUSOR_DEBUG_SAMPLER").is_some();
     let mut attempt = 0usize;
@@ -1108,7 +1125,7 @@ async fn sample_processed_logits_to_host(
             eprintln!("sampler_trace map_wait elapsed={:?}", start.elapsed());
         }
 
-        let view = download.slice(..).get_mapped_range();
+        let view = download.slice(..).get_mapped_range().unwrap();
         let word_size = std::mem::size_of::<u32>();
         let status = view
             .get(..word_size)
@@ -1167,9 +1184,9 @@ async fn sample_processed_logits_to_host(
                     let _ = id_rx.await;
                     let _ = val_rx.await;
                     let _ = log_rx.await;
-                    let ids_view = ids_dl.slice(..).get_mapped_range();
-                    let vals_view = values_dl.slice(..).get_mapped_range();
-                    let logits_view = logits_dl.slice(..).get_mapped_range();
+                    let ids_view = ids_dl.slice(..).get_mapped_range().unwrap();
+                    let vals_view = values_dl.slice(..).get_mapped_range().unwrap();
+                    let logits_view = logits_dl.slice(..).get_mapped_range().unwrap();
                     let ids_vec: Vec<u32> = bytemuck::cast_slice(&ids_view).to_vec();
                     let vals_vec: Vec<f32> = bytemuck::cast_slice(&vals_view).to_vec();
                     let logits_vec: Vec<f32> = bytemuck::cast_slice(&logits_view).to_vec();

--- a/fusor-ml/core/src/sampling/pipeline.rs
+++ b/fusor-ml/core/src/sampling/pipeline.rs
@@ -129,7 +129,7 @@ pub(crate) async fn qmat_mirostat2_sample_token_to_host(
         #[cfg(not(target_arch = "wasm32"))]
         device.poll_wait();
         let _ = rx.await;
-        let view = hidden_dl.slice(..).get_mapped_range().unwrap();
+        let view = hidden_dl.slice(..).get_mapped_range();
         let hidden_vec: Vec<f32> = bytemuck::cast_slice(&view).to_vec();
         drop(view);
         hidden_dl.unmap();
@@ -970,7 +970,7 @@ async fn sample_processed_standard_logits_to_host(
             );
         }
 
-        let view = download.slice(..).get_mapped_range().unwrap();
+        let view = download.slice(..).get_mapped_range();
         let word_size = std::mem::size_of::<u32>();
         let status = view
             .get(..word_size)
@@ -1125,7 +1125,7 @@ async fn sample_processed_logits_to_host(
             eprintln!("sampler_trace map_wait elapsed={:?}", start.elapsed());
         }
 
-        let view = download.slice(..).get_mapped_range().unwrap();
+        let view = download.slice(..).get_mapped_range();
         let word_size = std::mem::size_of::<u32>();
         let status = view
             .get(..word_size)
@@ -1184,9 +1184,9 @@ async fn sample_processed_logits_to_host(
                     let _ = id_rx.await;
                     let _ = val_rx.await;
                     let _ = log_rx.await;
-                    let ids_view = ids_dl.slice(..).get_mapped_range().unwrap();
-                    let vals_view = values_dl.slice(..).get_mapped_range().unwrap();
-                    let logits_view = logits_dl.slice(..).get_mapped_range().unwrap();
+                    let ids_view = ids_dl.slice(..).get_mapped_range();
+                    let vals_view = values_dl.slice(..).get_mapped_range();
+                    let logits_view = logits_dl.slice(..).get_mapped_range();
                     let ids_vec: Vec<u32> = bytemuck::cast_slice(&ids_view).to_vec();
                     let vals_vec: Vec<f32> = bytemuck::cast_slice(&vals_view).to_vec();
                     let logits_vec: Vec<f32> = bytemuck::cast_slice(&logits_view).to_vec();

--- a/fusor-ml/core/src/sampling/pipeline.rs
+++ b/fusor-ml/core/src/sampling/pipeline.rs
@@ -5,15 +5,6 @@ use crate::{
 };
 use web_time::Instant;
 
-// Diagnostic: the std `eprintln!` used for the `sampler_trace` timing below is
-// invisible on wasm, so on the web target route those lines to the browser
-// console instead. Native keeps the real `eprintln!`.
-#[cfg(target_arch = "wasm32")]
-macro_rules! eprintln {
-    ($($arg:tt)*) => {{
-        web_sys::console::log_1(&format!($($arg)*).into());
-    }};
-}
 use wgpu::CommandEncoder;
 
 use super::{
@@ -87,7 +78,7 @@ pub(crate) async fn qmat_mirostat2_sample_token_to_host(
         return Ok(None);
     };
     if let Some(start) = qmat_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace qmat_logits_setup elapsed={:?}",
             start.elapsed()
         );
@@ -157,7 +148,7 @@ pub(crate) async fn qmat_mirostat2_sample_token_to_host(
                 }
             }
         }
-        eprintln!(
+        tracing::warn!(
             "sampler_debug HIDDEN len={} nan={} +inf={} -inf={} finite={} min={} max={} first8={:?}",
             hidden_vec.len(),
             nan,
@@ -202,7 +193,7 @@ pub(crate) async fn qmat_mirostat2_sample_lazy_token_to_host(
         qmat_logits_data_with_encoder(hidden_data, matrix, encoder)
     });
     if let Some(start) = qmat_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace qmat_logits_tail elapsed={:?}",
             start.elapsed()
         );
@@ -273,7 +264,7 @@ pub(crate) async fn qmat_standard_sample_lazy_token_to_host(
         qmat_logits_data_with_encoder(hidden_data, matrix, encoder)
     });
     if let Some(start) = qmat_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace qmat_standard_logits_tail elapsed={:?}",
             start.elapsed()
         );
@@ -375,7 +366,7 @@ pub(crate) fn qmat_mirostat2_sample_lazy_token_pending(
     .then(Instant::now);
     let (materialized_hidden, _) = hidden.materialize();
     if let Some(start) = qmat_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace hidden_materialize_pending elapsed={:?}",
             start.elapsed()
         );
@@ -426,7 +417,7 @@ pub(crate) fn qmat_standard_sample_lazy_token_pending(
     .then(Instant::now);
     let (materialized_hidden, _) = hidden.materialize();
     if let Some(start) = qmat_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace standard_hidden_materialize_pending elapsed={:?}",
             start.elapsed()
         );
@@ -674,7 +665,7 @@ fn build_sample_attempt(
         }
     };
     if let Some(start) = topk_start {
-        eprintln!("sampler_trace topk_setup elapsed={:?}", start.elapsed());
+        tracing::info!("sampler_trace topk_setup elapsed={:?}", start.elapsed());
     }
 
     let merge_start = config.trace.then(Instant::now);
@@ -691,7 +682,7 @@ fn build_sample_attempt(
         Some(&mut encoder),
     )?;
     if let Some(start) = merge_start {
-        eprintln!("sampler_trace merge_setup elapsed={:?}", start.elapsed());
+        tracing::info!("sampler_trace merge_setup elapsed={:?}", start.elapsed());
     }
 
     let exactness_start = config.trace.then(Instant::now);
@@ -710,7 +701,7 @@ fn build_sample_attempt(
             None
         };
     if let Some(start) = exactness_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace exactness_setup elapsed={:?}",
             start.elapsed()
         );
@@ -726,7 +717,7 @@ fn build_sample_attempt(
         Some(&mut encoder),
     )?;
     if let Some(start) = sample_start {
-        eprintln!("sampler_trace sample_setup elapsed={:?}", start.elapsed());
+        tracing::info!("sampler_trace sample_setup elapsed={:?}", start.elapsed());
     }
 
     Some((output, ids, values, encoder))
@@ -779,7 +770,7 @@ fn build_standard_sample_attempt(
         }
     };
     if let Some(start) = topk_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace standard_topk_setup elapsed={:?}",
             start.elapsed()
         );
@@ -799,7 +790,7 @@ fn build_standard_sample_attempt(
         Some(&mut encoder),
     )?;
     if let Some(start) = merge_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace standard_merge_setup elapsed={:?}",
             start.elapsed()
         );
@@ -821,7 +812,7 @@ fn build_standard_sample_attempt(
             None
         };
     if let Some(start) = exactness_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace standard_exactness_setup elapsed={:?}",
             start.elapsed()
         );
@@ -836,7 +827,7 @@ fn build_standard_sample_attempt(
         Some(&mut encoder),
     )?;
     if let Some(start) = sample_start {
-        eprintln!(
+        tracing::info!(
             "sampler_trace standard_sample_setup elapsed={:?}",
             start.elapsed()
         );
@@ -947,7 +938,7 @@ async fn sample_processed_standard_logits_to_host(
         let submit_start = trace.then(Instant::now);
         device.wgpu_queue().submit(Some(encoder.finish()));
         if let Some(start) = submit_start {
-            eprintln!(
+            tracing::info!(
                 "sampler_trace standard_submit elapsed={:?}",
                 start.elapsed()
             );
@@ -964,7 +955,7 @@ async fn sample_processed_standard_logits_to_host(
         device.poll_wait();
         receiver.await.map_err(|_| wgpu::BufferAsyncError)??;
         if let Some(start) = map_start {
-            eprintln!(
+            tracing::info!(
                 "sampler_trace standard_map_wait elapsed={:?}",
                 start.elapsed()
             );
@@ -988,7 +979,7 @@ async fn sample_processed_standard_logits_to_host(
         match status {
             GPU_SAMPLE_STATUS_SAMPLED => {
                 if trace {
-                    eprintln!(
+                    tracing::info!(
                         "sampler_trace standard_sampled attempt={attempt} top_k={top_k} chunks={chunks} candidate_count={candidate_count} token={token}"
                     );
                 }
@@ -996,14 +987,14 @@ async fn sample_processed_standard_logits_to_host(
             }
             GPU_SAMPLE_STATUS_RETRY_NEEDED => {
                 if trace {
-                    eprintln!(
+                    tracing::info!(
                         "sampler_trace standard_retry attempt={attempt} top_k={top_k} chunks={chunks} candidate_count={candidate_count}"
                     );
                 }
             }
             _ => {
                 if trace {
-                    eprintln!(
+                    tracing::warn!(
                         "sampler_trace standard_invalid attempt={attempt} top_k={top_k} chunks={chunks} candidate_count={candidate_count} status={status}"
                     );
                 }
@@ -1108,7 +1099,7 @@ async fn sample_processed_logits_to_host(
         let submit_start = trace.then(Instant::now);
         device.wgpu_queue().submit(Some(encoder.finish()));
         if let Some(start) = submit_start {
-            eprintln!("sampler_trace submit elapsed={:?}", start.elapsed());
+            tracing::info!("sampler_trace submit elapsed={:?}", start.elapsed());
         }
 
         let map_start = trace.then(Instant::now);
@@ -1122,7 +1113,7 @@ async fn sample_processed_logits_to_host(
         device.poll_wait();
         receiver.await.map_err(|_| wgpu::BufferAsyncError)??;
         if let Some(start) = map_start {
-            eprintln!("sampler_trace map_wait elapsed={:?}", start.elapsed());
+            tracing::info!("sampler_trace map_wait elapsed={:?}", start.elapsed());
         }
 
         let view = download.slice(..).get_mapped_range();
@@ -1143,7 +1134,7 @@ async fn sample_processed_logits_to_host(
         match status {
             GPU_SAMPLE_STATUS_SAMPLED => {
                 if trace {
-                    eprintln!(
+                    tracing::info!(
                         "sampler_trace sampled attempt={attempt} top_k={top_k} chunks={chunks} candidate_count={candidate_count} token={token}"
                     );
                 }
@@ -1151,14 +1142,14 @@ async fn sample_processed_logits_to_host(
             }
             GPU_SAMPLE_STATUS_RETRY_NEEDED => {
                 if trace {
-                    eprintln!(
+                    tracing::info!(
                         "sampler_trace retry attempt={attempt} top_k={top_k} chunks={chunks} candidate_count={candidate_count}"
                     );
                 }
             }
             _ => {
                 if trace {
-                    eprintln!(
+                    tracing::warn!(
                         "sampler_trace invalid attempt={attempt} top_k={top_k} chunks={chunks} candidate_count={candidate_count} status={status}"
                     );
                 }
@@ -1222,7 +1213,7 @@ async fn sample_processed_logits_to_host(
                             }
                         }
                     }
-                    eprintln!(
+                    tracing::warn!(
                         "sampler_debug INVALID ids={:?} values={:?} logits_len={} nan={} +inf={} -inf={} finite={} min={} max={} argmax={} first8={:?} previous_tokens_last={:?}",
                         ids_vec,
                         vals_vec,

--- a/fusor-ml/core/src/slice_assign.rs
+++ b/fusor-ml/core/src/slice_assign.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::{hash::Hash, ops::Range};
 
 use crate::{
     DataTypeEnum, TILE_SIZE, Tensor, TensorData,
@@ -132,6 +132,12 @@ impl SliceAssignOperation {
 }
 
 impl Operation for SliceAssignOperation {
+    fn hash_kernel_fields(&self, state: &mut rustc_hash::FxHasher) {
+        self.slices.hash(state);
+        self.input_shape.hash(state);
+        self.in_place.hash(state);
+    }
+
     fn workgroup_shape_constraints(&self, device: &crate::Device) -> WorkgroupShapeConstraints {
         titled_map_workgroup_size_constraints(&self.operation_shape(), device)
     }

--- a/fusor-ml/core/src/softmax.rs
+++ b/fusor-ml/core/src/softmax.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, hash::Hash, sync::OnceLock};
+use std::{any::Any, hash::Hash};
 
 use fusor_tile_ir as tile_ir;
 use fusor_tile_ir_kernels as tile_ir_kernels;
@@ -20,12 +20,6 @@ use crate::{
 };
 
 const SOFTMAX_BLOCKS: [u32; 3] = [128, 512, 1024];
-const SOFTMAX_MODULE_CACHE_SIZE: usize = 128;
-
-fn softmax_module_cache() -> &'static kernel_backend::ModuleCache {
-    static CACHE: OnceLock<kernel_backend::ModuleCache> = OnceLock::new();
-    CACHE.get_or_init(|| kernel_backend::module_cache(SOFTMAX_MODULE_CACHE_SIZE))
-}
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 enum SoftmaxKernelVariant {
@@ -178,17 +172,14 @@ impl SoftmaxOperation {
                 self.datatype.hash(state);
             });
         let inputs = vec![input.clone().into(), output.clone().into()];
-        let key = self.kernel_module_key_with_dispatch(variant, None, dispatch_size, &inputs);
+        let key = self.kernel_cache_key_with_dispatch(variant, None, dispatch_size, &inputs);
         let buffers = vec![input.buffer().clone(), output.buffer().clone()];
         let layout = tile_ir_kernels::linear_storage_layout();
 
-        kernel_backend::dynamic_kernel_from_hashed_ir(
+        kernel_backend::dynamic_kernel_from_ir(
             device.kernel_cache(),
-            softmax_module_cache(),
             "softmax",
             key,
-            buffers,
-            dispatch_size,
             move || {
                 let mut kb = tile_ir::KernelBuilder::<()>::new();
                 let input_ref = tile_ir::KernelTensorRef::new((), layout.clone());
@@ -196,6 +187,8 @@ impl SoftmaxOperation {
                 tile_ir_kernels::softmax(&mut kb, element, input_ref, output_ref, meta)?;
                 Some(kb.finish().0)
             },
+            buffers,
+            dispatch_size,
         )
     }
 
@@ -228,7 +221,7 @@ impl SoftmaxOperation {
                 meta.split_blocks.hash(state);
                 self.datatype.hash(state);
             });
-        let partial_key = self.kernel_module_key_with_dispatch(
+        let partial_key = self.kernel_cache_key_with_dispatch(
             partial_variant,
             None,
             partial_dispatch_size,
@@ -237,13 +230,10 @@ impl SoftmaxOperation {
         let partial_buffers = vec![input.buffer().clone(), scratch.clone()];
         let partial_layout = layout.clone();
         let partial_meta = meta.clone();
-        let partial = kernel_backend::dynamic_kernel_from_hashed_ir(
+        let partial = kernel_backend::dynamic_kernel_from_ir(
             device.kernel_cache(),
-            softmax_module_cache(),
             "softmax_partials",
             partial_key,
-            partial_buffers,
-            partial_dispatch_size,
             move || {
                 let mut kb = tile_ir::KernelBuilder::<()>::new();
                 let input_ref = tile_ir::KernelTensorRef::new((), partial_layout.clone());
@@ -257,6 +247,8 @@ impl SoftmaxOperation {
                 )?;
                 Some(kb.finish().0)
             },
+            partial_buffers,
+            partial_dispatch_size,
         )?;
 
         let reduce_variant =
@@ -265,7 +257,7 @@ impl SoftmaxOperation {
                 meta.block.hash(state);
                 meta.split_blocks.hash(state);
             });
-        let reduce_key = self.kernel_module_key_with_dispatch(
+        let reduce_key = self.kernel_cache_key_with_dispatch(
             reduce_variant,
             None,
             reduce_dispatch_size,
@@ -275,13 +267,10 @@ impl SoftmaxOperation {
         let reduce_layout = layout.clone();
         let mut reduce_meta = meta.clone();
         reduce_meta.dispatch_size = reduce_dispatch_size;
-        let reduce = kernel_backend::dynamic_kernel_from_hashed_ir(
+        let reduce = kernel_backend::dynamic_kernel_from_ir(
             device.kernel_cache(),
-            softmax_module_cache(),
             "softmax_reduce",
             reduce_key,
-            reduce_buffers,
-            reduce_dispatch_size,
             move || {
                 let mut kb = tile_ir::KernelBuilder::<()>::new();
                 let scratch_ref = tile_ir::KernelTensorRef::new((), reduce_layout.clone());
@@ -294,6 +283,8 @@ impl SoftmaxOperation {
                 )?;
                 Some(kb.finish().0)
             },
+            reduce_buffers,
+            reduce_dispatch_size,
         )?;
 
         let write_variant =
@@ -303,7 +294,7 @@ impl SoftmaxOperation {
                 meta.split_blocks.hash(state);
                 self.datatype.hash(state);
             });
-        let write_key = self.kernel_module_key_with_dispatch(
+        let write_key = self.kernel_cache_key_with_dispatch(
             write_variant,
             None,
             partial_dispatch_size,
@@ -315,13 +306,10 @@ impl SoftmaxOperation {
             output.buffer().clone(),
         ];
         let write_layout = layout.clone();
-        let write = kernel_backend::dynamic_kernel_from_hashed_ir(
+        let write = kernel_backend::dynamic_kernel_from_ir(
             device.kernel_cache(),
-            softmax_module_cache(),
             "softmax_write",
             write_key,
-            write_buffers,
-            partial_dispatch_size,
             move || {
                 let mut kb = tile_ir::KernelBuilder::<()>::new();
                 let input_ref = tile_ir::KernelTensorRef::new((), write_layout.clone());
@@ -337,6 +325,8 @@ impl SoftmaxOperation {
                 )?;
                 Some(kb.finish().0)
             },
+            write_buffers,
+            partial_dispatch_size,
         )?;
 
         Some(DirectKernel::sequence(

--- a/fusor-ml/core/src/tensor/mod.rs
+++ b/fusor-ml/core/src/tensor/mod.rs
@@ -384,7 +384,7 @@ impl Tensor {
         receiver.await.map_err(|_| wgpu::BufferAsyncError)??;
 
         // Get the mapped view
-        let view = download.slice(..).get_mapped_range();
+        let view = download.slice(..).get_mapped_range().unwrap();
         Ok(TensorSlice::new(
             MappedBuffer { view },
             tensor.layout().clone(),
@@ -779,13 +779,10 @@ impl Tensor {
                 causal,
                 self.datatype(),
             );
-        // Browser WebGPU backends have been observed to hang/crash on the
-        // split decode workgroup kernel. The composite fallback still runs on
-        // GPU and is the reliable browser path for q_seq_len == 1.
-        #[cfg(target_arch = "wasm32")]
-        if is_decode_candidate {
-            return None;
-        }
+        // Decode (q_seq_len == 1) now uses the fused flash-attention decode
+        // kernel on wasm as well. The browser path was previously disabled here
+        // over WebGPU hang/crash reports on the split decode workgroup kernel;
+        // re-enabled to measure whether that's still an issue.
         // The streaming flash attention kernels emit a separate
         // monomorphization per hardware subgroup width and rely on
         // `subgroup_reduce_*`, so they can only target devices where we know

--- a/fusor-ml/core/src/tensor/mod.rs
+++ b/fusor-ml/core/src/tensor/mod.rs
@@ -384,7 +384,7 @@ impl Tensor {
         receiver.await.map_err(|_| wgpu::BufferAsyncError)??;
 
         // Get the mapped view
-        let view = download.slice(..).get_mapped_range().unwrap();
+        let view = download.slice(..).get_mapped_range();
         Ok(TensorSlice::new(
             MappedBuffer { view },
             tensor.layout().clone(),

--- a/fusor-ml/core/src/visit_tiled.rs
+++ b/fusor-ml/core/src/visit_tiled.rs
@@ -81,14 +81,11 @@ pub(crate) fn titled_map_workgroup_size_constraints(
 }
 
 pub(crate) fn distribute_workgroups(total_workgroups: u32, max_per_dim: u32) -> [u32; 3] {
-    if total_workgroups == 0 {
-        return [1, 1, 1];
-    }
-
+    let max_per_dim = max_per_dim.max(1);
     let x = total_workgroups.min(max_per_dim);
-    let remaining = total_workgroups.div_ceil(x);
-    let y = remaining.min(max_per_dim);
-    let z = total_workgroups.div_ceil(x * y).max(1);
+    let remaining = total_workgroups.div_ceil(x.max(1));
+    let y = remaining.min(max_per_dim).max(1);
+    let z = total_workgroups.div_ceil(x.max(1) * y).max(1);
 
     [x, y, z]
 }

--- a/fusor-ml/fusor/Cargo.toml
+++ b/fusor-ml/fusor/Cargo.toml
@@ -15,6 +15,7 @@ pollster = { version = "0.4.0", optional = true }
 paste = "1.0"
 bytemuck = { version = "1.14", features = ["derive"] }
 half = "2.4"
+tracing = "0.1.41"
 
 [dev-dependencies]
 tokio = { version = "1.43.0", features = ["full"] }

--- a/fusor-ml/fusor/src/composite/flash_attention.rs
+++ b/fusor-ml/fusor/src/composite/flash_attention.rs
@@ -68,7 +68,12 @@ where
             (Tensor::Gpu(q), Tensor::Gpu(k_gpu), Tensor::Gpu(v_gpu))
                 if !matches!(mask, Some((_, MaskKind::BatchKeyMask))) =>
             {
-                if !q.device().subgroups_supported() {
+                // Decode (q_seq_len == 1) runs the DecodeSmall attention kernel,
+                // which uses workgroup reductions and needs no subgroups, so it
+                // works on browser adapters that report no subgroup support. Only
+                // the prefill/streaming kernels require subgroups — keep the
+                // fallback for those (q_seq_len > 1).
+                if !q.device().subgroups_supported() && self.shape()[2] != 1 {
                     #[cfg(target_arch = "wasm32")]
                     {
                         return self.flash_attention_composite_impl(k, v, scale, mask);

--- a/fusor-ml/fusor/src/device.rs
+++ b/fusor-ml/fusor/src/device.rs
@@ -70,7 +70,7 @@ impl Device {
                     || std::env::var_os("FUSOR_TRACE_DECODE").is_some()
                     || std::env::var_os("FUSOR_TRACE_RESOLVE").is_some()
                 {
-                    eprintln!("fusor_device_auto_gpu_error={err}");
+                    tracing::warn!("fusor_device_auto_gpu_error={err}");
                 }
                 Device::Cpu
             }

--- a/fusor-ml/fusor/src/lib.rs
+++ b/fusor-ml/fusor/src/lib.rs
@@ -22,7 +22,7 @@ pub mod layers;
 pub mod quantized;
 mod varbuilder;
 
-pub use varbuilder::{ShardedVarBuilder, VarBuilder};
+pub use varbuilder::{AsyncReadRange, AsyncShardedVarBuilder, ShardedVarBuilder, VarBuilder};
 
 pub use quantized::{CpuF32Tensor, QMatrix};
 

--- a/fusor-ml/fusor/src/varbuilder.rs
+++ b/fusor-ml/fusor/src/varbuilder.rs
@@ -3,7 +3,7 @@
 //! This module provides a VarBuilder that wraps fusor-core's VarBuilder
 //! and creates unified `fusor::QMatrix` tensors that can run on either CPU or GPU.
 
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc};
 
 use crate::{Device, QMatrix};
 pub use fusor_gguf::{GgufMetadata, GgufReadError, GgufValue};
@@ -207,6 +207,73 @@ impl<R: std::io::Read + std::io::Seek> ShardedVarBuilder<R> {
                 let mut bytes = vec![0u8; byte_size];
                 r.read_exact(&mut bytes)
                     .map_err(|e| crate::Error::VarBuilder(format!("Failed to read: {}", e)))?;
+
+                return QMatrix::from_raw_bytes(device, shape, &bytes, ggml_type).map_err(|e| {
+                    crate::Error::VarBuilder(format!("Failed to create QMatrix: {}", e))
+                });
+            }
+        }
+        Err(crate::Error::VarBuilder(format!(
+            "Key '{}' not found in GGUF metadata",
+            name
+        )))
+    }
+}
+
+/// Async byte-range access used by browser-backed model files.
+pub trait AsyncReadRange {
+    fn read_range<'a>(
+        &'a mut self,
+        offset: u64,
+        len: usize,
+    ) -> Pin<Box<dyn Future<Output = std::io::Result<Vec<u8>>> + 'a>>;
+}
+
+/// Sharded VarBuilder for loading tensors from async range-readable GGUF files.
+///
+/// This is intended for browser storage such as OPFS where holding the complete
+/// model bytes in wasm memory is unnecessarily expensive.
+pub struct AsyncShardedVarBuilder<R> {
+    contents: Vec<(GgufMetadata, R)>,
+}
+
+impl<R: AsyncReadRange> AsyncShardedVarBuilder<R> {
+    /// Create a new async sharded VarBuilder from GGUF metadata and range readers.
+    pub fn new(contents: Vec<(GgufMetadata, R)>) -> Self {
+        Self { contents }
+    }
+
+    /// Get a metadata value by key from any shard.
+    pub fn get(&self, name: &str) -> crate::Result<&GgufValue> {
+        for (content, _) in &self.contents {
+            if let Some(value) = content.get_value(name) {
+                return Ok(value);
+            }
+        }
+        Err(crate::Error::VarBuilder(format!(
+            "Key '{}' not found in GGUF metadata",
+            name
+        )))
+    }
+
+    /// Load a tensor from any shard to the specified device.
+    pub async fn tensor(&mut self, name: &str, device: &Device) -> crate::Result<QMatrix> {
+        for (content, reader) in &mut self.contents {
+            if let Some(tensor_info) = content.tensor_infos.get(name) {
+                let offset = content.tensor_data_offset + tensor_info.offset;
+                let ggml_type = tensor_info.ty;
+                let shape: Box<[usize]> = tensor_info
+                    .shape
+                    .iter()
+                    .map(|&d| d as usize)
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+
+                let num_elements: usize = shape.iter().product();
+                let byte_size = tensor_byte_size(ggml_type, num_elements);
+                let bytes = reader.read_range(offset, byte_size).await.map_err(|e| {
+                    crate::Error::VarBuilder(format!("Failed to read tensor data: {}", e))
+                })?;
 
                 return QMatrix::from_raw_bytes(device, shape, &bytes, ggml_type).map_err(|e| {
                     crate::Error::VarBuilder(format!("Failed to create QMatrix: {}", e))

--- a/fusor-ml/tile-ir-kernels/Cargo.toml
+++ b/fusor-ml/tile-ir-kernels/Cargo.toml
@@ -15,18 +15,18 @@ bytemuck = "1.25.0"
 half = "2.4.1"
 
 [dev-dependencies]
-naga = "29.0.3"
+naga = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now" }
 pollster = "0.4.0"
-wgpu = { version = "29.0.3", default-features = false, features = ["std", "naga-ir"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["std", "naga-ir"] }
 
 [target.'cfg(target_vendor = "apple")'.dev-dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["metal"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["metal"] }
 
 [target.'cfg(windows)'.dev-dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["dx12"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["dx12"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dev-dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["vulkan"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["vulkan"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["webgpu"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["webgpu"] }

--- a/fusor-ml/tile-ir-kernels/src/grid.rs
+++ b/fusor-ml/tile-ir-kernels/src/grid.rs
@@ -8,6 +8,8 @@
 use fusor_tile_ir::tile::{Mask, Storage, Tile, TileBlock};
 use fusor_tile_ir::{ScalarElement, SubgroupToken, TileLiteral, WorkgroupAxis};
 
+use crate::dispatch::{QgemvShape, SubgroupConfig};
+
 #[derive(Clone, Copy)]
 pub(crate) struct QgemvGrid {
     pub(crate) workgroups_x: u32,
@@ -35,6 +37,31 @@ impl QgemvGrid {
     pub(crate) fn mask(self, in_bounds: Mask, col: &Tile) -> Mask {
         in_bounds.and(col.lt(self.n_cols))
     }
+}
+
+pub(crate) fn qgemv_has_no_packed_load_tails(
+    grid: QgemvGrid,
+    shape: QgemvShape,
+    block_count: u32,
+    subgroups: SubgroupConfig,
+    lanes_per_item: u32,
+) -> bool {
+    if lanes_per_item == 0 || !subgroups.is_fixed() {
+        return false;
+    }
+
+    let blocks_per_pass = subgroups.max_size() / lanes_per_item;
+    if blocks_per_pass == 0 || !block_count.is_multiple_of(blocks_per_pass) {
+        return false;
+    }
+
+    let cols_per_workgroup = shape.cols_per_workgroup();
+    if cols_per_workgroup == 0 || !grid.n_cols.is_multiple_of(cols_per_workgroup) {
+        return false;
+    }
+
+    let total_workgroups = grid.n_cols / cols_per_workgroup;
+    total_workgroups.is_multiple_of(grid.workgroups_x.max(1))
 }
 
 #[derive(Clone)]
@@ -153,4 +180,83 @@ pub(crate) fn dot4_sum(program: &TileBlock<'_>, a: &[Tile], b: &[Tile]) -> Tile 
         });
     }
     sum.expect("values >= 4")
+}
+
+#[cfg(test)]
+mod tests {
+    use fusor_tile_ir::SubgroupToken;
+
+    use super::*;
+
+    fn fixed_subgroups(size: u32) -> SubgroupConfig {
+        SubgroupConfig::fixed(SubgroupToken::new_unchecked(), size)
+    }
+
+    #[test]
+    fn packed_load_tail_detector_accepts_aligned_8b_q4k_shape() {
+        let shape = QgemvShape {
+            subgroups: 8,
+            cols_per_subgroup: 4,
+        };
+        let grid = qgemv_grid(shape.subgroups, shape.cols_per_subgroup, 14_336, 448);
+
+        assert!(qgemv_has_no_packed_load_tails(
+            grid,
+            shape,
+            16,
+            fixed_subgroups(32),
+            8,
+        ));
+    }
+
+    #[test]
+    fn packed_load_tail_detector_rejects_column_tail() {
+        let shape = QgemvShape {
+            subgroups: 8,
+            cols_per_subgroup: 4,
+        };
+        let grid = qgemv_grid(shape.subgroups, shape.cols_per_subgroup, 14_337, 449);
+
+        assert!(!qgemv_has_no_packed_load_tails(
+            grid,
+            shape,
+            16,
+            fixed_subgroups(32),
+            8,
+        ));
+    }
+
+    #[test]
+    fn packed_load_tail_detector_rejects_block_tail() {
+        let shape = QgemvShape {
+            subgroups: 8,
+            cols_per_subgroup: 4,
+        };
+        let grid = qgemv_grid(shape.subgroups, shape.cols_per_subgroup, 14_336, 448);
+
+        assert!(!qgemv_has_no_packed_load_tails(
+            grid,
+            shape,
+            17,
+            fixed_subgroups(32),
+            8,
+        ));
+    }
+
+    #[test]
+    fn packed_load_tail_detector_rejects_dispatch_split_tail() {
+        let shape = QgemvShape {
+            subgroups: 8,
+            cols_per_subgroup: 4,
+        };
+        let grid = qgemv_grid(shape.subgroups, shape.cols_per_subgroup, 65_536, 1_000);
+
+        assert!(!qgemv_has_no_packed_load_tails(
+            grid,
+            shape,
+            16,
+            fixed_subgroups(32),
+            8,
+        ));
+    }
 }

--- a/fusor-ml/tile-ir-kernels/src/kernels/qgemv.rs
+++ b/fusor-ml/tile-ir-kernels/src/kernels/qgemv.rs
@@ -608,6 +608,8 @@ fn qgemv_q4k_ggml(
                                 &block_idx,
                                 &matrix_col,
                                 &q4k_lane,
+                                grid.mask(in_bounds.clone(), &output_col)
+                                    .and(matrix_col.lt(b.cols)),
                                 &acts,
                             )
                         })
@@ -639,6 +641,7 @@ fn qgemv_q4k_ggml(
                                 &block_idx,
                                 &col,
                                 &q4k_lane,
+                                grid.mask(in_bounds.clone(), &col),
                                 &acts,
                             )
                         })

--- a/fusor-ml/tile-ir-kernels/src/kernels/qgemv.rs
+++ b/fusor-ml/tile-ir-kernels/src/kernels/qgemv.rs
@@ -24,7 +24,8 @@ use crate::dispatch::{
     qgemv_subgroups_per_workgroup_for_shape, QgemvShape, SubgroupConfig,
 };
 use crate::grid::{
-    dot4_sum, qgemv_grid, qgemv_program_scope, store_qgemv_sums_with_epilogue, QgemvStoreTarget,
+    dot4_sum, qgemv_grid, qgemv_has_no_packed_load_tails, qgemv_program_scope,
+    store_qgemv_sums_with_epilogue, QgemvStoreTarget,
 };
 use crate::kernels::qgemv_q4k_ggml::{
     load_q4k_ggml_activations, q4k_ggml_dot_tiles, q4k_lane_decomposition,
@@ -568,6 +569,8 @@ fn qgemv_q4k_ggml(
     let post_accumulator_offsets = (!epilogues.post_accumulator_offsets.is_empty())
         .then(|| epilogues.post_accumulator_offsets().to_vec());
     let row = Tile::u32(0);
+    let packed_loads_always_in_bounds =
+        qgemv_has_no_packed_load_tails(grid, shape, block_count, subgroups, 8);
 
     program.program_grid(block, [grid.workgroups_x, grid.dispatch_y, 1], |program| {
         let scope = qgemv_program_scope(program, grid, cols_per_subgroup, subgroup);
@@ -599,6 +602,12 @@ fn qgemv_q4k_ggml(
                             let output_col = col0.clone() + c as u32;
                             let matrix_col =
                                 output_col.clone() + post_accumulator_offsets[value_idx];
+                            let packed_load_mask = if packed_loads_always_in_bounds {
+                                Tile::all()
+                            } else {
+                                grid.mask(in_bounds.clone(), &output_col)
+                                    .and(matrix_col.lt(b.cols))
+                            };
                             acc + q4k_ggml_dot_tiles(
                                 program,
                                 &qwords,
@@ -608,8 +617,7 @@ fn qgemv_q4k_ggml(
                                 &block_idx,
                                 &matrix_col,
                                 &q4k_lane,
-                                grid.mask(in_bounds.clone(), &output_col)
-                                    .and(matrix_col.lt(b.cols)),
+                                packed_load_mask,
                                 &acts,
                             )
                         })
@@ -632,6 +640,11 @@ fn qgemv_q4k_ggml(
                         .enumerate()
                         .map(|(c, acc)| {
                             let col = col0.clone() + c as u32;
+                            let packed_load_mask = if packed_loads_always_in_bounds {
+                                Tile::all()
+                            } else {
+                                grid.mask(in_bounds.clone(), &col)
+                            };
                             acc + q4k_ggml_dot_tiles(
                                 program,
                                 &qwords,
@@ -641,7 +654,7 @@ fn qgemv_q4k_ggml(
                                 &block_idx,
                                 &col,
                                 &q4k_lane,
-                                grid.mask(in_bounds.clone(), &col),
+                                packed_load_mask,
                                 &acts,
                             )
                         })

--- a/fusor-ml/tile-ir-kernels/src/kernels/qgemv_q4k_ggml.rs
+++ b/fusor-ml/tile-ir-kernels/src/kernels/qgemv_q4k_ggml.rs
@@ -1,4 +1,4 @@
-use fusor_tile_ir::tile::{Storage, Tile, TileBlock};
+use fusor_tile_ir::tile::{Mask, Storage, Tile, TileBlock};
 use fusor_tile_ir::{ElementType, ScalarElement};
 
 /// Q4K subgroup-lane decomposition: `ix = lane / 8` selects the super-block
@@ -70,11 +70,12 @@ pub(crate) fn q4k_ggml_dot_tiles(
     block: &Tile,
     col: &Tile,
     lane: &Q4KLane,
+    mask: Mask,
     acts: &Q4KGgmlActs,
 ) -> Tile {
     let base = (col.clone() * blocks_per_col + block.clone()) * block_words;
     let load = |program: &mut TileBlock<'_>, offset: Tile| -> Tile {
-        program.load(qwords.at(base.clone() + offset), Tile::all(), 0u32)
+        program.load(qwords.at(base.clone() + offset), mask.clone(), 0u32)
     };
 
     let (scale0, data_base) = if native { (1u32, 4u32) } else { (2u32, 5u32) };

--- a/fusor-ml/tile-ir-kernels/src/kernels/qgemv_q6k.rs
+++ b/fusor-ml/tile-ir-kernels/src/kernels/qgemv_q6k.rs
@@ -16,7 +16,8 @@ use fusor_tile_ir::{ElementType, GgmlQuantFormat};
 
 use crate::dispatch::{QgemvShape, SubgroupConfig};
 use crate::grid::{
-    qgemv_grid, qgemv_program_scope, store_qgemv_sums_with_epilogue, QgemvStoreTarget,
+    qgemv_grid, qgemv_has_no_packed_load_tails, qgemv_program_scope,
+    store_qgemv_sums_with_epilogue, QgemvStoreTarget,
 };
 use crate::kernels::qgemv::QgemvTensors;
 use crate::types::{matrix_shape, QmatmulEpilogues};
@@ -112,6 +113,8 @@ pub(crate) fn qgemv_q6k_ggml(
     let post_accumulator_offsets = (!epilogues.post_accumulator_offsets.is_empty())
         .then(|| epilogues.post_accumulator_offsets().to_vec());
     let row = Tile::u32(0);
+    let packed_loads_always_in_bounds =
+        qgemv_has_no_packed_load_tails(grid, shape, block_count, subgroups, 16);
 
     program.program_grid(block, [grid.workgroups_x, grid.dispatch_y, 1], |program| {
         let scope = qgemv_program_scope(program, grid, cols_per_subgroup, subgroup);
@@ -143,6 +146,12 @@ pub(crate) fn qgemv_q6k_ggml(
                             let output_col = col0.clone() + c as u32;
                             let matrix_col =
                                 output_col.clone() + post_accumulator_offsets[value_idx];
+                            let packed_load_mask = if packed_loads_always_in_bounds {
+                                Tile::all()
+                            } else {
+                                grid.mask(in_bounds.clone(), &output_col)
+                                    .and(matrix_col.lt(b.cols))
+                            };
                             acc + q6k_ggml_dot_tiles(
                                 program,
                                 &qwords,
@@ -151,8 +160,7 @@ pub(crate) fn qgemv_q6k_ggml(
                                 &block_idx,
                                 &matrix_col,
                                 &q6k_lane,
-                                grid.mask(in_bounds.clone(), &output_col)
-                                    .and(matrix_col.lt(b.cols)),
+                                packed_load_mask,
                                 &acts,
                             )
                         })
@@ -175,6 +183,11 @@ pub(crate) fn qgemv_q6k_ggml(
                         .enumerate()
                         .map(|(c, acc)| {
                             let col = col0.clone() + c as u32;
+                            let packed_load_mask = if packed_loads_always_in_bounds {
+                                Tile::all()
+                            } else {
+                                grid.mask(in_bounds.clone(), &col)
+                            };
                             acc + q6k_ggml_dot_tiles(
                                 program,
                                 &qwords,
@@ -183,7 +196,7 @@ pub(crate) fn qgemv_q6k_ggml(
                                 &block_idx,
                                 &col,
                                 &q6k_lane,
-                                grid.mask(in_bounds.clone(), &col),
+                                packed_load_mask,
                                 &acts,
                             )
                         })

--- a/fusor-ml/tile-ir-kernels/src/kernels/qgemv_q6k.rs
+++ b/fusor-ml/tile-ir-kernels/src/kernels/qgemv_q6k.rs
@@ -11,7 +11,7 @@
 //! stride is not word-aligned, so the raw-word-load addressing this kernel uses
 //! does not apply; that layout stays on the generic perf path.
 
-use fusor_tile_ir::tile::{range, Program, Storage, Tile, TileBlock};
+use fusor_tile_ir::tile::{range, Mask, Program, Storage, Tile, TileBlock};
 use fusor_tile_ir::{ElementType, GgmlQuantFormat};
 
 use crate::dispatch::{QgemvShape, SubgroupConfig};
@@ -151,6 +151,8 @@ pub(crate) fn qgemv_q6k_ggml(
                                 &block_idx,
                                 &matrix_col,
                                 &q6k_lane,
+                                grid.mask(in_bounds.clone(), &output_col)
+                                    .and(matrix_col.lt(b.cols)),
                                 &acts,
                             )
                         })
@@ -181,6 +183,7 @@ pub(crate) fn qgemv_q6k_ggml(
                                 &block_idx,
                                 &col,
                                 &q6k_lane,
+                                grid.mask(in_bounds.clone(), &col),
                                 &acts,
                             )
                         })
@@ -231,14 +234,15 @@ pub(crate) fn q6k_ggml_dot_tiles(
     block: &Tile,
     col: &Tile,
     lane: &Q6KLane,
+    mask: Mask,
     acts: &Q6KGgmlActs,
 ) -> Tile {
     let base = (col.clone() * blocks_per_col + block.clone()) * block_words;
-    // Weights/scales are read unconditionally (constant-true mask) so each lowers
-    // to a direct pointer load. Out-of-bounds K is zeroed via the masked
-    // activations; out-of-bounds columns are discarded by the store mask.
+    // The final workgroup can cover tail columns that are never stored. Keep the
+    // packed-weight reads masked too, because robust buffer access still has to
+    // evaluate the load address.
     let load = |program: &mut TileBlock<'_>, offset: Tile| -> Tile {
-        program.load(qwords.at(base.clone() + offset), Tile::all(), 0u32)
+        program.load(qwords.at(base.clone() + offset), mask.clone(), 0u32)
     };
 
     // Super-block scale `d` (f32-scale layout): one f32 word at word 52.

--- a/fusor-ml/tile-ir-kernels/src/kernels/qmatmul.rs
+++ b/fusor-ml/tile-ir-kernels/src/kernels/qmatmul.rs
@@ -198,6 +198,12 @@ pub(crate) fn qmatmul_try_coop(
     bn: u32,
     bk: u32,
 ) -> bool {
+    if std::env::var_os("FUSOR_DIAG_DISABLE_COOP").is_some() {
+        return false;
+    }
+    if b.format.is_q4k_family() || b.format.is_q6k_family() {
+        return false;
+    }
     if !subgroups.is_fixed() {
         return false;
     }

--- a/fusor-ml/tile-ir-kernels/tests/lowering.rs
+++ b/fusor-ml/tile-ir-kernels/tests/lowering.rs
@@ -108,7 +108,12 @@ fn rms_norm_vec4_minimal_lowers() {
     lower_or_fail(&ir, "rms_norm_vec4");
 }
 
-fn qgemv_ir(format: GgmlQuantFormat, rows: u32, cols: u32) -> fusor_tile_ir::KernelIr {
+fn qgemv_ir_with_subgroup_size(
+    format: GgmlQuantFormat,
+    rows: u32,
+    cols: u32,
+    subgroup_size: u32,
+) -> fusor_tile_ir::KernelIr {
     tile::build(|program| {
         let a = program.storage_read(ScalarElement::F32.element(), Shape::new([1, rows]));
         let b = quantized_matrix(program, format, rows, cols);
@@ -119,10 +124,14 @@ fn qgemv_ir(format: GgmlQuantFormat, rows: u32, cols: u32) -> fusor_tile_ir::Ker
             &b,
             &y,
             1,
-            subgroup_config(32),
+            subgroup_config(subgroup_size),
             Option::<&UnaryEpilogue>::None,
         );
     })
+}
+
+fn qgemv_ir(format: GgmlQuantFormat, rows: u32, cols: u32) -> fusor_tile_ir::KernelIr {
+    qgemv_ir_with_subgroup_size(format, rows, cols, 32)
 }
 
 #[test]
@@ -135,6 +144,18 @@ fn generic_q8_qgemv_lowers() {
 fn q4k_ggml_qgemv_lowers() {
     let ir = qgemv_ir(GgmlQuantFormat::Q4K, 4096, 8192);
     lower_or_fail(&ir, "q4k ggml qgemv");
+}
+
+#[test]
+fn q4k_ggml_qgemv_tail_columns_lower() {
+    let ir = qgemv_ir(GgmlQuantFormat::Q4K, 4096, 8193);
+    lower_or_fail(&ir, "q4k ggml qgemv tail columns");
+}
+
+#[test]
+fn q4k_ggml_qgemv_tail_columns_lower_with_64_lane_subgroups() {
+    let ir = qgemv_ir_with_subgroup_size(GgmlQuantFormat::Q4K, 4096, 8193, 64);
+    lower_or_fail(&ir, "q4k ggml qgemv tail columns subgroup64");
 }
 
 #[test]

--- a/fusor-ml/tile-ir-runtime/Cargo.toml
+++ b/fusor-ml/tile-ir-runtime/Cargo.toml
@@ -8,19 +8,20 @@ publish = false
 
 [dependencies]
 fusor-tile-ir = { workspace = true }
-wgpu = { version = "29.0.3", default-features = false, features = ["std", "naga-ir"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["std", "naga-ir"] }
 lru = { version = "0.14.0", default-features = false }
 parking_lot = "0.12.3"
 rustc-hash = "2.1.1"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["metal"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["metal"] }
 
 [target.'cfg(windows)'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["dx12"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["dx12"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["vulkan"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["vulkan"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["webgpu", "wgsl"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["webgpu", "wgsl"] }
+web-sys = { version = "0.3", features = ["console"] }

--- a/fusor-ml/tile-ir-runtime/Cargo.toml
+++ b/fusor-ml/tile-ir-runtime/Cargo.toml
@@ -12,6 +12,7 @@ wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default
 lru = { version = "0.14.0", default-features = false }
 parking_lot = "0.12.3"
 rustc-hash = "2.1.1"
+tracing = "0.1.41"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["metal"] }
@@ -24,4 +25,3 @@ wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["webgpu", "wgsl"] }
-web-sys = { version = "0.3", features = ["console"] }

--- a/fusor-ml/tile-ir-runtime/src/cache.rs
+++ b/fusor-ml/tile-ir-runtime/src/cache.rs
@@ -271,6 +271,7 @@ impl KernelCache {
     }
 
     pub fn create_naga_shader_module(&self, kernel: &NagaKernel) -> wgpu::ShaderModule {
+        crate::note_compile("shader");
         // SAFETY: all kernels avoid out-of-bounds memory access and unbounded loops.
         unsafe {
             self.device.create_shader_module_trusted(

--- a/fusor-ml/tile-ir-runtime/src/cache.rs
+++ b/fusor-ml/tile-ir-runtime/src/cache.rs
@@ -13,6 +13,8 @@ use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHasher};
 use wgpu::{BindGroupLayout, PipelineLayout};
 
+use crate::DirectPlanCache;
+
 #[cfg(not(target_arch = "wasm32"))]
 const KERNEL_CACHE_SIZE: usize = 4096;
 #[cfg(target_arch = "wasm32")]
@@ -147,6 +149,7 @@ pub struct KernelCache {
     pub(crate) kernels: RwLock<LruCache<KernelCacheKey, Arc<CachedKernel>, FxBuildHasher>>,
     pub(crate) direct_dynamic_bind_group_cache:
         RwLock<LruCache<DirectDynamicBindGroupKey, CachedDirectBindGroup, FxBuildHasher>>,
+    direct_plan_cache: DirectPlanCache,
     direct_three_buffer_bind_group_layout: OnceLock<BindGroupLayout>,
     direct_three_buffer_pipeline_layout: OnceLock<PipelineLayout>,
 }
@@ -192,6 +195,7 @@ impl KernelCache {
             cache_file,
             kernels: make_lru(KERNEL_CACHE_SIZE),
             direct_dynamic_bind_group_cache: make_lru(DIRECT_DYNAMIC_BIND_GROUP_CACHE_SIZE),
+            direct_plan_cache: DirectPlanCache::new(),
             direct_three_buffer_bind_group_layout: OnceLock::new(),
             direct_three_buffer_pipeline_layout: OnceLock::new(),
         }
@@ -199,6 +203,10 @@ impl KernelCache {
 
     pub fn wgpu_device(&self) -> &Arc<wgpu::Device> {
         &self.device
+    }
+
+    pub fn direct_plan_cache(&self) -> &DirectPlanCache {
+        &self.direct_plan_cache
     }
 
     pub fn direct_three_buffer_bind_group_layout(&self) -> BindGroupLayout {

--- a/fusor-ml/tile-ir-runtime/src/cache.rs
+++ b/fusor-ml/tile-ir-runtime/src/cache.rs
@@ -90,18 +90,6 @@ impl CachedKernel {
     }
 }
 
-/// Static, per-kernel-family LRU of lowered kernels. Used by hot
-/// kernels (flash attention, rms norm, …) to short-circuit before the
-/// device-wide [`KernelCache`].
-pub type ModuleCache = RwLock<LruCache<KernelCacheKey, Arc<NagaKernel>, FxBuildHasher>>;
-
-pub fn module_cache(capacity: usize) -> ModuleCache {
-    RwLock::new(LruCache::with_hasher(
-        NonZeroUsize::new(capacity).expect("module cache capacity must be non-zero"),
-        Default::default(),
-    ))
-}
-
 #[derive(Debug)]
 pub(crate) struct CachedDirectBindGroup {
     pub(crate) bind_group: wgpu::BindGroup,

--- a/fusor-ml/tile-ir-runtime/src/direct_kernel.rs
+++ b/fusor-ml/tile-ir-runtime/src/direct_kernel.rs
@@ -188,10 +188,6 @@ impl DirectKernel {
                 weight,
                 output,
             } => {
-                let [x, y, z] = self.dispatch_size;
-                if x * y * z == 0 {
-                    return None;
-                }
                 let bind_group_layout = cache.direct_three_buffer_bind_group_layout();
                 let bind_entries = [
                     wgpu::BindGroupEntry {
@@ -222,10 +218,6 @@ impl DirectKernel {
                 })
             }
             DirectKernelKind::Dynamic { cached, bindings } => {
-                let [x, y, z] = self.dispatch_size;
-                if x * y * z == 0 {
-                    return None;
-                }
                 let bind_group_layout = cached
                     .dynamic_bind_group_layout
                     .get_or_init(|| {
@@ -382,9 +374,9 @@ impl DirectKernel {
     }
 
     /// The buffers this kernel binds, in the canonical order used internally by
-    /// `prepare_dispatch` (and mirrored by `rebind_buffers`). Used by the decode
-    /// plan cache to record where each binding's buffer comes from so the kernel
-    /// can be replayed across tokens with fresh buffers.
+    /// `prepare_dispatch` (and mirrored by `rebind_buffers`). Used by plan
+    /// caches to record where each binding's buffer comes from so the kernel can
+    /// be replayed with fresh per-resolve binding buffers.
     pub fn binding_buffers(&self) -> Vec<Arc<wgpu::Buffer>> {
         let mut out = Vec::new();
         self.collect_buffers(&mut out);
@@ -417,9 +409,9 @@ impl DirectKernel {
     /// Clone this kernel, replacing its bound buffers positionally with `new`
     /// (which must have exactly `binding_buffers().len()` entries in the same
     /// order). The compiled pipeline / cached analysis is preserved; only the
-    /// buffers (i.e. the bind-group inputs) change. This lets the decode plan
-    /// cache reuse a kernel built on a previous token while swapping in the
-    /// current token's input/output buffers.
+    /// buffers (i.e. the bind-group resources) change. This lets a plan cache
+    /// reuse a kernel built during a previous resolve while swapping in the
+    /// current replay buffers.
     pub fn rebind_buffers(&self, new: &[Arc<wgpu::Buffer>]) -> Self {
         let mut cursor = 0;
         let kernel = self.rebind_from(new, &mut cursor);
@@ -551,6 +543,9 @@ impl PreparedDirectDispatch {
             return;
         };
         let [x, y, z] = step.dispatch_size;
+        if step.dispatch_size.contains(&0) {
+            return;
+        }
         pass.set_pipeline(&step.pipeline);
         pass.set_bind_group(0, &step.bind_group, &[]);
         pass.dispatch_workgroups(x, y, z);

--- a/fusor-ml/tile-ir-runtime/src/direct_kernel.rs
+++ b/fusor-ml/tile-ir-runtime/src/direct_kernel.rs
@@ -11,7 +11,7 @@ pub struct DirectKernelBinding {
     pub read_only: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum DirectKernelKind {
     /// Generic path: bindings are derived from the kernel's lowered storage
     /// declarations; the pipeline is built lazily from the cached shader on
@@ -34,11 +34,41 @@ enum DirectKernelKind {
     Sequence(Vec<DirectKernel>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DirectKernel {
     name: String,
     dispatch_size: [u32; 3],
     kind: DirectKernelKind,
+}
+
+#[derive(Debug, Clone)]
+struct DirectKernelTemplateBinding {
+    binding: u32,
+    read_only: bool,
+}
+
+#[derive(Debug, Clone)]
+enum DirectKernelTemplateKind {
+    Dynamic {
+        cached: Arc<CachedKernel>,
+        bindings: Vec<DirectKernelTemplateBinding>,
+    },
+    Storage3 {
+        pipeline: wgpu::ComputePipeline,
+    },
+    Sequence(Vec<DirectKernelTemplate>),
+}
+
+/// A direct-kernel template with all bound buffers stripped out.
+///
+/// This preserves the lowered shader/pipeline metadata needed to rebuild a
+/// dispatchable [`DirectKernel`] while avoiding retention of per-run input and
+/// output buffers.
+#[derive(Debug, Clone)]
+pub struct DirectKernelTemplate {
+    name: String,
+    dispatch_size: [u32; 3],
+    kind: DirectKernelTemplateKind,
 }
 
 pub struct PreparedDirectDispatch {
@@ -96,6 +126,34 @@ impl DirectKernel {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Clone this kernel's dispatch metadata without retaining any currently
+    /// bound buffers.
+    pub fn to_template(&self) -> DirectKernelTemplate {
+        let kind = match &self.kind {
+            DirectKernelKind::Dynamic { cached, bindings } => DirectKernelTemplateKind::Dynamic {
+                cached: cached.clone(),
+                bindings: bindings
+                    .iter()
+                    .map(|binding| DirectKernelTemplateBinding {
+                        binding: binding.binding,
+                        read_only: binding.read_only,
+                    })
+                    .collect(),
+            },
+            DirectKernelKind::Storage3 { pipeline, .. } => DirectKernelTemplateKind::Storage3 {
+                pipeline: pipeline.clone(),
+            },
+            DirectKernelKind::Sequence(kernels) => DirectKernelTemplateKind::Sequence(
+                kernels.iter().map(DirectKernel::to_template).collect(),
+            ),
+        };
+        DirectKernelTemplate {
+            name: self.name.clone(),
+            dispatch_size: self.dispatch_size,
+            kind,
+        }
     }
 
     pub fn run(&self, cache: &KernelCache, command_encoder: &mut CommandEncoder) {
@@ -254,14 +312,12 @@ impl DirectKernel {
                 let pipeline = cached
                     .pipeline
                     .get_or_init(|| {
-                        if std::env::var_os("FUSOR_TRACE_PIPELINE_COMPILES").is_some() {
-                            eprintln!(
-                                "fusor_pipeline_compile name={} dispatch={:?} bindings={}",
-                                self.name,
-                                self.dispatch_size,
-                                bindings.len()
-                            );
-                        }
+                        crate::note_compile(&format!(
+                            "pipeline name={} dispatch={:?} bindings={}",
+                            self.name,
+                            self.dispatch_size,
+                            bindings.len()
+                        ));
                         cache
                             .device
                             .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -322,6 +378,165 @@ impl DirectKernel {
                 .iter()
                 .flat_map(|kernel| kernel.bindings_for_test())
                 .collect(),
+        }
+    }
+
+    /// The buffers this kernel binds, in the canonical order used internally by
+    /// `prepare_dispatch` (and mirrored by `rebind_buffers`). Used by the decode
+    /// plan cache to record where each binding's buffer comes from so the kernel
+    /// can be replayed across tokens with fresh buffers.
+    pub fn binding_buffers(&self) -> Vec<Arc<wgpu::Buffer>> {
+        let mut out = Vec::new();
+        self.collect_buffers(&mut out);
+        out
+    }
+
+    fn collect_buffers(&self, out: &mut Vec<Arc<wgpu::Buffer>>) {
+        match &self.kind {
+            DirectKernelKind::Dynamic { bindings, .. } => {
+                out.extend(bindings.iter().map(|binding| binding.buffer.clone()));
+            }
+            DirectKernelKind::Storage3 {
+                input,
+                weight,
+                output,
+                ..
+            } => {
+                out.push(input.clone());
+                out.push(weight.clone());
+                out.push(output.clone());
+            }
+            DirectKernelKind::Sequence(kernels) => {
+                for kernel in kernels {
+                    kernel.collect_buffers(out);
+                }
+            }
+        }
+    }
+
+    /// Clone this kernel, replacing its bound buffers positionally with `new`
+    /// (which must have exactly `binding_buffers().len()` entries in the same
+    /// order). The compiled pipeline / cached analysis is preserved; only the
+    /// buffers (i.e. the bind-group inputs) change. This lets the decode plan
+    /// cache reuse a kernel built on a previous token while swapping in the
+    /// current token's input/output buffers.
+    pub fn rebind_buffers(&self, new: &[Arc<wgpu::Buffer>]) -> Self {
+        let mut cursor = 0;
+        let kernel = self.rebind_from(new, &mut cursor);
+        debug_assert_eq!(
+            cursor,
+            new.len(),
+            "rebind_buffers received {} buffers for a kernel binding {cursor}",
+            new.len()
+        );
+        kernel
+    }
+
+    fn rebind_from(&self, new: &[Arc<wgpu::Buffer>], cursor: &mut usize) -> Self {
+        let kind = match &self.kind {
+            DirectKernelKind::Dynamic { cached, bindings } => {
+                let bindings = bindings
+                    .iter()
+                    .map(|binding| {
+                        let buffer = new[*cursor].clone();
+                        *cursor += 1;
+                        DirectKernelBinding {
+                            binding: binding.binding,
+                            buffer,
+                            read_only: binding.read_only,
+                        }
+                    })
+                    .collect();
+                DirectKernelKind::Dynamic {
+                    cached: cached.clone(),
+                    bindings,
+                }
+            }
+            DirectKernelKind::Storage3 { pipeline, .. } => {
+                let input = new[*cursor].clone();
+                let weight = new[*cursor + 1].clone();
+                let output = new[*cursor + 2].clone();
+                *cursor += 3;
+                DirectKernelKind::Storage3 {
+                    pipeline: pipeline.clone(),
+                    input,
+                    weight,
+                    output,
+                }
+            }
+            DirectKernelKind::Sequence(kernels) => DirectKernelKind::Sequence(
+                kernels
+                    .iter()
+                    .map(|kernel| kernel.rebind_from(new, cursor))
+                    .collect(),
+            ),
+        };
+        Self {
+            name: self.name.clone(),
+            dispatch_size: self.dispatch_size,
+            kind,
+        }
+    }
+}
+
+impl DirectKernelTemplate {
+    /// Build a dispatchable [`DirectKernel`] by binding buffers positionally in
+    /// the same order returned by [`DirectKernel::binding_buffers`].
+    pub fn bind_buffers(&self, new: &[Arc<wgpu::Buffer>]) -> DirectKernel {
+        let mut cursor = 0;
+        let kernel = self.bind_from(new, &mut cursor);
+        debug_assert_eq!(
+            cursor,
+            new.len(),
+            "bind_buffers received {} buffers for a template binding {cursor}",
+            new.len()
+        );
+        kernel
+    }
+
+    fn bind_from(&self, new: &[Arc<wgpu::Buffer>], cursor: &mut usize) -> DirectKernel {
+        let kind = match &self.kind {
+            DirectKernelTemplateKind::Dynamic { cached, bindings } => {
+                let bindings = bindings
+                    .iter()
+                    .map(|binding| {
+                        let buffer = new[*cursor].clone();
+                        *cursor += 1;
+                        DirectKernelBinding {
+                            binding: binding.binding,
+                            buffer,
+                            read_only: binding.read_only,
+                        }
+                    })
+                    .collect();
+                DirectKernelKind::Dynamic {
+                    cached: cached.clone(),
+                    bindings,
+                }
+            }
+            DirectKernelTemplateKind::Storage3 { pipeline } => {
+                let input = new[*cursor].clone();
+                let weight = new[*cursor + 1].clone();
+                let output = new[*cursor + 2].clone();
+                *cursor += 3;
+                DirectKernelKind::Storage3 {
+                    pipeline: pipeline.clone(),
+                    input,
+                    weight,
+                    output,
+                }
+            }
+            DirectKernelTemplateKind::Sequence(kernels) => DirectKernelKind::Sequence(
+                kernels
+                    .iter()
+                    .map(|kernel| kernel.bind_from(new, cursor))
+                    .collect(),
+            ),
+        };
+        DirectKernel {
+            name: self.name.clone(),
+            dispatch_size: self.dispatch_size,
+            kind,
         }
     }
 }

--- a/fusor-ml/tile-ir-runtime/src/dispatch.rs
+++ b/fusor-ml/tile-ir-runtime/src/dispatch.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use fusor_tile_ir as tile_ir;
 use wgpu::naga::{AddressSpace, StorageAccess};
 
-use crate::cache::{CachedKernel, KernelCache, KernelCacheKey, ModuleCache};
+use crate::cache::{CachedKernel, KernelCache, KernelCacheKey};
 use crate::direct_kernel::{DirectKernel, DirectKernelBinding};
 
 /// Get the cached entry for `key`, or lower `build_ir` and insert it.
@@ -17,26 +17,6 @@ fn cached_kernel(
     }
     let kernel = Arc::new(build_ir()?.lower_to_naga().ok()?);
     Some(cache.get_or_insert_kernel(key, || kernel))
-}
-
-/// Static lowered-kernel-cache front for [`cached_kernel`]: hot kernel families
-/// short-circuit through their per-family LRU before touching the device-wide
-/// cache.
-pub fn cached_hashed_naga(
-    module_cache: &'static ModuleCache,
-    key: KernelCacheKey,
-    build_kernel: impl FnOnce() -> Option<Arc<tile_ir::NagaKernel>>,
-) -> Option<Arc<tile_ir::NagaKernel>> {
-    if let Some(kernel) = module_cache.write().get(&key) {
-        return Some(kernel.clone());
-    }
-    let kernel = build_kernel()?;
-    Some(
-        module_cache
-            .write()
-            .get_or_insert(key, || kernel.clone())
-            .clone(),
-    )
 }
 
 /// Build a `DirectKernel` whose binding list is derived from the kernel's
@@ -58,31 +38,6 @@ pub fn dynamic_kernel_from_ir(
     let bindings = bindings_from_naga(cached.kernel.module(), buffers)?;
     Some(DirectKernel::from_cached(
         name,
-        cached,
-        bindings,
-        dispatch_size,
-    ))
-}
-
-/// Two-tier variant of [`dynamic_kernel_from_ir`]: the static `module_cache`
-/// short-circuits compilation; misses fall through to the device-wide cache
-/// and finally to `build_ir`.
-pub fn dynamic_kernel_from_hashed_ir(
-    cache: &KernelCache,
-    module_cache: &'static ModuleCache,
-    label: &str,
-    module_key: KernelCacheKey,
-    buffers: impl IntoIterator<Item = Arc<wgpu::Buffer>>,
-    dispatch_size: [u32; 3],
-    build_ir: impl FnOnce() -> Option<tile_ir::KernelIr>,
-) -> Option<DirectKernel> {
-    let kernel = cached_hashed_naga(module_cache, module_key, || {
-        Some(Arc::new(build_ir()?.lower_to_naga().ok()?))
-    })?;
-    let bindings = bindings_from_naga(kernel.module(), buffers)?;
-    let cached = cache.get_or_insert_kernel(module_key, || kernel);
-    Some(DirectKernel::from_cached(
-        label,
         cached,
         bindings,
         dispatch_size,
@@ -169,15 +124,6 @@ pub fn three_buffer_pipeline_from_ir(
     build_ir: impl FnOnce() -> Option<tile_ir::KernelIr>,
 ) -> Option<wgpu::ComputePipeline> {
     let cached = cached_kernel(cache, cache_key, build_ir)?;
-    Some(prepare_three_buffer_pipeline(cache, name, &cached))
-}
-
-pub fn three_buffer_pipeline_from_cached_module(
-    cache: &KernelCache,
-    name: &str,
-    cache_key: KernelCacheKey,
-) -> Option<wgpu::ComputePipeline> {
-    let cached = cache.kernels.write().get(&cache_key).cloned()?;
     Some(prepare_three_buffer_pipeline(cache, name, &cached))
 }
 

--- a/fusor-ml/tile-ir-runtime/src/lib.rs
+++ b/fusor-ml/tile-ir-runtime/src/lib.rs
@@ -9,6 +9,7 @@ mod buffer_pool;
 mod cache;
 mod direct_kernel;
 mod dispatch;
+mod plan_cache;
 
 pub use buffer_pool::BufferPool;
 pub use cache::{
@@ -20,6 +21,7 @@ pub use direct_kernel::{
 pub use dispatch::{
     dynamic_kernel_from_ir, run_direct_kernel, run_kernel, three_buffer_pipeline_from_ir,
 };
+pub use plan_cache::DirectPlanCache;
 
 /// Diagnostic: total shader-module / compute-pipeline compilations performed at
 /// runtime. Each WGSL shader-module and pipeline creation bumps this counter.

--- a/fusor-ml/tile-ir-runtime/src/lib.rs
+++ b/fusor-ml/tile-ir-runtime/src/lib.rs
@@ -13,29 +13,22 @@ mod dispatch;
 pub use buffer_pool::BufferPool;
 pub use cache::{
     CachedKernel, DirectDynamicBindGroupKey, KernelCache, KernelCacheKey, KernelVariantKey,
-    ModuleCache, module_cache,
 };
 pub use direct_kernel::{
     DirectKernel, DirectKernelBinding, DirectKernelTemplate, PreparedDirectDispatch,
 };
 pub use dispatch::{
-    cached_hashed_naga, dynamic_kernel_from_hashed_ir, dynamic_kernel_from_ir, run_direct_kernel,
-    run_kernel, three_buffer_pipeline_from_cached_module, three_buffer_pipeline_from_ir,
+    dynamic_kernel_from_ir, run_direct_kernel, run_kernel, three_buffer_pipeline_from_ir,
 };
 
 /// Diagnostic: total shader-module / compute-pipeline compilations performed at
-/// runtime. Each WGSL shader-module and pipeline creation bumps this counter. On
-/// wasm every compile is logged to the browser console so per-token pipeline
-/// recompilation (cache thrashing during decode) is directly observable; on
-/// native it is only logged when `FUSOR_TRACE_PIPELINE_COMPILES` is set.
+/// runtime. Each WGSL shader-module and pipeline creation bumps this counter.
+/// It is logged when `FUSOR_TRACE_PIPELINE_COMPILES` is set.
 static COMPILES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 pub(crate) fn note_compile(what: &str) {
     let n = COMPILES.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(&format!("fusor_compile #{n} {what}").into());
-    #[cfg(not(target_arch = "wasm32"))]
     if std::env::var_os("FUSOR_TRACE_PIPELINE_COMPILES").is_some() {
-        eprintln!("fusor_compile #{n} {what}");
+        tracing::info!("fusor_compile #{n} {what}");
     }
 }

--- a/fusor-ml/tile-ir-runtime/src/lib.rs
+++ b/fusor-ml/tile-ir-runtime/src/lib.rs
@@ -15,8 +15,27 @@ pub use cache::{
     CachedKernel, DirectDynamicBindGroupKey, KernelCache, KernelCacheKey, KernelVariantKey,
     ModuleCache, module_cache,
 };
-pub use direct_kernel::{DirectKernel, DirectKernelBinding, PreparedDirectDispatch};
+pub use direct_kernel::{
+    DirectKernel, DirectKernelBinding, DirectKernelTemplate, PreparedDirectDispatch,
+};
 pub use dispatch::{
     cached_hashed_naga, dynamic_kernel_from_hashed_ir, dynamic_kernel_from_ir, run_direct_kernel,
     run_kernel, three_buffer_pipeline_from_cached_module, three_buffer_pipeline_from_ir,
 };
+
+/// Diagnostic: total shader-module / compute-pipeline compilations performed at
+/// runtime. Each WGSL shader-module and pipeline creation bumps this counter. On
+/// wasm every compile is logged to the browser console so per-token pipeline
+/// recompilation (cache thrashing during decode) is directly observable; on
+/// native it is only logged when `FUSOR_TRACE_PIPELINE_COMPILES` is set.
+static COMPILES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+pub(crate) fn note_compile(what: &str) {
+    let n = COMPILES.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(&format!("fusor_compile #{n} {what}").into());
+    #[cfg(not(target_arch = "wasm32"))]
+    if std::env::var_os("FUSOR_TRACE_PIPELINE_COMPILES").is_some() {
+        eprintln!("fusor_compile #{n} {what}");
+    }
+}

--- a/fusor-ml/tile-ir-runtime/src/plan_cache.rs
+++ b/fusor-ml/tile-ir-runtime/src/plan_cache.rs
@@ -1,0 +1,153 @@
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use lru::LruCache;
+use parking_lot::Mutex;
+use rustc_hash::FxBuildHasher;
+
+use crate::{DirectKernel, DirectKernelTemplate, KernelCacheKey};
+
+#[cfg(not(target_arch = "wasm32"))]
+const DIRECT_PLAN_CACHE_SIZE: usize = 4096;
+#[cfg(target_arch = "wasm32")]
+const DIRECT_PLAN_CACHE_SIZE: usize = 512;
+
+/// Per-device cache for direct-kernel plans.
+///
+/// This stores bufferless direct-kernel templates and replays them with the
+/// caller-provided binding buffers for the current dispatch. The cache never
+/// infers binding provenance from pointer equality; callers must provide the
+/// buffers in the exact order returned by [`DirectKernel::binding_buffers`].
+pub struct DirectPlanCache {
+    enabled: bool,
+    plans: Mutex<LruCache<KernelCacheKey, Vec<CachedDirectKernelPlan>, FxBuildHasher>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+struct CachedDirectKernelPlan {
+    template: DirectKernelTemplate,
+    binding_count: usize,
+}
+
+impl std::fmt::Debug for DirectPlanCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DirectPlanCache")
+            .field("enabled", &self.enabled)
+            .finish()
+    }
+}
+
+impl DirectPlanCache {
+    pub fn new() -> Self {
+        Self {
+            enabled: std::env::var_os("FUSOR_DISABLE_DECODE_PLAN_CACHE").is_none(),
+            plans: Mutex::new(LruCache::with_hasher(
+                NonZeroUsize::new(DIRECT_PLAN_CACHE_SIZE)
+                    .expect("direct plan cache size must be non-zero"),
+                Default::default(),
+            )),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn try_get_or_insert<E>(
+        &self,
+        key: KernelCacheKey,
+        binding_buffers: &[Arc<wgpu::Buffer>],
+        build: impl FnOnce() -> Result<DirectKernel, E>,
+    ) -> Result<DirectKernel, E> {
+        let mut kernels = self.try_get_or_insert_many(key, &[binding_buffers], || {
+            build().map(|kernel| vec![kernel])
+        })?;
+        Ok(kernels
+            .pop()
+            .expect("single direct plan cache result must contain one kernel"))
+    }
+
+    pub fn try_get_or_insert_many<E>(
+        &self,
+        key: KernelCacheKey,
+        binding_buffers: &[&[Arc<wgpu::Buffer>]],
+        build: impl FnOnce() -> Result<Vec<DirectKernel>, E>,
+    ) -> Result<Vec<DirectKernel>, E> {
+        if !self.enabled {
+            return build();
+        }
+
+        {
+            let mut plans = self.plans.lock();
+            if let Some(plan) = plans.get(&key)
+                && binding_shape_matches(plan, binding_buffers)
+            {
+                let hit_total = self.hits.fetch_add(1, Ordering::Relaxed) + 1;
+                trace_cache_event(hit_total, self.misses.load(Ordering::Relaxed));
+                return Ok(plan
+                    .iter()
+                    .zip(binding_buffers)
+                    .map(|(plan, buffers)| plan.template.bind_buffers(buffers))
+                    .collect());
+            }
+        }
+
+        let miss_total = self.misses.fetch_add(1, Ordering::Relaxed) + 1;
+        trace_cache_event(self.hits.load(Ordering::Relaxed), miss_total);
+        let built = build()?;
+        if binding_buffers_match(&built, binding_buffers) {
+            self.plans.lock().put(key, record_plan(&built));
+        }
+        Ok(built)
+    }
+}
+
+fn record_plan(kernels: &[DirectKernel]) -> Vec<CachedDirectKernelPlan> {
+    kernels
+        .iter()
+        .map(|kernel| CachedDirectKernelPlan {
+            template: kernel.to_template(),
+            binding_count: kernel.binding_buffers().len(),
+        })
+        .collect()
+}
+
+fn binding_shape_matches(
+    plan: &[CachedDirectKernelPlan],
+    binding_buffers: &[&[Arc<wgpu::Buffer>]],
+) -> bool {
+    plan.len() == binding_buffers.len()
+        && plan
+            .iter()
+            .zip(binding_buffers)
+            .all(|(plan, buffers)| plan.binding_count == buffers.len())
+}
+
+fn binding_buffers_match(kernels: &[DirectKernel], expected: &[&[Arc<wgpu::Buffer>]]) -> bool {
+    if kernels.len() != expected.len() {
+        return false;
+    }
+
+    kernels.iter().zip(expected).all(|(kernel, expected)| {
+        let actual = kernel.binding_buffers();
+        actual.len() == expected.len()
+            && actual
+                .iter()
+                .zip(*expected)
+                .all(|(actual, expected)| Arc::ptr_eq(actual, expected))
+    })
+}
+
+fn trace_cache_event(hits: u64, misses: u64) {
+    if cfg!(target_arch = "wasm32") || std::env::var_os("FUSOR_TRACE_RESOLVE_HOST").is_some() {
+        tracing::info!("direct_plan_cache hit={hits} miss={misses}");
+    }
+}

--- a/fusor-ml/tile-ir-runtime/src/plan_cache.rs
+++ b/fusor-ml/tile-ir-runtime/src/plan_cache.rs
@@ -43,6 +43,12 @@ impl std::fmt::Debug for DirectPlanCache {
     }
 }
 
+impl Default for DirectPlanCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DirectPlanCache {
     pub fn new() -> Self {
         Self {

--- a/fusor-ml/tile-ir/Cargo.toml
+++ b/fusor-ml/tile-ir/Cargo.toml
@@ -9,21 +9,21 @@ autoexamples = false
 bytemuck = "1.25.0"
 half = "2.4.1"
 rustc-hash = "2.1.1"
-naga = "29.0.3"
+naga = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now" }
 pollster = "0.4.0"
-wgpu = { version = "29.0.3", default-features = false, features = ["std", "naga-ir"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["std", "naga-ir"] }
 
 [dev-dependencies]
-naga = { version = "29.0.3", features = ["wgsl-in", "wgsl-out"] }
+naga = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", features = ["wgsl-in", "wgsl-out"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["metal"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["metal"] }
 
 [target.'cfg(windows)'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["dx12"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["dx12"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["vulkan"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["vulkan"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wgpu = { version = "29.0.3", default-features = false, features = ["webgpu"] }
+wgpu = { git = "https://github.com/ealmloff/wgpu", branch = "yield-now", default-features = false, features = ["webgpu"] }

--- a/fusor-ml/tile-ir/src/lower/coop.rs
+++ b/fusor-ml/tile-ir/src/lower/coop.rs
@@ -181,7 +181,11 @@ impl<'a> Lowerer<'a> {
                         data: CooperativeData {
                             pointer: ptr,
                             stride,
-                            row_major: true,
+                            // Metal's simdgroup matrix orientation makes
+                            // row-major A/B fragments multiply as B * A.
+                            // Keep Fusor's logical A * B by holding coop
+                            // fragments transposed internally.
+                            row_major: false,
                         },
                     },
                 ))
@@ -206,7 +210,9 @@ impl<'a> Lowerer<'a> {
                         data: CooperativeData {
                             pointer: ptr,
                             stride,
-                            row_major: true,
+                            // C-broadcast participates in the same transposed
+                            // accumulator representation as A/B fragments.
+                            row_major: false,
                         },
                     },
                 ))
@@ -799,7 +805,9 @@ impl<'a> Lowerer<'a> {
                 data: CooperativeData {
                     pointer: storage_ptr,
                     stride,
-                    row_major,
+                    // Accumulators are transposed internally; invert the
+                    // destination layout flag to write logical row/col order.
+                    row_major: !row_major,
                 },
             },
             Span::default(),

--- a/fusor-ml/tile-ir/src/lower/coop.rs
+++ b/fusor-ml/tile-ir/src/lower/coop.rs
@@ -181,7 +181,7 @@ impl<'a> Lowerer<'a> {
                         data: CooperativeData {
                             pointer: ptr,
                             stride,
-                            row_major: false,
+                            row_major: true,
                         },
                     },
                 ))
@@ -842,9 +842,9 @@ impl<'a> Lowerer<'a> {
         }
         let strides = layout.affine_strides();
         if strides[1] == 1 {
-            Ok((strides[0], false))
+            Ok((strides[0], true))
         } else if strides[0] == 1 {
-            Ok((strides[1], true))
+            Ok((strides[1], false))
         } else {
             Err(LowerError::UnsupportedOperation(
                 "cooperative store requires row-major or column-major output strides",

--- a/fusor-ml/tile-ir/src/tests/lowering.rs
+++ b/fusor-ml/tile-ir/src/tests/lowering.rs
@@ -265,7 +265,7 @@ fn typed_coop_accumulator_records_scalar_role_and_shape() {
 }
 
 #[test]
-fn cooperative_load_store_layout_flags_match_affine_layouts() {
+fn cooperative_load_store_layout_flags_use_transposed_internal_layout() {
     fn collect_coop_store_row_major(block: &naga::Block, out: &mut Vec<bool>) {
         for stmt in block.iter() {
             match stmt {
@@ -330,10 +330,10 @@ fn cooperative_load_store_layout_flags_match_affine_layouts() {
     let col_major = Layout::strided(MemoryLevel::Storage, Shape::new([8, 8]), &[1, 8]);
 
     let (loads, stores) = lowered_coop_layout_flags(row_major);
-    assert_eq!(loads, [true, true]);
-    assert_eq!(stores, [true]);
+    assert_eq!(loads, [false, false]);
+    assert_eq!(stores, [false]);
 
     let (loads, stores) = lowered_coop_layout_flags(col_major);
-    assert_eq!(loads, [true, true]);
-    assert_eq!(stores, [false]);
+    assert_eq!(loads, [false, false]);
+    assert_eq!(stores, [true]);
 }

--- a/fusor-ml/tile-ir/src/tests/lowering.rs
+++ b/fusor-ml/tile-ir/src/tests/lowering.rs
@@ -263,3 +263,77 @@ fn typed_coop_accumulator_records_scalar_role_and_shape() {
         ElementType::coop_matrix(ScalarElement::F32, CoopMatrixRole::C, 8, 8)
     );
 }
+
+#[test]
+fn cooperative_load_store_layout_flags_match_affine_layouts() {
+    fn collect_coop_store_row_major(block: &naga::Block, out: &mut Vec<bool>) {
+        for stmt in block.iter() {
+            match stmt {
+                naga::Statement::CooperativeStore { data, .. } => out.push(data.row_major),
+                naga::Statement::Block(inner) => collect_coop_store_row_major(inner, out),
+                naga::Statement::If { accept, reject, .. } => {
+                    collect_coop_store_row_major(accept, out);
+                    collect_coop_store_row_major(reject, out);
+                }
+                naga::Statement::Switch { cases, .. } => {
+                    for case in cases {
+                        collect_coop_store_row_major(&case.body, out);
+                    }
+                }
+                naga::Statement::Loop {
+                    body, continuing, ..
+                } => {
+                    collect_coop_store_row_major(body, out);
+                    collect_coop_store_row_major(continuing, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn lowered_coop_layout_flags(output_layout: Layout) -> (Vec<bool>, Vec<bool>) {
+        let ir = tile::build(|phase| {
+            let coop = crate::CoopMatrixToken::new_unchecked();
+            let y = phase.storage_write_with_layout(f32(), output_layout);
+            let a_tile = phase.alloc_workgroup_tile(ScalarElement::F32, 8, 8);
+            let b_tile = phase.alloc_workgroup_tile(ScalarElement::F32, 8, 8);
+            phase.program_grid(32, [1, 1, 1], |program| {
+                let acc = coop.alloc_coop_acc(program, ScalarElement::F32, 8, 8);
+                let zero = coop.coop_zero(program, ScalarElement::F32, 8, 8);
+                coop.store_local_coop(program, &acc, zero);
+
+                let a = coop.coop_load_a(program, &a_tile, 0u32, 0u32, ScalarElement::F32, 8, 8);
+                let b = coop.coop_load_b(program, &b_tile, 0u32, 0u32, ScalarElement::F32, 8, 8);
+                let c = coop.load_local_coop(program, &acc);
+                let mma = coop.coop_mma(program, a, b, c);
+                coop.store_local_coop(program, &acc, mma);
+                coop.coop_store(program, &acc, &y, 0u32, 0u32);
+            });
+        });
+
+        let lowered = lower_or_fail(&ir, "coop layout flags");
+        let function = &lowered.module().entry_points[0].function;
+        let load_flags = function
+            .expressions
+            .iter()
+            .filter_map(|(_, expr)| match expr {
+                naga::Expression::CooperativeLoad { data, .. } => Some(data.row_major),
+                _ => None,
+            })
+            .collect();
+        let mut store_flags = Vec::new();
+        collect_coop_store_row_major(&function.body, &mut store_flags);
+        (load_flags, store_flags)
+    }
+
+    let row_major = Layout::contiguous(MemoryLevel::Storage, Shape::new([8, 8]));
+    let col_major = Layout::strided(MemoryLevel::Storage, Shape::new([8, 8]), &[1, 8]);
+
+    let (loads, stores) = lowered_coop_layout_flags(row_major);
+    assert_eq!(loads, [true, true]);
+    assert_eq!(stores, [true]);
+
+    let (loads, stores) = lowered_coop_layout_flags(col_major);
+    assert_eq!(loads, [true, true]);
+    assert_eq!(stores, [false]);
+}

--- a/interfaces/kalosm-common/src/cache.rs
+++ b/interfaces/kalosm-common/src/cache.rs
@@ -126,6 +126,19 @@ impl Cache {
         source: &FileSource,
         progress: &mut impl FnMut(FileLoadingProgress),
     ) -> Result<Vec<u8>, CacheError> {
+        self.get_opfs_file(source, progress).await?.read_all().await
+    }
+
+    /// WASM: Get an OPFS file handle using persistent caching.
+    ///
+    /// This validates or downloads the cache entry, then returns a range-readable
+    /// handle without reading the whole file into wasm memory.
+    #[cfg(target_arch = "wasm32")]
+    pub async fn get_opfs_file(
+        &self,
+        source: &FileSource,
+        progress: &mut impl FnMut(FileLoadingProgress),
+    ) -> Result<crate::opfs::OpfsFile, CacheError> {
         use crate::opfs::{
             close_writable_stream, seek_writable_stream, write_chunk_to_stream, OpfsCache,
         };
@@ -171,14 +184,13 @@ impl Cache {
                 if let Some(expected) = expected_size {
                     if local_size == expected {
                         // Cache hit - file is complete
-                        let bytes = opfs.read_file(&cache_dir, &safe_file).await?;
                         progress(FileLoadingProgress {
                             progress: local_size,
                             cached_size: local_size,
                             size: local_size,
                             start_time: None,
                         });
-                        return Ok(bytes);
+                        return opfs.open_file(&cache_dir, &safe_file).await;
                     } else if local_size > expected {
                         // File is corrupted (larger than expected), delete and start fresh
                         let _ = opfs.delete_file(&cache_dir, &safe_file).await;
@@ -208,14 +220,13 @@ impl Cache {
                 // Handle 416 Range Not Satisfiable
                 if status == StatusCode::RANGE_NOT_SATISFIABLE {
                     if local_size > 0 {
-                        let bytes = opfs.read_file(&cache_dir, &safe_file).await?;
                         progress(FileLoadingProgress {
                             progress: local_size,
                             cached_size: local_size,
                             size: local_size,
                             start_time: None,
                         });
-                        return Ok(bytes);
+                        return opfs.open_file(&cache_dir, &safe_file).await;
                     }
                     // local_size is 0 but we got 416 - something is wrong, restart fresh
                     response = client
@@ -259,33 +270,11 @@ impl Cache {
 
                     // Already complete
                     if actual_start == size {
-                        return opfs.read_file(&cache_dir, &safe_file).await;
+                        return opfs.open_file(&cache_dir, &safe_file).await;
                     }
                 }
 
-                // 7. If resuming, try to read existing data first
-                let mut all_bytes = if resuming && actual_start > 0 {
-                    match opfs.read_file(&cache_dir, &safe_file).await {
-                        Ok(existing) => existing,
-                        Err(e) => {
-                            // Can't read existing file - delete it and return error
-                            // The next call will start fresh
-                            tracing::warn!(
-                                "[OPFS] Can't read existing file for resume: {}, deleting",
-                                e
-                            );
-                            let _ = opfs.delete_file(&cache_dir, &safe_file).await;
-                            return Err(CacheError::OpfsError(format!(
-                                "Failed to read partial download for resume: {}. File deleted, please retry.",
-                                e
-                            )));
-                        }
-                    }
-                } else {
-                    Vec::new()
-                };
-
-                // 8. Create writable stream and download
+                // 7. Create writable stream and download
                 let mut writable = opfs
                     .create_writable(&cache_dir, &safe_file, resuming)
                     .await?;
@@ -304,7 +293,6 @@ impl Cache {
                 while let Some(chunk_result) = stream.next().await {
                     let chunk = chunk_result?;
                     write_chunk_to_stream(&writable, &chunk).await?;
-                    all_bytes.extend_from_slice(&chunk);
 
                     current_progress += chunk.len() as u64;
                     bytes_since_flush += chunk.len() as u64;
@@ -329,7 +317,7 @@ impl Cache {
 
                 close_writable_stream(&writable).await?;
 
-                Ok(all_bytes)
+                opfs.open_file(&cache_dir, &safe_file).await
             }
             FileSource::Local(_) => Err(CacheError::Io(std::io::Error::other(
                 "Local file access not supported on WASM",

--- a/interfaces/kalosm-common/src/opfs.rs
+++ b/interfaces/kalosm-common/src/opfs.rs
@@ -8,9 +8,63 @@ use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
-    File, FileSystemCreateWritableOptions, FileSystemDirectoryHandle, FileSystemFileHandle,
+    Blob, File, FileSystemCreateWritableOptions, FileSystemDirectoryHandle, FileSystemFileHandle,
     FileSystemGetDirectoryOptions, FileSystemGetFileOptions, FileSystemWritableFileStream,
 };
+
+const OPFS_READ_CHUNK_SIZE: usize = 16 * 1024 * 1024;
+
+/// A cached OPFS file that can be read in byte ranges without materializing the
+/// whole file in wasm memory.
+#[derive(Clone)]
+pub struct OpfsFile {
+    file_handle: FileSystemFileHandle,
+    name: String,
+    size: u64,
+}
+
+impl OpfsFile {
+    /// The current size of the file when this handle was opened.
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Read the whole file into wasm memory.
+    pub async fn read_all(&self) -> Result<Vec<u8>, CacheError> {
+        let size = usize::try_from(self.size).map_err(|_| {
+            CacheError::OpfsError(format!(
+                "File '{}' is too large to read into wasm memory",
+                self.name
+            ))
+        })?;
+        self.read_range(0, size).await
+    }
+
+    /// Read a byte range from the file into wasm memory.
+    pub async fn read_range(&self, offset: u64, len: usize) -> Result<Vec<u8>, CacheError> {
+        let end = offset.checked_add(len as u64).ok_or_else(|| {
+            CacheError::OpfsError(format!(
+                "Requested range for '{}' overflows: {} + {}",
+                self.name, offset, len
+            ))
+        })?;
+        if end > self.size {
+            return Err(CacheError::OpfsError(format!(
+                "Requested range {}..{} exceeds file '{}' size {}",
+                offset, end, self.name, self.size
+            )));
+        }
+
+        let file: File = JsFuture::from(self.file_handle.get_file())
+            .await
+            .map_err(|e| {
+                CacheError::OpfsError(format!("Failed to get file '{}': {:?}", self.name, e))
+            })?
+            .unchecked_into();
+
+        read_blob_range_to_vec_chunked(file.unchecked_ref(), &self.name, offset, end).await
+    }
+}
 
 /// Sanitize a name for OPFS compatibility
 ///
@@ -144,6 +198,15 @@ impl OpfsCache {
         dir: &FileSystemDirectoryHandle,
         name: &str,
     ) -> Result<Vec<u8>, CacheError> {
+        self.open_file(dir, name).await?.read_all().await
+    }
+
+    /// Open a file for range reads.
+    pub async fn open_file(
+        &self,
+        dir: &FileSystemDirectoryHandle,
+        name: &str,
+    ) -> Result<OpfsFile, CacheError> {
         let options = FileSystemGetFileOptions::new();
         options.set_create(false);
 
@@ -160,12 +223,19 @@ impl OpfsCache {
             .map_err(|e| CacheError::OpfsError(format!("Failed to get file '{}': {:?}", name, e)))?
             .unchecked_into();
 
-        let array_buffer = JsFuture::from(file.array_buffer()).await.map_err(|e| {
-            CacheError::OpfsError(format!("Failed to read file '{}': {:?}", name, e))
-        })?;
+        let size = file.size();
+        if !size.is_finite() || size < 0.0 {
+            return Err(CacheError::OpfsError(format!(
+                "Invalid size for file '{}': {}",
+                name, size
+            )));
+        }
 
-        let uint8_array = Uint8Array::new(&array_buffer);
-        Ok(uint8_array.to_vec())
+        Ok(OpfsFile {
+            file_handle,
+            name: name.to_string(),
+            size: size as u64,
+        })
     }
 
     /// Create a writable stream for a file (for streaming writes)
@@ -218,6 +288,53 @@ impl OpfsCache {
 
         Ok(())
     }
+}
+
+async fn read_blob_range_to_vec_chunked(
+    blob: &Blob,
+    name: &str,
+    start: u64,
+    end: u64,
+) -> Result<Vec<u8>, CacheError> {
+    let len = end.checked_sub(start).ok_or_else(|| {
+        CacheError::OpfsError(format!(
+            "Invalid range for file '{}': {}..{}",
+            name, start, end
+        ))
+    })?;
+    let len = usize::try_from(len).map_err(|_| {
+        CacheError::OpfsError(format!(
+            "Range for file '{}' is too large to read into wasm memory",
+            name
+        ))
+    })?;
+
+    let mut bytes = Vec::with_capacity(len);
+    let mut offset = start;
+    while offset < end {
+        let chunk_end = (offset + OPFS_READ_CHUNK_SIZE as u64).min(end);
+        let chunk = blob
+            .slice_with_f64_and_f64(offset as f64, chunk_end as f64)
+            .map_err(|e| {
+                CacheError::OpfsError(format!(
+                    "Failed to slice file '{}' at bytes {}..{}: {:?}",
+                    name, offset, chunk_end, e
+                ))
+            })?;
+        let array_buffer = JsFuture::from(chunk.array_buffer()).await.map_err(|e| {
+            CacheError::OpfsError(format!(
+                "Failed to read file '{}' at bytes {}..{}: {:?}",
+                name, offset, chunk_end, e
+            ))
+        })?;
+        let chunk = Uint8Array::new(&array_buffer);
+        let start = bytes.len();
+        bytes.resize(start + chunk.length() as usize, 0);
+        chunk.copy_to(&mut bytes[start..]);
+        offset = chunk_end;
+    }
+
+    Ok(bytes)
 }
 
 /// Seek to a position in an OPFS writable stream

--- a/interfaces/kalosm/examples/vision.rs
+++ b/interfaces/kalosm/examples/vision.rs
@@ -10,7 +10,7 @@ async fn main() {
         .build()
         .await
         .unwrap();
-    eprintln!("[timing] model load: {:.2?}", t_load_start.elapsed());
+    tracing::info!("[timing] model load: {:.2?}", t_load_start.elapsed());
 
     let mut chat = model.chat();
     let max_tokens = std::env::var("KALOSM_VISION_MAX_TOKENS")
@@ -41,7 +41,7 @@ async fn main() {
     while let Some(token) = response.next().await {
         if first_token_at.is_none() {
             first_token_at = Some(t_prefill.elapsed());
-            eprintln!(
+            tracing::info!(
                 "[timing] first token (prefill): {:.2?}",
                 first_token_at.unwrap()
             );
@@ -62,8 +62,12 @@ async fn main() {
     } else {
         0.0
     };
-    eprintln!(
+    tracing::info!(
         "[timing] total: {:.2?} | prefill: {:.2?} | decode: {:.2?} ({} tok, {:.1} tok/s)",
-        total, prefill, decode, decode_tokens, toks_per_sec
+        total,
+        prefill,
+        decode,
+        decode_tokens,
+        toks_per_sec
     );
 }

--- a/models/kalosm-llama/examples/decode_latency.rs
+++ b/models/kalosm-llama/examples/decode_latency.rs
@@ -10,6 +10,8 @@ fn env_usize(name: &str, default: usize) -> usize {
 }
 
 fn main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
     pollster::block_on(async {
         let warmup = env_usize("KALOSM_DECODE_BENCH_WARMUP", 8);
         let measured = env_usize("KALOSM_DECODE_BENCH_TOKENS", 64);
@@ -25,7 +27,7 @@ fn main() {
         let mut stream = model.complete(&prompt).take(warmup + measured);
         for _ in 0..warmup {
             if stream.next().await.is_none() {
-                eprintln!("stream ended during warmup");
+                tracing::warn!("stream ended during warmup");
                 return;
             }
         }

--- a/models/kalosm-llama/examples/plan_cache_repro.rs
+++ b/models/kalosm-llama/examples/plan_cache_repro.rs
@@ -1,0 +1,24 @@
+// Native GPU reproduction for the decode-plan-cache gibberish bug.
+// Generates a short completion on the default (GPU) device and prints it, so
+// coherence can be eyeballed. Run with the cache on (default) vs off
+// (FUSOR_DISABLE_DECODE_PLAN_CACHE=1) to compare.
+use kalosm_llama::prelude::*;
+use kalosm_model_types::ModelLoadingProgress;
+use std::io::Write;
+
+fn main() {
+    pollster::block_on(async {
+        let model = Llama::builder()
+            .with_source(LlamaSource::qwen_2_5_0_5b_instruct())
+            .build_with_loading_handler(|_: ModelLoadingProgress| {})
+            .await
+            .unwrap();
+
+        let mut stream = model("Once upon a time there was a penguin named Peng.").take(40);
+        while let Some(token) = stream.next().await {
+            print!("{token}");
+            std::io::stdout().flush().unwrap();
+        }
+        println!();
+    });
+}

--- a/models/kalosm-llama/examples/profile_forward.rs
+++ b/models/kalosm-llama/examples/profile_forward.rs
@@ -7,7 +7,7 @@ where
 {
     for _ in 0..warmup {
         if stream.next().await.is_none() {
-            eprintln!("stream ended during warmup");
+            tracing::warn!("stream ended during warmup");
             return;
         }
     }
@@ -69,6 +69,8 @@ fn source() -> LlamaSource {
 }
 
 fn main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
     pollster::block_on(async {
         let warmup = env_usize("KALOSM_PROFILE_LLAMA_WARMUP", 4);
         let measured = env_usize("KALOSM_PROFILE_LLAMA_TOKENS", 16);

--- a/models/kalosm-llama/examples/token_probe.rs
+++ b/models/kalosm-llama/examples/token_probe.rs
@@ -10,6 +10,8 @@ const WARMUP_TOKENS: usize = 8;
 const DEFAULT_GPU_SAMPLE_TOP_K: &str = "1";
 
 fn main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
     pollster::block_on(async {
         fn progress(_: ModelLoadingProgress) {}
 
@@ -46,7 +48,7 @@ async fn run_probe(model: &Llama, label: &str, tokens_to_generate: usize, print_
         first_token_at.get_or_insert(now);
         last_token_at = Some(now);
         if print_tokens {
-            eprintln!(
+            tracing::info!(
                 "{label} token {tokens:02}: step={:?} total={:?} text={token:?}",
                 now.duration_since(last),
                 now.duration_since(total_start)
@@ -63,7 +65,7 @@ async fn run_probe(model: &Llama, label: &str, tokens_to_generate: usize, print_
         } else {
             0.0
         };
-        eprintln!(
+        tracing::info!(
             "{label} decode: {measured_tokens} tokens in {:.3}s = {tps:.2} t/s",
             elapsed.as_secs_f64()
         );

--- a/models/kalosm-llama/src/model/forward.rs
+++ b/models/kalosm-llama/src/model/forward.rs
@@ -48,7 +48,7 @@ where
         let build_start = trace_enabled.then(Instant::now);
         let logits = model.forward(tokens, images, device, cache);
         if let Some(start) = build_start {
-            eprintln!(
+            tracing::info!(
                 "forward_graph_build path={path} decode_eligible={decode_eligible} elapsed={:?}",
                 start.elapsed()
             );
@@ -63,13 +63,15 @@ where
                 let resolve_start = Some(Instant::now());
                 kernels = gpu_logits.count_kernels_to_resolve();
                 if let Some(start) = resolve_start {
-                    eprintln!(
+                    tracing::info!(
                         "forward_resolve path={path} decode_eligible={decode_eligible} kernels={kernels} elapsed={:?}",
                         start.elapsed()
                     );
                 }
             } else {
-                eprintln!("forward_logits_on_cpu path={path} decode_eligible={decode_eligible}");
+                tracing::info!(
+                    "forward_logits_on_cpu path={path} decode_eligible={decode_eligible}"
+                );
             }
         }
 
@@ -117,7 +119,7 @@ where
             let download_start = trace.step_start();
             let logits = logits.as_slice().await?;
             if let Some(start) = download_start {
-                eprintln!(
+                tracing::info!(
                     "forward_download path={} decode_eligible={} elapsed={:?}",
                     trace.path,
                     trace.decode_eligible,
@@ -186,7 +188,7 @@ where
                     .collect()
             };
             if let Some(start) = download_start {
-                eprintln!(
+                tracing::info!(
                     "forward_top_k_download path={} decode_eligible={} k={top_k} elapsed={:?}",
                     trace.path,
                     trace.decode_eligible,
@@ -279,7 +281,7 @@ where
                 }
             };
             if let Some(start) = download_start {
-                eprintln!(
+                tracing::info!(
                     "forward_sample_token_download path={} decode_eligible={} k={} elapsed={:?}",
                     trace.path,
                     trace.decode_eligible,
@@ -435,7 +437,7 @@ where
         let build_start = trace.then(Instant::now);
         let hidden = model.forward_last_hidden_f32(tokens, images, device, cache);
         if let Some(start) = build_start {
-            eprintln!(
+            tracing::info!(
                 "forward_graph_build path={path} decode_eligible={decode_eligible} elapsed={:?}",
                 start.elapsed()
             );
@@ -452,7 +454,7 @@ where
                 let resolve_start = Some(Instant::now());
                 kernels = gpu_hidden.count_kernels_to_resolve();
                 if let Some(start) = resolve_start {
-                    eprintln!(
+                    tracing::info!(
                         "forward_resolve path={path} decode_eligible={decode_eligible} kernels={kernels} elapsed={:?}",
                         start.elapsed()
                     );
@@ -487,7 +489,7 @@ where
                 LlamaModelError::SamplerError("fused logits sampler refused slow fallback".into())
             })?;
             if let Some(start) = sample_start {
-                eprintln!(
+                tracing::info!(
                     "forward_sample_token_download path={path} decode_eligible={decode_eligible} fused_logits=1 k={} elapsed={:?}",
                     top_k,
                     start.elapsed()

--- a/models/kalosm-llama/src/model/mod.rs
+++ b/models/kalosm-llama/src/model/mod.rs
@@ -1,18 +1,23 @@
 use crate::gguf_tokenizer::get_pre_tokenizer;
 use crate::raw::cache::LlamaCache;
-use crate::raw::Model;
+use crate::raw::{LlamaVarSource, Model, RopeScalingConfig};
 use crate::token_stream::TokenOutputStream;
 use crate::token_stream::TokenOutputStreamError;
 use crate::tokenizer::{LlamaTokenizer, LlamaTokenizerError};
 #[cfg(feature = "hf-config-json")]
 use crate::LlamaConfigJson;
+#[cfg(not(target_arch = "wasm32"))]
+use fusor::ShardedVarBuilder;
 use fusor::{
     AddOp, CastTensor, CastTo, Device, FloatDataType, FloatOps, MatmulImpl, Mirostat2Sampler,
-    Mirostat2SamplerParams, MulOp, ShardedVarBuilder, SimdBinaryOp, SimdElement, SimdReduceOp,
-    StandardSamplerParams, SumOp, WasmNotSend, WasmNotSync,
+    Mirostat2SamplerParams, MulOp, SimdBinaryOp, SimdElement, SimdReduceOp, StandardSamplerParams,
+    SumOp, WasmNotSend, WasmNotSync,
 };
-use fusor_gguf::GgufMetadata;
-use fusor_gguf::GgufValue;
+#[cfg(target_arch = "wasm32")]
+use fusor::{AsyncReadRange, AsyncShardedVarBuilder};
+#[cfg(target_arch = "wasm32")]
+use fusor_gguf::GgufReadError;
+use fusor_gguf::{GgufMetadata, GgufValue};
 #[cfg(feature = "vision")]
 use kalosm_language_model::ImageFetchError;
 use kalosm_model_types::ModelLoadingProgress;
@@ -20,6 +25,8 @@ use rand::{Rng, SeedableRng};
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::collections::HashMap;
+#[cfg(target_arch = "wasm32")]
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock};
 use web_time::{Duration, Instant};
@@ -119,6 +126,226 @@ fn gpu_sample_top_k(config: &GpuSamplerConfig) -> usize {
         .or(config.top_k)
         .unwrap_or(default_top_k)
         .max(1)
+}
+
+fn parse_external_tokenizer(
+    tokenizer_source: Option<Vec<u8>>,
+) -> Result<Option<LlamaTokenizer>, LlamaSourceError> {
+    #[cfg(feature = "hf-tokenizer-json")]
+    {
+        match tokenizer_source {
+            Some(tokenizer_source) => {
+                let tokenizer = LlamaTokenizer::from_hf_bytes(tokenizer_source)
+                    .map_err(|err| LlamaSourceError::Tokenizer(Box::new(err)))?;
+                Ok(Some(tokenizer))
+            }
+            None => Ok(None),
+        }
+    }
+    #[cfg(not(feature = "hf-tokenizer-json"))]
+    {
+        let _ = tokenizer_source;
+        Ok(None)
+    }
+}
+
+fn parse_external_config(
+    config_bytes: Option<Vec<u8>>,
+) -> Result<Option<RopeScalingConfig>, LlamaSourceError> {
+    #[cfg(feature = "hf-config-json")]
+    {
+        match config_bytes {
+            Some(config_bytes) => {
+                let config: LlamaConfigJson =
+                    serde_json::from_slice(&config_bytes).map_err(LlamaSourceError::Config)?;
+                Ok(config.rope_scaling)
+            }
+            None => Ok(None),
+        }
+    }
+    #[cfg(not(feature = "hf-config-json"))]
+    {
+        let _ = config_bytes;
+        Ok(None)
+    }
+}
+
+fn tokenizer_from_gguf_source<S: LlamaVarSource>(
+    source: &S,
+) -> Result<LlamaTokenizer, LlamaSourceError> {
+    let tokenizer_model: Box<str> = source
+        .get("tokenizer.ggml.model")
+        .map_err(|_| LlamaSourceError::NoTokenizer)?
+        .clone()
+        .try_into()
+        .map_err(|_| LlamaSourceError::NoTokenizer)?;
+    if &*tokenizer_model != "gpt2" {
+        return Err(LlamaSourceError::NoTokenizer);
+    }
+    let pre: Box<str> = source
+        .get("tokenizer.ggml.pre")
+        .map_err(|_| LlamaSourceError::NoTokenizer)?
+        .clone()
+        .try_into()
+        .map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let add_bos_token = source
+        .get("tokenizer.ggml.add_bos_token")
+        .ok()
+        .cloned()
+        .and_then(|v| v.try_into().ok());
+    let config = get_pre_tokenizer(&pre, add_bos_token);
+
+    let token_values: Box<[GgufValue]> = source
+        .get("tokenizer.ggml.tokens")
+        .map_err(|_| LlamaSourceError::NoTokenizer)?
+        .clone()
+        .try_into()
+        .map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let tokens: Result<Vec<_>, _> = token_values.iter().map(|v| v.clone().try_into()).collect();
+    let tokens: Vec<Box<str>> = tokens.map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let token_type_values: Box<[GgufValue]> = source
+        .get("tokenizer.ggml.token_type")
+        .map_err(|_| LlamaSourceError::NoTokenizer)?
+        .clone()
+        .try_into()
+        .map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let types: Result<Vec<_>, _> = token_type_values
+        .iter()
+        .map(|v| v.to_u8().map_err(|_| LlamaSourceError::NoTokenizer))
+        .collect();
+    let types = types.map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let vocab: HashMap<_, _> = tokens
+        .iter()
+        .enumerate()
+        .map(|(id, v)| (v.to_string(), id as u32))
+        .collect();
+    let merges: Box<[GgufValue]> = source
+        .get("tokenizer.ggml.merges")
+        .map_err(|_| LlamaSourceError::NoTokenizer)?
+        .clone()
+        .try_into()
+        .map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let merges: Result<Vec<_>, _> = merges
+        .iter()
+        .map(|v| {
+            let as_str: Box<str> = v
+                .clone()
+                .try_into()
+                .map_err(|_| LlamaSourceError::NoTokenizer)?;
+            as_str
+                .split_once(' ')
+                .ok_or(LlamaSourceError::NoTokenizer)
+                .map(|(a, b)| (a.to_string(), b.to_string()))
+        })
+        .collect();
+    let merges = merges.map_err(|_| LlamaSourceError::NoTokenizer)?;
+
+    let eos = source
+        .get("tokenizer.ggml.eos_token_id")
+        .map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let eos: u32 = eos.try_into().map_err(|_| LlamaSourceError::NoTokenizer)?;
+    let eos = &tokens[eos as usize];
+
+    // Some models (e.g. Qwen) don't use a BOS token and ship the GGUF
+    // file without `tokenizer.ggml.bos_token_id`. Treat it as optional
+    // rather than failing to load the embedded tokenizer entirely.
+    let bos: Option<&str> = source
+        .get("tokenizer.ggml.bos_token_id")
+        .ok()
+        .and_then(|v| {
+            let id: u32 = v.try_into().ok()?;
+            Some(&*tokens[id as usize])
+        });
+
+    config
+        .build(vocab, types, merges, bos, eos)
+        .map(LlamaTokenizer::from_gguf)
+        .map_err(|err| LlamaSourceError::Tokenizer(Box::new(err)))
+}
+
+#[cfg(target_arch = "wasm32")]
+enum ModelRangeReader {
+    Opfs(kalosm_common::OpfsFile),
+    Bytes(Vec<u8>),
+}
+
+#[cfg(target_arch = "wasm32")]
+impl AsyncReadRange for ModelRangeReader {
+    fn read_range<'a>(
+        &'a mut self,
+        offset: u64,
+        len: usize,
+    ) -> Pin<Box<dyn Future<Output = std::io::Result<Vec<u8>>> + 'a>> {
+        Box::pin(async move {
+            match self {
+                Self::Opfs(file) => file
+                    .read_range(offset, len)
+                    .await
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string())),
+                Self::Bytes(bytes) => {
+                    let start = usize::try_from(offset).map_err(|_| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "range offset does not fit in usize",
+                        )
+                    })?;
+                    let end = start.checked_add(len).ok_or_else(|| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "range length overflows usize",
+                        )
+                    })?;
+                    if end > bytes.len() {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "range exceeds in-memory model bytes",
+                        ));
+                    }
+                    Ok(bytes[start..end].to_vec())
+                }
+            }
+        })
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+enum WasmModelSource {
+    Opfs(Vec<kalosm_common::OpfsFile>),
+    Bytes(Vec<Vec<u8>>),
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_opfs_gguf_metadata(
+    file: &kalosm_common::OpfsFile,
+) -> Result<GgufMetadata, LlamaSourceError> {
+    const INITIAL_METADATA_READ: usize = 1024 * 1024;
+    const MAX_METADATA_READ: usize = 256 * 1024 * 1024;
+
+    let file_size = usize::try_from(file.size()).map_err(|_| {
+        LlamaSourceError::Model(kalosm_common::CacheError::OpfsError(
+            "Model file is too large for this wasm target".to_string(),
+        ))
+    })?;
+
+    let mut read_len = INITIAL_METADATA_READ.min(file_size);
+    loop {
+        let bytes = file.read_range(0, read_len).await?;
+        let mut cursor = std::io::Cursor::new(&bytes);
+        match GgufMetadata::read(&mut cursor) {
+            Ok(metadata) => return Ok(metadata),
+            Err(GgufReadError::Io(err))
+                if err.kind() == std::io::ErrorKind::UnexpectedEof
+                    && read_len < file_size
+                    && read_len < MAX_METADATA_READ =>
+            {
+                read_len = read_len
+                    .saturating_mul(2)
+                    .min(file_size)
+                    .min(MAX_METADATA_READ);
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
 }
 
 pub(crate) struct LlamaGpuSamplerState {
@@ -529,48 +756,98 @@ where
 
         let source = format!("Model ({})", builder.source.model[0]);
         let mut create_progress = ModelLoadingProgress::downloading_progress(source);
+        #[cfg(target_arch = "wasm32")]
+        let model_source = match builder
+            .source
+            .model_opfs_files(|progress| handler(create_progress(progress)))
+            .await
+        {
+            Ok(files) => WasmModelSource::Opfs(files),
+            Err(err) => {
+                tracing::warn!("OPFS model loading failed, falling back to in-memory: {err}");
+                WasmModelSource::Bytes(
+                    builder
+                        .source
+                        .model_bytes(|progress| handler(create_progress(progress)))
+                        .await?,
+                )
+            }
+        };
+        #[cfg(not(target_arch = "wasm32"))]
         let model_bytes = builder
             .source
             .model(|progress| handler(create_progress(progress)))
             .await?;
 
-        // Then actually load the model and tokenizer. This is expensive, so we do it in a blocking task
-        let load_model = {
+        let override_stop_token_string = builder.source.override_stop_token_string.clone();
+        let override_chat_template = builder.source.override_chat_template.clone();
+
+        #[cfg(target_arch = "wasm32")]
+        let (model, tokenizer) = {
+            let files_with_metadata = match model_source {
+                WasmModelSource::Opfs(model_files) => {
+                    if model_files.is_empty() {
+                        return Err(LlamaSourceError::InvalidGguf);
+                    }
+                    let mut files_with_metadata = Vec::new();
+                    for file in model_files {
+                        let metadata = read_opfs_gguf_metadata(&file).await?;
+                        files_with_metadata.push((metadata, ModelRangeReader::Opfs(file)));
+                    }
+                    files_with_metadata
+                }
+                WasmModelSource::Bytes(model_bytes) => {
+                    if model_bytes.is_empty() {
+                        return Err(LlamaSourceError::InvalidGguf);
+                    }
+                    let mut files_with_metadata = Vec::new();
+                    for bytes in model_bytes {
+                        let metadata = {
+                            let mut cursor = std::io::Cursor::new(&bytes);
+                            GgufMetadata::read(&mut cursor)?
+                        };
+                        files_with_metadata.push((metadata, ModelRangeReader::Bytes(bytes)));
+                    }
+                    files_with_metadata
+                }
+            };
+
+            let mut source = AsyncShardedVarBuilder::new(files_with_metadata);
+
+            let (vision_ct, vision_bytes) = match vision_model_bytes {
+                Some(bytes) => {
+                    let mut cursor = std::io::Cursor::new(&bytes);
+                    let metadata = GgufMetadata::read(&mut cursor)?;
+                    (Some(metadata), Some(bytes))
+                }
+                None => (None, None),
+            };
+
+            let tokenizer = match parse_external_tokenizer(tokenizer_source)? {
+                Some(tokenizer) => tokenizer,
+                None => tokenizer_from_gguf_source(&source)?,
+            };
+            let config = parse_external_config(config_bytes)?;
+            let model = Model::from_var_source(
+                &mut source,
+                vision_ct,
+                vision_bytes,
+                &device,
+                override_stop_token_string,
+                override_chat_template,
+                config,
+            )
+            .await?;
+
+            (model, tokenizer)
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let (model, tokenizer) = {
             let device = device.clone();
-            move || -> Result<(Model<F>, LlamaTokenizer), LlamaSourceError> {
-                #[cfg(feature = "hf-tokenizer-json")]
-                let tokenizer = match tokenizer_source {
-                    Some(tokenizer_source) => {
-                        let tokenizer = LlamaTokenizer::from_hf_bytes(tokenizer_source)
-                            .map_err(|err| LlamaSourceError::Tokenizer(Box::new(err)))?;
-                        Some(tokenizer)
-                    }
-                    None => None,
-                };
-                #[cfg(not(feature = "hf-tokenizer-json"))]
-                let tokenizer: Option<LlamaTokenizer> = {
-                    let _ = tokenizer_source;
-                    None
-                };
-
-                #[cfg(feature = "hf-config-json")]
-                let config = match config_bytes {
-                    Some(config_bytes) => {
-                        let config: LlamaConfigJson = serde_json::from_slice(&config_bytes)
-                            .map_err(LlamaSourceError::Config)?;
-                        config.rope_scaling
-                    }
-                    None => None,
-                };
-                #[cfg(not(feature = "hf-config-json"))]
-                let config = {
-                    let _ = config_bytes;
-                    None
-                };
-
-                let override_stop_token_string = builder.source.override_stop_token_string;
-                let override_chat_template = builder.source.override_chat_template;
-
+            let load_model = move || -> Result<(Model<F>, LlamaTokenizer), LlamaSourceError> {
+                let tokenizer = parse_external_tokenizer(tokenizer_source)?;
+                let config = parse_external_config(config_bytes)?;
                 if model_bytes.is_empty() {
                     return Err(LlamaSourceError::InvalidGguf);
                 }
@@ -596,98 +873,7 @@ where
 
                 let tokenizer = match tokenizer {
                     Some(tokenizer) => tokenizer,
-                    None => {
-                        let tokenizer_model: Box<str> = source
-                            .get("tokenizer.ggml.model")
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?
-                            .clone()
-                            .try_into()
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        if &*tokenizer_model != "gpt2" {
-                            return Err(LlamaSourceError::NoTokenizer);
-                        }
-                        let pre: Box<str> = source
-                            .get("tokenizer.ggml.pre")
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?
-                            .clone()
-                            .try_into()
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let add_bos_token = source
-                            .get("tokenizer.ggml.add_bos_token")
-                            .ok()
-                            .cloned()
-                            .and_then(|v| v.try_into().ok());
-                        let config = get_pre_tokenizer(&pre, add_bos_token);
-
-                        let token_values: Box<[GgufValue]> = source
-                            .get("tokenizer.ggml.tokens")
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?
-                            .clone()
-                            .try_into()
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let tokens: Result<Vec<_>, _> =
-                            token_values.iter().map(|v| v.clone().try_into()).collect();
-                        let tokens: Vec<Box<str>> =
-                            tokens.map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let token_type_values: Box<[GgufValue]> = source
-                            .get("tokenizer.ggml.token_type")
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?
-                            .clone()
-                            .try_into()
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let types: Result<Vec<_>, _> = token_type_values
-                            .iter()
-                            .map(|v| v.to_u8().map_err(|_| LlamaSourceError::NoTokenizer))
-                            .collect();
-                        let types = types.map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let vocab: HashMap<_, _> = tokens
-                            .iter()
-                            .enumerate()
-                            .map(|(id, v)| (v.to_string(), id as u32))
-                            .collect();
-                        let merges: Box<[GgufValue]> = source
-                            .get("tokenizer.ggml.merges")
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?
-                            .clone()
-                            .try_into()
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let merges: Result<Vec<_>, _> = merges
-                            .iter()
-                            .map(|v| {
-                                let as_str: Box<str> = v
-                                    .clone()
-                                    .try_into()
-                                    .map_err(|_| LlamaSourceError::NoTokenizer)?;
-                                as_str
-                                    .split_once(' ')
-                                    .ok_or(LlamaSourceError::NoTokenizer)
-                                    .map(|(a, b)| (a.to_string(), b.to_string()))
-                            })
-                            .collect();
-                        let merges = merges.map_err(|_| LlamaSourceError::NoTokenizer)?;
-
-                        let eos = source
-                            .get("tokenizer.ggml.eos_token_id")
-                            .map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let eos: u32 = eos.try_into().map_err(|_| LlamaSourceError::NoTokenizer)?;
-                        let eos = &tokens[eos as usize];
-
-                        // Some models (e.g. Qwen) don't use a BOS token and ship the GGUF
-                        // file without `tokenizer.ggml.bos_token_id`. Treat it as optional
-                        // rather than failing to load the embedded tokenizer entirely.
-                        let bos: Option<&str> = source
-                            .get("tokenizer.ggml.bos_token_id")
-                            .ok()
-                            .and_then(|v| {
-                                let id: u32 = v.try_into().ok()?;
-                                Some(&*tokens[id as usize])
-                            });
-
-                        config
-                            .build(vocab, types, merges, bos, eos)
-                            .map(LlamaTokenizer::from_gguf)
-                            .map_err(|err| LlamaSourceError::Tokenizer(Box::new(err)))?
-                    }
+                    None => tokenizer_from_gguf_source(&source)?,
                 };
                 let model = Model::from_gguf(
                     &mut source,
@@ -699,10 +885,10 @@ where
                     config,
                 )?;
                 Ok((model, tokenizer))
-            }
-        };
+            };
 
-        let (model, tokenizer) = load_model()?;
+            load_model()?
+        };
         Self::prewarm_fused_logits_sampling(&model, &device).await;
 
         Ok(Self {

--- a/models/kalosm-llama/src/model/mod.rs
+++ b/models/kalosm-llama/src/model/mod.rs
@@ -58,7 +58,7 @@ fn record_decode_trace(path: &'static str, decode_eligible: bool, kernels: usize
     total_samples.sort_unstable();
     let p50 = percentile_duration(&total_samples, 50);
     let p95 = percentile_duration(&total_samples, 95);
-    eprintln!(
+    tracing::info!(
         "decode_trace_summary samples={} path={path} decode_eligible={decode_eligible} kernels={kernels} total={total:?} p50={p50:?} p95={p95:?}",
         total_samples.len()
     );
@@ -662,7 +662,7 @@ where
             .try_sample_mirostat2_token_q_mat(model.output_matrix(), &mut sampler, &[], params)
             .await;
         if let Some(start) = start {
-            eprintln!(
+            tracing::info!(
                 "prewarm_fused_logits_sampling elapsed={:?}",
                 start.elapsed()
             );
@@ -676,8 +676,8 @@ where
         let device = builder.get_device().await;
         if decode_trace_enabled() {
             match &device {
-                Device::Cpu => eprintln!("llama_device=cpu"),
-                Device::Gpu(gpu) => eprintln!(
+                Device::Cpu => tracing::info!("llama_device=cpu"),
+                Device::Gpu(gpu) => tracing::info!(
                     "llama_device=gpu adapter={:?}",
                     gpu.wgpu_adapter().get_info(),
                 ),

--- a/models/kalosm-llama/src/raw/mod.rs
+++ b/models/kalosm-llama/src/raw/mod.rs
@@ -48,7 +48,7 @@ pub(crate) fn debug_check_nan_f32<const R: usize>(
             }
         }
         if nan > 0 || pos_inf > 0 || neg_inf > 0 {
-            eprintln!(
+            tracing::warn!(
                 "trace_nan layer={layer} label={label} index_pos={index_pos} shape={:?} nan={nan} (first_nan_indices={:?}) +inf={pos_inf} -inf={neg_inf} max_abs={max_abs}",
                 t.shape(),
                 &sample_vals[..sample_idx]
@@ -944,9 +944,10 @@ where
             seq_len > 1 || std::env::var_os("KALOSM_TRACE_FORWARD_TIMING").is_some();
         if trace_forward_timing {
             if let Some(encode_elapsed) = encode_elapsed {
-                eprintln!(
+                tracing::info!(
                     "[timing] encode_tokens (incl. vision): {:.2?} seq_len={}",
-                    encode_elapsed, seq_len
+                    encode_elapsed,
+                    seq_len
                 );
             }
         }
@@ -1039,7 +1040,7 @@ where
             }
         }
         if trace_forward_timing {
-            eprintln!("[timing] text layer loop: {:.2?}", t_text_layers.elapsed());
+            tracing::info!("[timing] text layer loop: {:.2?}", t_text_layers.elapsed());
         }
         let x = self.norm.forward_generic(&layer_in);
         let x = x.i((.., seq_len - 1, ..));

--- a/models/kalosm-llama/src/raw/mod.rs
+++ b/models/kalosm-llama/src/raw/mod.rs
@@ -1,4 +1,8 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use web_time::{Duration, Instant};
 
 #[cfg(feature = "vision")]
@@ -83,6 +87,7 @@ use fusor::{
     AddOp, CastTensor, CastTo, FloatDataType, FloatOps, MatmulImpl, MulOp, SimdBinaryOp,
     SimdElement, SimdReduceOp, SumOp,
 };
+use fusor::{AsyncReadRange, AsyncShardedVarBuilder};
 use fusor::{Device, Result, Tensor};
 use fusor_gguf::GgufMetadata;
 use fusor_gguf::GgufValue;
@@ -185,14 +190,103 @@ pub(crate) struct EncodedTokens<F: FloatDataType + SimdElement> {
     pos_ids: Option<Tensor<2, F>>,
 }
 
+pub(crate) trait LlamaVarSource {
+    fn get(&self, name: &str) -> Result<&GgufValue>;
+
+    fn tensor<'a>(
+        &'a mut self,
+        name: &'a str,
+        device: &'a Device,
+    ) -> Pin<Box<dyn Future<Output = Result<QMatrix>> + 'a>>;
+}
+
+impl<R: std::io::Read + std::io::Seek> LlamaVarSource for ShardedVarBuilder<R> {
+    fn get(&self, name: &str) -> Result<&GgufValue> {
+        ShardedVarBuilder::get(self, name)
+    }
+
+    fn tensor<'a>(
+        &'a mut self,
+        name: &'a str,
+        device: &'a Device,
+    ) -> Pin<Box<dyn Future<Output = Result<QMatrix>> + 'a>> {
+        Box::pin(std::future::ready(ShardedVarBuilder::tensor(
+            self, name, device,
+        )))
+    }
+}
+
+impl<R: AsyncReadRange> LlamaVarSource for AsyncShardedVarBuilder<R> {
+    fn get(&self, name: &str) -> Result<&GgufValue> {
+        AsyncShardedVarBuilder::get(self, name)
+    }
+
+    fn tensor<'a>(
+        &'a mut self,
+        name: &'a str,
+        device: &'a Device,
+    ) -> Pin<Box<dyn Future<Output = Result<QMatrix>> + 'a>> {
+        Box::pin(AsyncShardedVarBuilder::tensor(self, name, device))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn block_on_ready<F: Future>(future: F) -> F::Output {
+    fn clone(_: *const ()) -> RawWaker {
+        noop_raw_waker()
+    }
+
+    fn wake(_: *const ()) {}
+
+    fn noop_raw_waker() -> RawWaker {
+        RawWaker::new(
+            std::ptr::null(),
+            &RawWakerVTable::new(clone, wake, wake, wake),
+        )
+    }
+
+    let waker = unsafe { Waker::from_raw(noop_raw_waker()) };
+    let mut cx = Context::from_waker(&waker);
+    let mut future = Box::pin(future);
+    match future.as_mut().poll(&mut cx) {
+        Poll::Ready(output) => output,
+        Poll::Pending => panic!("synchronous GGUF model loading unexpectedly yielded"),
+    }
+}
+
 impl<F: FloatDataType + SimdElement + FloatOps + MatmulImpl> Model<F>
 where
     MulOp: SimdBinaryOp<F>,
     AddOp: SimdBinaryOp<F>,
     SumOp: SimdReduceOp<F>,
 {
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_gguf<R: std::io::Seek + std::io::Read>(
         source: &mut ShardedVarBuilder<R>,
+        vision_ct: Option<GgufMetadata>,
+        vision_bytes: Option<Vec<u8>>,
+        device: &Device,
+        override_stop_token_string: Option<String>,
+        override_chat_template: Option<String>,
+        rope_scaling: Option<RopeScalingConfig>,
+    ) -> std::result::Result<Self, LlamaSourceError>
+    where
+        f32: CastTensor<F> + CastTo<F>,
+        F: CastTensor<f32> + CastTo<f32>,
+    {
+        block_on_ready(Self::from_var_source(
+            source,
+            vision_ct,
+            vision_bytes,
+            device,
+            override_stop_token_string,
+            override_chat_template,
+            rope_scaling,
+        ))
+    }
+
+    pub(crate) async fn from_var_source<S: LlamaVarSource>(
+        source: &mut S,
         vision_ct: Option<GgufMetadata>,
         vision_bytes: Option<Vec<u8>>,
         device: &Device,
@@ -322,6 +416,7 @@ where
 
         let rope_freq_weight: Option<Tensor<1, F>> = source
             .tensor("rope_freqs.weight", device)
+            .await
             .ok()
             .map(&dequantize_1d);
 
@@ -375,40 +470,55 @@ where
             })
             .transpose()?;
 
-        let tok_embeddings_q = source.tensor("token_embd.weight", device)?;
+        let tok_embeddings_q = source.tensor("token_embd.weight", device).await?;
         let tok_embedding_scale =
             (&*architecture == "gemma3").then(|| (embedding_length as f32).sqrt());
         let tok_embeddings = Embedding::new(tok_embeddings_q.clone());
 
-        let norm = source.tensor("output_norm.weight", device)?;
+        let norm = source.tensor("output_norm.weight", device).await?;
         let norm = decode_norm(norm, rms_norm_eps)?;
-        let output = source.tensor("output.weight", device).unwrap_or_else(|_| {
-            // If there is no output layer, assume the word embeddings are tied to the output
-            tok_embeddings_q.clone()
-        });
+        let output = match source.tensor("output.weight", device).await {
+            Ok(output) => output,
+            Err(_) => {
+                // If there is no output layer, assume the word embeddings are tied to the output
+                tok_embeddings_q.clone()
+            }
+        };
         let mut layers = Vec::with_capacity(block_count);
         let interleaved_rope = architecture.as_ref() != "qwen2"
             && architecture.as_ref() != "qwen3"
             && architecture.as_ref() != "gemma3";
         for layer_idx in 0..block_count {
             let prefix = format!("blk.{layer_idx}");
-            let attention_variant = if let Ok(attention_qkv) =
-                source.tensor(&format!("{prefix}.attn_qkv.weight"), device)
+            let attention_variant = if let Ok(attention_qkv) = source
+                .tensor(&format!("{prefix}.attn_qkv.weight"), device)
+                .await
             {
                 AttentionVariant::Grouped(GroupedAttention {
                     attention_qkv,
                     interleaved_rope,
                 })
             } else {
-                let q = source.tensor(&format!("{prefix}.attn_q.weight"), device)?;
-                let k = source.tensor(&format!("{prefix}.attn_k.weight"), device)?;
-                let v = source.tensor(&format!("{prefix}.attn_v.weight"), device)?;
+                let q = source
+                    .tensor(&format!("{prefix}.attn_q.weight"), device)
+                    .await?;
+                let k = source
+                    .tensor(&format!("{prefix}.attn_k.weight"), device)
+                    .await?;
+                let v = source
+                    .tensor(&format!("{prefix}.attn_v.weight"), device)
+                    .await?;
                 let qkv = QMatrix::concat_rows(&[&q, &k, &v]);
-                let bias = if let (Ok(bias_q), Ok(bias_k), Ok(bias_v)) = (
-                    source.tensor(&format!("{prefix}.attn_q.bias"), device),
-                    source.tensor(&format!("{prefix}.attn_k.bias"), device),
-                    source.tensor(&format!("{prefix}.attn_v.bias"), device),
-                ) {
+                let bias_q = source
+                    .tensor(&format!("{prefix}.attn_q.bias"), device)
+                    .await;
+                let bias_k = source
+                    .tensor(&format!("{prefix}.attn_k.bias"), device)
+                    .await;
+                let bias_v = source
+                    .tensor(&format!("{prefix}.attn_v.bias"), device)
+                    .await;
+                let bias = if let (Ok(bias_q), Ok(bias_k), Ok(bias_v)) = (bias_q, bias_k, bias_v) {
                     Some(AttentionBias::new(
                         dequantize_1d(bias_q),
                         dequantize_1d(bias_k),
@@ -419,9 +529,11 @@ where
                 };
                 let q_norm = source
                     .tensor(&format!("{prefix}.attn_q_norm.weight"), device)
+                    .await
                     .ok();
                 let k_norm = source
                     .tensor(&format!("{prefix}.attn_k_norm.weight"), device)
+                    .await
                     .ok();
                 let separate = SeparateAttention {
                     attention_wq: q,
@@ -439,15 +551,21 @@ where
                 };
                 AttentionVariant::Separate(Box::new(separate))
             };
-            let attention_wo = source.tensor(&format!("{prefix}.attn_output.weight"), device)?;
+            let attention_wo = source
+                .tensor(&format!("{prefix}.attn_output.weight"), device)
+                .await?;
             // Try to read from the up, down and gate weights
-            let feed_forward_variant = if let Ok(ffn_gate) =
-                source.tensor(&format!("{prefix}.ffn_gate.weight"), device)
+            let feed_forward_variant = if let Ok(ffn_gate) = source
+                .tensor(&format!("{prefix}.ffn_gate.weight"), device)
+                .await
             {
                 let feed_forward_w1 = ffn_gate;
-                let feed_forward_w2 =
-                    source.tensor(&format!("{prefix}.ffn_down.weight"), device)?;
-                let feed_forward_w3 = source.tensor(&format!("{prefix}.ffn_up.weight"), device)?;
+                let feed_forward_w2 = source
+                    .tensor(&format!("{prefix}.ffn_down.weight"), device)
+                    .await?;
+                let feed_forward_w3 = source
+                    .tensor(&format!("{prefix}.ffn_up.weight"), device)
+                    .await?;
                 FeedForwardVariant::Llama(Box::new(LlamaFeedForward::new(
                     feed_forward_w1,
                     feed_forward_w2,
@@ -455,9 +573,13 @@ where
                 )))
             } else {
                 // Otherwise, try to read from the up, and down weights
-                let up = source.tensor(&format!("{prefix}.ffn_up.weight"), device)?;
+                let up = source
+                    .tensor(&format!("{prefix}.ffn_up.weight"), device)
+                    .await?;
                 // Transpose the down tensor
-                let down = source.tensor(&format!("{prefix}.ffn_down.weight"), device)?;
+                let down = source
+                    .tensor(&format!("{prefix}.ffn_down.weight"), device)
+                    .await?;
                 let feed_forward_length = source.get(".feed_forward_length")?.to_u32()? as usize;
 
                 FeedForwardVariant::Phi(PhiFeedForward {
@@ -466,13 +588,19 @@ where
                     feed_forward_length,
                 })
             };
-            let attention_norm = source.tensor(&format!("{prefix}.attn_norm.weight"), device)?;
+            let attention_norm = source
+                .tensor(&format!("{prefix}.attn_norm.weight"), device)
+                .await?;
             let post_attention_norm = source
                 .tensor(&format!("{prefix}.post_attention_norm.weight"), device)
+                .await
                 .ok();
-            let ffn_norm = source.tensor(&format!("{prefix}.ffn_norm.weight"), device)?;
+            let ffn_norm = source
+                .tensor(&format!("{prefix}.ffn_norm.weight"), device)
+                .await?;
             let ffn_post_norm = source
                 .tensor(&format!("{prefix}.post_ffw_norm.weight"), device)
+                .await
                 .ok();
 
             let mut layer_sliding_window_size = None;

--- a/models/kalosm-llama/src/raw/vision/qwen_vision_block.rs
+++ b/models/kalosm-llama/src/raw/vision/qwen_vision_block.rs
@@ -82,7 +82,7 @@ where
         let after_norm = self.norm1.forward_generic(&xs_3d);
         flush(&after_norm);
         if trace {
-            eprintln!("    norm1: {:.2?}", t0.elapsed());
+            tracing::info!("    norm1: {:.2?}", t0.elapsed());
         }
         let t1 = Instant::now();
         let after_attention = self
@@ -90,7 +90,7 @@ where
             .forward(&after_norm, cu_seqlens, rope_cache, cache)?;
         flush(&after_attention);
         if trace {
-            eprintln!("    attn:  {:.2?}", t1.elapsed());
+            tracing::info!("    attn:  {:.2?}", t1.elapsed());
         }
 
         // Work in f32 for tensor addition
@@ -100,20 +100,20 @@ where
         let xs_3d: Tensor<3, F> = (xs_3d_f32 + after_attention_f32).cast();
         flush(&xs_3d);
         if trace {
-            eprintln!("    res1:  {:.2?}", t2.elapsed());
+            tracing::info!("    res1:  {:.2?}", t2.elapsed());
         }
 
         let t3 = Instant::now();
         let after_norm2 = self.norm2.forward_generic(&xs_3d);
         flush(&after_norm2);
         if trace {
-            eprintln!("    norm2: {:.2?}", t3.elapsed());
+            tracing::info!("    norm2: {:.2?}", t3.elapsed());
         }
         let t4 = Instant::now();
         let mlp_out = self.mlp.forward(&after_norm2);
         flush(&mlp_out);
         if trace {
-            eprintln!("    mlp:   {:.2?}", t4.elapsed());
+            tracing::info!("    mlp:   {:.2?}", t4.elapsed());
         }
 
         // Work in f32 for tensor addition
@@ -123,7 +123,7 @@ where
         let out: Tensor<3, F> = (xs_3d_f32 + mlp_out_f32).cast();
         flush(&out);
         if trace {
-            eprintln!("    res2:  {:.2?}", t5.elapsed());
+            tracing::info!("    res2:  {:.2?}", t5.elapsed());
         }
 
         Ok(out.squeeze(0).to_concrete())
@@ -214,7 +214,7 @@ where
                 let qkv: Tensor<3, f32> = qkv.forward_generic(xs).cast();
                 if trace_attn {
                     qkv.as_gpu().map(|g| g.materialize_sync());
-                    eprintln!("      qkv:   {:.2?}", t_qkv.elapsed());
+                    tracing::info!("      qkv:   {:.2?}", t_qkv.elapsed());
                 }
                 let q = qkv
                     .narrow(2, 0, self.embed_dim)
@@ -248,7 +248,7 @@ where
                     .to_concrete();
                 if trace_attn {
                     v.as_gpu().map(|g| g.materialize_sync());
-                    eprintln!("      qkv:   {:.2?} (split)", t_qkv.elapsed());
+                    tracing::info!("      qkv:   {:.2?} (split)", t_qkv.elapsed());
                 }
                 (q, k, v)
             }
@@ -273,7 +273,7 @@ where
         let t_after_rope = Instant::now();
         if trace_attn {
             value_states.as_gpu().map(|g| g.materialize_sync());
-            eprintln!(
+            tracing::info!(
                 "      rope:  {:.2?} (incl. q/k/v split + transpose)",
                 t_qkv.elapsed()
             );
@@ -287,7 +287,7 @@ where
         };
 
         if trace_attn {
-            eprintln!("      mask:  {:.2?}", t_after_rope.elapsed());
+            tracing::info!("      mask:  {:.2?}", t_after_rope.elapsed());
         }
 
         // The attention pattern is block-diagonal per `cu_seqlens`. The dense
@@ -363,7 +363,7 @@ where
         let output: Tensor<3, F> = self.proj.forward_generic(&attn_output.cast());
         if trace_attn {
             output.as_gpu().map(|g| g.materialize_sync());
-            eprintln!("      flash+proj: {:.2?}", t_flash.elapsed());
+            tracing::info!("      flash+proj: {:.2?}", t_flash.elapsed());
         }
 
         Ok(output)

--- a/models/kalosm-llama/src/source.rs
+++ b/models/kalosm-llama/src/source.rs
@@ -223,7 +223,32 @@ impl LlamaSource {
         self
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) async fn model(
+        &self,
+        mut progress: impl FnMut(FileLoadingProgress),
+    ) -> Result<Vec<Vec<u8>>, LlamaSourceError> {
+        let mut model_bytes = Vec::new();
+        for file in &self.model {
+            model_bytes.push(self.cache.get_bytes(file, &mut progress).await?);
+        }
+        Ok(model_bytes)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) async fn model_opfs_files(
+        &self,
+        mut progress: impl FnMut(FileLoadingProgress),
+    ) -> Result<Vec<kalosm_common::OpfsFile>, LlamaSourceError> {
+        let mut files = Vec::new();
+        for file in &self.model {
+            files.push(self.cache.get_opfs_file(file, &mut progress).await?);
+        }
+        Ok(files)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) async fn model_bytes(
         &self,
         mut progress: impl FnMut(FileLoadingProgress),
     ) -> Result<Vec<Vec<u8>>, LlamaSourceError> {

--- a/models/rwhisper/examples/transcribe_file.rs
+++ b/models/rwhisper/examples/transcribe_file.rs
@@ -2,16 +2,18 @@ use kalosm::sound::*;
 use rodio::Decoder;
 
 fn main() -> Result<(), anyhow::Error> {
+    let _ = tracing_subscriber::fmt::try_init();
+
     pollster::block_on(async {
-        eprintln!("Starting transcription...");
+        tracing::info!("Starting transcription...");
 
         // Create a new large whisper model
-        eprintln!("Building model...");
+        tracing::info!("Building model...");
         let model = WhisperBuilder::default()
             .with_source(WhisperSource::tiny_en())
             .build()
             .await?;
-        eprintln!("Model built successfully");
+        tracing::info!("Model built successfully");
 
         // Load audio from a file
         let contents = std::fs::read("./models/rwhisper/examples/samples_jfk.wav").unwrap();
@@ -22,22 +24,22 @@ fn main() -> Result<(), anyhow::Error> {
         let rate = audio.sample_rate() as f32;
 
         // Transcribe the source audio into text
-        eprintln!("Starting transcription...");
+        tracing::info!("Starting transcription...");
         let mut text = model.transcribe(audio);
 
-        eprintln!("Waiting for segments...");
+        tracing::info!("Waiting for segments...");
         let mut segment_count = 0;
         // As the model transcribes the audio, print the text to the console
         while let Some(segment) = text.next().await {
             segment_count += 1;
             let chunks: Vec<_> = segment.chunks().collect();
-            eprintln!(
+            tracing::info!(
                 "Received segment {}: {} chunks",
                 segment_count,
                 chunks.len()
             );
             for chunk in chunks {
-                eprintln!("Chunk: {:?}", chunk);
+                tracing::info!("Chunk: {:?}", chunk);
                 print!("{chunk}");
                 // Play the audio chunk
                 if let Some(timestamp) = chunk.timestamp() {
@@ -55,7 +57,7 @@ fn main() -> Result<(), anyhow::Error> {
             }
         }
 
-        eprintln!("Transcription complete. Total segments: {}", segment_count);
+        tracing::info!("Transcription complete. Total segments: {}", segment_count);
         Ok(())
     })
 }


### PR DESCRIPTION
- subgroup size is not set correctly on wasm and macos. this pr fixes that which makes llm decode performance ~2x faster
- caching currently relies on hardcoding the size of the tensors instead of passing that in as an input. this causes a lot of performance issues for small models