### PR TITLE
Fix Rust CI: the system packages are never installed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,9 +58,6 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Bump when the apt dependency list below changes so the next run
-  # rebuilds the apt archive instead of restoring a stale one.
-  APT_CACHE_VERSION: "v2"
 
 jobs:
   check:
@@ -72,10 +69,11 @@ jobs:
       # hashes the real `Cargo.lock`. Without it every job gets the same
       # toolchain-only key and clobbers the previous job's cache.
       - uses: actions/checkout@v6
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev
-          version: ${{ env.APT_CACHE_VERSION }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -116,10 +114,11 @@ jobs:
           sudo rm -rf /opt/ghc
           docker system prune -af || true
           df -h
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev mesa-vulkan-drivers vulkan-tools
-          version: ${{ env.APT_CACHE_VERSION }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev mesa-vulkan-drivers vulkan-tools
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -180,10 +179,11 @@ jobs:
           sudo rm -rf /opt/ghc
           docker system prune -af || true
           df -h
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev
-          version: ${{ env.APT_CACHE_VERSION }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -211,10 +211,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev
-          version: ${{ env.APT_CACHE_VERSION }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libayatana-appindicator3-dev libxdo-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/interfaces/kalosm/src/surrealdb_integration/mod.rs
+++ b/interfaces/kalosm/src/surrealdb_integration/mod.rs
@@ -88,7 +88,7 @@ impl<C: Connection, R> EmbeddingIndexedTable<C, R> {
 
     /// Get the name of the table that links embedding ids to byte ranges in documents.
     pub fn table_links(&self) -> String {
-        format!("{}-links", &self.table)
+        format!("{}-links", self.table)
     }
 
     /// Get the raw vector database.


### PR DESCRIPTION
Rust CI has been red since 2026-07-03. The last green run was 2026-07-02. It is not the code, the system libraries are simply not installed. `Check`, `Clippy` and `Docs` die when `alsa-sys` builds:

```
error: failed to run custom build command for `alsa-sys v0.3.1`
  Package alsa was not found in the pkg-config search path.
```

and `Test Suite` dies earlier, in `Configure lavapipe`:

```
Vulkan ICD directory was not installed: /usr/share/vulkan/icd.d
```

Both are packages `cache-apt-pkgs-action` is asked to install. It installs them with `apt-fast`, which cannot read the `mirror+file:/etc/apt/apt-mirrors.txt` source that the ubuntu-24.04 image uses. It pastes that line together with the pool path into a URL that cannot exist, so every `.deb` returns 404:

```
Clean installing 5 packages...
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/gst-plugins-good1.0/...deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Installed package list:
Caching 0 installed packages...
Skipped all manifest write. No packages to install.
```

The action then reports success. That is why this was not obvious: the step is green, zero packages are installed, and the job only breaks minutes later somewhere unrelated.

So this installs the packages with plain `apt-get` in all four jobs. apt reads the mirror list correctly, and the step now fails immediately if a package cannot be installed, instead of failing quietly. `APT_CACHE_VERSION` is not used anymore, so it is gone. The install takes about half a minute per job.

The second commit is one line. Rust 1.97 promoted `clippy::useless_borrows_in_formatting`, so the Clippy job fails on `-D warnings` for a `format!("{}-links", &self.table)` in the surrealdb integration. `Display` prints `String` and `&String` the same way, so dropping the `&` does not change the output. The same lint hit candle and the same fix is merged there, huggingface/candle#3754. Without this commit CI here is still red, so it is in this PR rather than its own.

I checked this on a run in my own fork, where the Actions cache was empty, so it is not just a stale cache being cleared. `Check`, `Clippy` and `Rustfmt` pass there, and `Test Suite` now installs the packages, gets through `Configure lavapipe` and reaches the tests.

One thing this does not fix. `Test Suite`, `Mac Test Suite` and the windows job run the remote model tests, which need `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` and `GEMINI_API_KEY`. All three workflows use `pull_request`, and GitHub does not pass secrets to a `pull_request` run from a fork, so on any PR from a fork those keys are empty and 10 tests fail with 401. That is the same `11 passed; 10 failed` you can see on #452 and on my fork run. So those three checks cannot go green on a PR from outside the repo. Skipping the remote model tests when the key is empty would fix that, but it is out of scope here, so tell me if you want a separate PR for it.

I first tried pinning the action to v1.6.3 (its v1.6.2 is marked broken by its author) and bumping the cache key. That changed nothing, a cold cache runs the same broken install, which is what pointed at apt-fast.
